### PR TITLE
Type descriptor for each Value

### DIFF
--- a/src/main/scala/scapi/sigma/DLogProtocol.scala
+++ b/src/main/scala/scapi/sigma/DLogProtocol.scala
@@ -24,8 +24,7 @@ object DLogProtocol {
   }
 
   case class ProveDlog(value: Value[SGroupElement.type])
-    extends SigmaProtocolCommonInput[DLogSigmaProtocol]
-      with SigmaProofOfKnowledgeTree[DLogSigmaProtocol, DLogProverInput] {
+    extends SigmaProofOfKnowledgeTree[DLogSigmaProtocol, DLogProverInput] {
 
     override val cost: Int = Cost.Dlog
 

--- a/src/main/scala/sigmastate/interpreter/CostAccumulator.scala
+++ b/src/main/scala/sigmastate/interpreter/CostAccumulator.scala
@@ -21,7 +21,7 @@ case class CostAccumulator(initialValue: Int, limit: Int) {
     */
   def addCost(delta: Int): Either[Int, Int] = {
     mutVal = mutVal + delta
-    if (mutVal <= limit) Right(limit) else Left(limit)
+    if (mutVal <= limit) Right(mutVal) else Left(mutVal)
   }
 
   def value: Int = mutVal

--- a/src/main/scala/sigmastate/serialization/ConcreteCollectionSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ConcreteCollectionSerializer.scala
@@ -1,37 +1,39 @@
 package sigmastate.serialization
 
 import com.google.common.primitives.Chars
+import sigmastate.serialization.ValueSerializer.Position
 import sigmastate.{ConcreteCollection, SCollection, Value, SType}
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-object ConcreteCollectionSerializer extends SigmaSerializer[ConcreteCollection[_ <: SCollection[_ <: SType]]] {
+object ConcreteCollectionSerializer extends ValueSerializer[ConcreteCollection[_ <: SType]] {
 
-  override val opCode: Byte = SigmaSerializer.ConcreteCollectionCode
+  override val opCode: Byte = ValueSerializer.ConcreteCollectionCode
 
-  override def parseBody = {
-    case (bytes, pos) =>
-      val sizeBytes = bytes.slice(pos, pos + 2)
-      val elemCode = bytes(pos + 2)
-      val size = Chars.fromBytes(sizeBytes.head, sizeBytes.tail.head)
-      val (values, consumed, types) = (1 to size).foldLeft((Seq[Value[SType]](), 2, Seq[SType.TypeCode]())) {
-        case ((vs, c, ts), _) =>
-          val (v, consumed, typeCode) = SigmaSerializer.deserialize(bytes, pos + c)
-          (vs :+ v, c + consumed, ts :+ typeCode)
-      }
-      assert(Constraints.sameTypeN(types))
-      (ConcreteCollection(values.toIndexedSeq), consumed, SCollection.collectionOf(types.head))
+  override def parseBody(bytes: Array[Byte], pos: Position) = {
+    val size = Chars.fromBytes(bytes(pos), bytes(pos + 1))
+    val (tItem, tItemLen) = STypeSerializer.deserialize(bytes, pos + 2)
+    val (values, typeCodes, consumed) = (1 to size).foldLeft((Seq[Value[SType]](), Seq[SType.TypeCode](), 2 + tItemLen)) {
+      case ((vs, ts, c), _) =>
+        val (v, consumed) = ValueSerializer.deserialize(bytes, pos + c)
+        (vs :+ v, ts :+ v.tpe.typeCode, c + consumed)
+    }
+    assert(Constraints.sameTypeN(typeCodes))
+    (ConcreteCollection[SType](values.toIndexedSeq)(tItem), consumed)
   }
 
-  override def serializeBody = { cc =>
-    require(cc.value.size <= Char.MaxValue, "max collection size is Char.MaxValue = 65535")
-    val elemCode = cc.tpe.elemType.typeCode
-    val size = cc.value.size.toChar
+  override def serializeBody(cc: ConcreteCollection[_ <: SType]) = {
+    val ccSize = cc.items.size
+    require(ccSize <= Char.MaxValue, "max collection size is Char.MaxValue = 65535")
+    val elemTpeBytes = STypeSerializer.serialize(cc.tpe.elemType)
+    val size = ccSize.toChar
     val sizeBytes = Chars.toByteArray(size)
-    val b = ArrayBuffer[Byte](sizeBytes)
-    b += elemCode
-    for (elem <- cc.value) {
-      b += SigmaSerializer.serialize(elem)
+    val b = ArrayBuffer[Byte]()
+    b ++= sizeBytes
+    b ++= elemTpeBytes
+    for (item <- cc.items) {
+      b ++= ValueSerializer.serialize(item)
     }
     b.toArray
   }

--- a/src/main/scala/sigmastate/serialization/FalseLeafSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/FalseLeafSerializer.scala
@@ -2,13 +2,14 @@ package sigmastate.serialization
 
 import sigmastate.{FalseLeaf, SBoolean}
 import sigmastate.SType.TypeCode
+import sigmastate.serialization.ValueSerializer.Position
 
-object FalseLeafSerializer extends SigmaSerializer[FalseLeaf.type] {
-  override val opCode = SigmaSerializer.FalseCode
+object FalseLeafSerializer extends ValueSerializer[FalseLeaf.type] {
+  override val opCode = ValueSerializer.FalseCode
 
   val typeCode: TypeCode = SBoolean.typeCode
 
-  override def parseBody = {case (bytes, pos) => (FalseLeaf, 0, typeCode)}
+  override def parseBody(bytes: Array[Byte], pos: Position) = (FalseLeaf, 0)
 
-  override def serializeBody = {_ => Array[Byte]()}
+  override def serializeBody(obj: FalseLeaf.type) = Array[Byte]()
 }

--- a/src/main/scala/sigmastate/serialization/IntConstantSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/IntConstantSerializer.scala
@@ -4,15 +4,15 @@ import com.google.common.primitives.Longs
 import sigmastate.{IntConstant, SInt}
 import sigmastate.SType.TypeCode
 
-object IntConstantSerializer extends SigmaSerializer[IntConstant] {
-  override val opCode = SigmaSerializer.IntConstantCode
+object IntConstantSerializer extends ValueSerializer[IntConstant] {
+  import ValueSerializer._
+  override val opCode = ValueSerializer.IntConstantCode
 
   val typeCode: TypeCode = SInt.typeCode
 
-  override def parseBody = {
-    case (bytes, pos) =>
-      (IntConstant(Longs.fromByteArray(bytes.slice(pos, pos + 8))), 8, typeCode)
+  override def parseBody(bytes: Array[Byte], pos: Position) = {
+    (IntConstant(Longs.fromByteArray(bytes.slice(pos, pos + 8))), 8)
   }
 
-  override def serializeBody = (c => Longs.toByteArray(c.value))
+  override def serializeBody(c: IntConstant) = Longs.toByteArray(c.value)
 }

--- a/src/main/scala/sigmastate/serialization/RelationSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/RelationSerializer.scala
@@ -2,29 +2,26 @@ package sigmastate.serialization
 
 import sigmastate.SType.TypeCode
 import sigmastate._
+import sigmastate.serialization.ValueSerializer.Position
 
 case class RelationSerializer[S1 <: SType, S2 <: SType, R <: Relation[S1, S2]]
   (override val opCode: Byte,
    constructor: (Value[S1], Value[S2]) => R,
-   constraints: Seq[Constraints.Constraint2]) extends
+   constraints: Seq[Constraints.Constraint2]) extends ValueSerializer[R] {
 
-  SigmaSerializer[R]{
-
-  import SigmaSerializer.{serialize, deserialize}
+  import ValueSerializer.{serialize, deserialize}
 
   val typeCode: TypeCode = SBoolean.typeCode
 
-  override def parseBody = {
-    case (bytes, pos) =>
-      val (firstArg, consumed, tc1) = deserialize(bytes, pos)
-      val (secondArg, consumed2, tc2) = deserialize(bytes, pos + consumed)
-      assert(constraints.forall(c => c(tc1, tc2)))
-      (constructor(firstArg.asInstanceOf[Value[S1]], secondArg.asInstanceOf[Value[S2]]),
-        (consumed + consumed2),
-        typeCode)
+  override def parseBody(bytes: Array[Byte], pos: Position) = {
+    val (firstArg, consumed) = deserialize(bytes, pos)
+    val (secondArg, consumed2) = deserialize(bytes, pos + consumed)
+    assert(constraints.forall(c => c(firstArg.tpe.typeCode, secondArg.tpe.typeCode)))
+    (constructor(firstArg.asInstanceOf[Value[S1]], secondArg.asInstanceOf[Value[S2]]),
+      (consumed + consumed2))
   }
 
-  override def serializeBody = {rel =>
+  override def serializeBody(rel: R) = {
     serialize(rel.left) ++ serialize(rel.right)
   }
 }

--- a/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
@@ -1,123 +1,19 @@
 package sigmastate.serialization
 
-import sigmastate._
+trait SigmaSerializer[TFamily, T <: TFamily] extends Serializer[T] {
+  val companion: SigmaSerializerCompanion[TFamily]
+  import companion._
 
-import scala.util.Try
-
-
-
-trait SigmaSerializer[V <: Value[_ <: SType]] extends Serializer[V] {
-  import SigmaSerializer._
-
-  val opCode: OpCode
-
-  def parseBody: DeserializingFn
-
-  def serializeBody: SerializingFn[V]
-
-  override def toBytes(obj: V): Array[Byte] = serialize(obj)
-
-  override def parseBytes(bytes: Array[Byte]): Try[V] = Try {
-    deserialize(bytes).asInstanceOf[V]
-  }
+  def parseBody(bytes: Array[Byte], pos: Position): (TFamily, Consumed)
+  def serializeBody(obj: T): Array[Byte]
 }
 
-object SigmaSerializer extends App {
-  type OpCode = Byte
-
+trait SigmaSerializerCompanion[TFamily] {
   type Position = Int
   type Consumed = Int
-  type DeserializingFn = (Array[Byte], Position) => (Value[_ <: SType], Consumed, SType.TypeCode)
-  type SerializingFn[V <: Value[_ <: SType]] = V => Array[Byte]
-
-  val IntConstantCode = 11: Byte
-  val TaggedVariableCode = 1: Byte
-
-  val LtCode = 21: Byte
-  val LeCode = 22: Byte
-  val GtCode = 23: Byte
-  val GeCode = 24: Byte
-  val EqCode = 25: Byte
-  val NeqCode = 26: Byte
-
-
-  val TrueCode = 12: Byte
-  val FalseCode = 13: Byte
-
-  val ConcreteCollectionCode = 35: Byte
-
-  val serializers = Seq[SigmaSerializer[_ <: Value[_ <: SType]]](
-    RelationSerializer(GtCode, GT.apply, Seq(Constraints.onlyInt2)),
-    RelationSerializer(GeCode, GE.apply, Seq(Constraints.onlyInt2)),
-    RelationSerializer(LtCode, LT.apply, Seq(Constraints.onlyInt2)),
-    RelationSerializer(LeCode, LE.apply, Seq(Constraints.onlyInt2)),
-    RelationSerializer(EqCode, EQ.applyNonTyped, Seq(Constraints.sameType2)),
-    RelationSerializer(NeqCode, NEQ.apply, Seq(Constraints.sameType2)),
-    IntConstantSerializer,
-    TrueLeafSerializer,
-    FalseLeafSerializer,
-    ConcreteCollectionSerializer,
-    TaggedVariableSerializer
-  )
-
-  val table: Map[Value.PropositionCode, (DeserializingFn, SerializingFn[_ <: Value[_ <: SType]])] =
-    serializers.map(s => s.opCode -> (s.parseBody, s.serializeBody)).toMap
-
-  def deserialize(bytes: Array[Byte], pos: Int): (Value[_ <: SType], Consumed, SType.TypeCode) = {
-    val c = bytes(pos)
-    val handler = table(c)
-    val (v, consumed, tc) = handler._1(bytes, pos + 1)
-    (v, consumed + 1, tc)
-  }
-
-  def deserialize(bytes: Array[Byte]): Value[_ <: SType] = deserialize(bytes, 0)._1
-
-  def serialize(v: Value[_ <: SType]) = {
-    val opCode = v.opCode
-    val serFn = table(opCode)._2.asInstanceOf[SerializingFn[v.type]]
-    opCode +: serFn(v)
-  }
-
-  //todo: convert cases below into tests:
-
-  println(deserialize(Array[Byte](21, 11, 0, 0, 0, 0, 0, 0, 0, 2,
-    11, 0, 0, 0, 0, 0, 0, 0, 3)))
-
-  val s: Value[SInt.type] = IntConstant(4)
-  println(serialize(s))
-
-  assert(deserialize(serialize(s)) == s)
-
-  assert(Try(deserialize(Array[Byte](21, 12, 13))).isFailure, "LT(bool, bool) must fail")
-
-  val gt = GT(IntConstant(6), IntConstant(5))
-  println(deserialize(serialize(gt)))
-  assert(deserialize(serialize(gt)) == gt)
-
-  val eq = EQ(TrueLeaf, FalseLeaf)
-  println(serialize(eq).mkString(","))
-  assert(deserialize(serialize(eq)) == eq)
-
-  //todo: make this expression does not compile?
-  val eq2 = EQ(TrueLeaf, IntConstant(5))
-
-  //concrete collection
-  val cc = ConcreteCollection(IndexedSeq(IntConstant(5), IntConstant(6), IntConstant(7)))
-  assert(deserialize(serialize(cc)) == cc)
-
-  val tb = TaggedBox(21: Byte)
-  assert(deserialize(serialize(tb)) == tb)
-
-  val cc2 = ConcreteCollection(IndexedSeq(IntConstant(5), TaggedInt(21)))
-  assert(deserialize(serialize(cc2)) == cc2)
+  type Tag
+  val table: Map[Tag, SigmaSerializer[TFamily, _]]
+  def deserialize(bytes: Array[Byte], pos: Position): (TFamily, Consumed)
+  def serialize(v: TFamily): Array[Byte]
 }
 
-object Constraints {
-  type Constraint2 = (SType.TypeCode, SType.TypeCode) => Boolean
-  type ConstraintN = Seq[SType.TypeCode] => Boolean
-
-  def onlyInt2: Constraint2 = {case (tc1, tc2) => tc1 == SInt.typeCode && tc2 == SInt.typeCode}
-  def sameType2: Constraint2 = {case (tc1, tc2) => tc1 == tc2}
-
-  def sameTypeN: ConstraintN = {tcs => tcs.tail.forall(_ == tcs.head)}
-}

--- a/src/main/scala/sigmastate/serialization/SigmaSerializerExample.scala
+++ b/src/main/scala/sigmastate/serialization/SigmaSerializerExample.scala
@@ -1,0 +1,40 @@
+package sigmastate.serialization
+
+import scala.util.Try
+import sigmastate._
+import sigmastate.serialization.ValueSerializer.{deserialize, serialize}
+
+object SigmaSerializerExample extends App {
+  //todo: convert cases below into tests:
+
+  println(deserialize(Array[Byte](21, 11, 0, 0, 0, 0, 0, 0, 0, 2,
+    11, 0, 0, 0, 0, 0, 0, 0, 3)))
+
+  val s: Value[SInt.type] = IntConstant(4)
+  println(serialize(s))
+
+  assert(deserialize(serialize(s)) == s)
+
+  assert(Try(deserialize(Array[Byte](21, 12, 13))).isFailure, "LT(bool, bool) must fail")
+
+  val gt = GT(IntConstant(6), IntConstant(5))
+  println(deserialize(serialize(gt)))
+  assert(deserialize(serialize(gt)) == gt)
+
+  val eq = EQ(TrueLeaf, FalseLeaf)
+  println(serialize(eq).mkString(","))
+  assert(deserialize(serialize(eq)) == eq)
+
+  //todo: make this expression does not compile?
+  val eq2 = EQ(TrueLeaf, IntConstant(5))
+
+  //concrete collection
+  val cc = ConcreteCollection(IndexedSeq(IntConstant(5), IntConstant(6), IntConstant(7)))
+  assert(deserialize(serialize(cc)) == cc)
+
+  val tb = TaggedBox(21: Byte)
+  assert(deserialize(serialize(tb)) == tb)
+
+  val cc2 = ConcreteCollection(IndexedSeq(IntConstant(5), TaggedInt(21)))
+  assert(deserialize(serialize(cc2)) == cc2)
+}

--- a/src/main/scala/sigmastate/serialization/TaggedVariableSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TaggedVariableSerializer.scala
@@ -1,12 +1,13 @@
 package sigmastate.serialization
 
 import sigmastate._
+import sigmastate.serialization.ValueSerializer.Position
 
-object TaggedVariableSerializer extends SigmaSerializer[TaggedVariable[_ <: SType]] {
+object TaggedVariableSerializer extends ValueSerializer[TaggedVariable[_ <: SType]] {
 
-  override val opCode = SigmaSerializer.TaggedVariableCode
+  override val opCode = ValueSerializer.TaggedVariableCode
 
-  override def parseBody = {case (bytes, pos) =>
+  override def parseBody(bytes: Array[Byte], pos: Position) = {
     val tc = bytes(pos)
     val id = bytes(pos + 1)
 
@@ -20,10 +21,10 @@ object TaggedVariableSerializer extends SigmaSerializer[TaggedVariable[_ <: STyp
       case b: Byte if b == SAvlTree.typeCode => TaggedAvlTree(id)
       case b: Byte if b == SGroupElement.typeCode => TaggedGroupElement(id)
       case b: Byte if b == SBox.typeCode => TaggedBox(id)
-    }, consumed, tc)
+    }, consumed)
   }
 
-  override def serializeBody = {v =>
+  override def serializeBody(v: TaggedVariable[_ <: SType]) = {
     Array(v.typeCode, v.id)
   }
 }

--- a/src/main/scala/sigmastate/serialization/TrueLeafSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TrueLeafSerializer.scala
@@ -1,14 +1,15 @@
 package sigmastate.serialization
 
 import sigmastate.SType.TypeCode
-import sigmastate.{SBoolean, TrueLeaf}
+import sigmastate.serialization.ValueSerializer.Position
+import sigmastate.{TrueLeaf, SBoolean}
 
-object TrueLeafSerializer extends SigmaSerializer[TrueLeaf.type] {
-  override val opCode = SigmaSerializer.TrueCode
+object TrueLeafSerializer extends ValueSerializer[TrueLeaf.type] {
+  override val opCode = ValueSerializer.TrueCode
 
   val typeCode: TypeCode = SBoolean.typeCode
 
-  override def parseBody = {case (bytes, pos) => (TrueLeaf, 0, typeCode)}
+  override def parseBody(bytes: Array[Byte], pos: Position) = {(TrueLeaf, 0)}
 
-  override def serializeBody = {_ => Array[Byte]()}
+  override def serializeBody(obj: TrueLeaf.type) = {Array[Byte]()}
 }

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -1,0 +1,77 @@
+package sigmastate.serialization
+
+import sigmastate._
+import scala.util.Try
+
+
+trait ValueSerializer[V <: Value[SType]] extends SigmaSerializer[Value[SType], V] {
+  import ValueSerializer._
+  override val companion = ValueSerializer
+  val opCode: OpCode
+
+  override def toBytes(obj: V): Array[Byte] = serialize(obj)
+
+  override def parseBytes(bytes: Array[Byte]): Try[V] = Try {
+    deserialize(bytes).asInstanceOf[V]
+  }
+}
+
+object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
+  type OpCode = Byte
+  type Tag = OpCode
+
+  val IntConstantCode = 11: Byte
+  val TaggedVariableCode = 1: Byte
+
+  val LtCode = 21: Byte
+  val LeCode = 22: Byte
+  val GtCode = 23: Byte
+  val GeCode = 24: Byte
+  val EqCode = 25: Byte
+  val NeqCode = 26: Byte
+
+
+  val TrueCode = 12: Byte
+  val FalseCode = 13: Byte
+
+  val ConcreteCollectionCode = 35: Byte
+
+  val table = Seq[ValueSerializer[_ <: Value[SType]]](
+    RelationSerializer(GtCode, GT.apply, Seq(Constraints.onlyInt2)),
+    RelationSerializer(GeCode, GE.apply, Seq(Constraints.onlyInt2)),
+    RelationSerializer(LtCode, LT.apply, Seq(Constraints.onlyInt2)),
+    RelationSerializer(LeCode, LE.apply, Seq(Constraints.onlyInt2)),
+    RelationSerializer(EqCode, EQ.applyNonTyped, Seq(Constraints.sameType2)),
+    RelationSerializer(NeqCode, NEQ.apply, Seq(Constraints.sameType2)),
+    IntConstantSerializer,
+    TrueLeafSerializer,
+    FalseLeafSerializer,
+    ConcreteCollectionSerializer,
+    TaggedVariableSerializer
+  ).map(s => (s.opCode, s)).toMap
+
+  def deserialize(bytes: Array[Byte], pos: Int): (Value[_ <: SType], Consumed) = {
+    val c = bytes(pos)
+    val handler = table(c)
+    val (v, consumed) = handler.parseBody(bytes, pos + 1)
+    (v, consumed + 1)
+  }
+
+  def deserialize(bytes: Array[Byte]): Value[_ <: SType] = deserialize(bytes, 0)._1
+
+  def serialize(v: Value[SType]): Array[Byte] = {
+    val opCode = v.opCode
+    val serFn = table(opCode).asInstanceOf[SigmaSerializer[Value[SType], v.type]]
+    opCode +: serFn.serializeBody(v)
+  }
+}
+
+object Constraints {
+  type Constraint2 = (SType.TypeCode, SType.TypeCode) => Boolean
+  type ConstraintN = Seq[SType.TypeCode] => Boolean
+
+  def onlyInt2: Constraint2 = {case (tc1, tc2) => tc1 == SInt.typeCode && tc2 == SInt.typeCode}
+  def sameType2: Constraint2 = {case (tc1, tc2) => tc1 == tc2}
+
+  def sameTypeN: ConstraintN = {tcs => tcs.tail.forall(_ == tcs.head)}
+}

--- a/src/main/scala/sigmastate/trees.scala
+++ b/src/main/scala/sigmastate/trees.scala
@@ -7,8 +7,8 @@ import scapi.sigma.DLogProtocol._
 import scapi.sigma.{FirstDiffieHellmanTupleProverMessage, ProveDiffieHellmanTuple, SecondDiffieHellmanTupleProverMessage}
 import scapi.sigma.rework.{FirstProverMessage, SigmaProtocol, SigmaProtocolCommonInput, SigmaProtocolPrivateInput}
 import scorex.crypto.hash.Blake2b256
-import sigmastate.serialization.SigmaSerializer
-import sigmastate.serialization.SigmaSerializer.OpCode
+import sigmastate.serialization.ValueSerializer
+import sigmastate.serialization.ValueSerializer.OpCode
 import sigmastate.utxo.Transformer
 import sigmastate.utxo.CostTable.Cost
 
@@ -218,26 +218,26 @@ sealed trait Relation[LIV <: SType, RIV <: SType] extends Triple[LIV, RIV, SBool
 
 case class LT(override val left: Value[SInt.type],
               override val right: Value[SInt.type]) extends Relation[SInt.type, SInt.type]{
-  override val opCode: OpCode = SigmaSerializer.LtCode
+  override val opCode: OpCode = ValueSerializer.LtCode
 }
 
 case class LE(override val left: Value[SInt.type],
               override val right: Value[SInt.type]) extends Relation[SInt.type, SInt.type] {
-  override val opCode: OpCode = SigmaSerializer.LeCode
+  override val opCode: OpCode = ValueSerializer.LeCode
 }
 
 case class GT(override val left: Value[SInt.type],
               override val right: Value[SInt.type]) extends Relation[SInt.type, SInt.type] {
-  override val opCode: OpCode = SigmaSerializer.GtCode
+  override val opCode: OpCode = ValueSerializer.GtCode
 }
 
 case class GE(override val left: Value[SInt.type],
               override val right: Value[SInt.type]) extends Relation[SInt.type, SInt.type] {
-  override val opCode: OpCode = SigmaSerializer.GeCode
+  override val opCode: OpCode = ValueSerializer.GeCode
 }
 
 case class EQ[S <: SType](override val left: Value[S], override val right: Value[S]) extends Relation[S, S] {
-  override val opCode: OpCode = SigmaSerializer.EqCode
+  override val opCode: OpCode = ValueSerializer.EqCode
 }
 
 object EQ {
@@ -246,7 +246,7 @@ object EQ {
 
 case class NEQ(override val left: Value[SType],
                                          override val right: Value[SType]) extends Relation[SType, SType] {
-  override val opCode: OpCode = SigmaSerializer.NeqCode
+  override val opCode: OpCode = ValueSerializer.NeqCode
 }
 
 
@@ -280,7 +280,7 @@ case class IsMember(tree: Value[SAvlTree.type],
 
 case class If[T <: SType](condition: Value[SBoolean.type], trueBranch: Value[T], falseBranch: Value[T])
   extends Quadruple[SBoolean.type, T, T, T] {
-
+  override def tpe = trueBranch.tpe
   override lazy val first = condition
   override lazy val second = trueBranch
   override lazy val third = falseBranch

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -2,16 +2,22 @@ package sigmastate
 
 import java.math.BigInteger
 import java.util.Objects
-
 import edu.biu.scapi.primitives.dlog.GroupElement
 import sigmastate.SType.TypeCode
 import sigmastate.utxo.SigmaStateBox
 
-
-
+/** Every type descriptor is a tree represented by nodes in SType hierarchy.
+  * In order to extend type family:
+  * - Implement concrete class derived from SType
+  * - Implement serializer (see SCollectionSerializer) and register it in STypeSerializer.table
+  * Each SType is serialized to array of bytes by:
+  * - emitting typeCode of each node
+  * - then recursively serializing subtrees from left to right on each level
+  * */
 sealed trait SType {
   type WrappedType
   val typeCode: SType.TypeCode
+
   def isPrimitive: Boolean = SType.allPrimitiveTypes.contains(this)
 }
 
@@ -24,8 +30,10 @@ object SType {
   implicit val typeAvlTree = SAvlTree
   implicit val typeGroupElement = SGroupElement
   implicit val typeBox = SBox
+
   implicit def typeCollection[V <: SType](implicit tV: V): SCollection[V] = SCollection[V]
 
+  /** All primitive types should be listed here */
   val allPrimitiveTypes = Seq(SInt, SBigInt, SBoolean, SByteArray, SAvlTree, SGroupElement, SBox)
   val typeCodeToType = allPrimitiveTypes.map(t => t.typeCode -> t).toMap
 }
@@ -37,61 +45,51 @@ object PrimType {
 
 case object SInt extends SType {
   override type WrappedType = Long
-
   override val typeCode = 1: Byte
 }
 
 case object SBigInt extends SType {
   override type WrappedType = BigInteger
-
   override val typeCode = 2: Byte
 }
 
 case object SBoolean extends SType {
   override type WrappedType = Boolean
-
   override val typeCode = 3: Byte
 }
 
 case object SByteArray extends SType {
   override type WrappedType = Array[Byte]
-
   override val typeCode = 4: Byte
 }
 
 case object SAvlTree extends SType {
   override type WrappedType = AvlTreeData
-
   override val typeCode = 5: Byte
 }
 
 case object SGroupElement extends SType {
   override type WrappedType = GroupElement
-
   override val typeCode: Byte = 6: Byte
 }
 
 case object SBox extends SType {
   override type WrappedType = SigmaStateBox
-
   override val typeCode: Byte = 7: Byte
 }
 
-case class  SCollection[ElemType <: SType]()(implicit val elemType: ElemType) extends SType {
+case class SCollection[ElemType <: SType]()(implicit val elemType: ElemType) extends SType {
   override type WrappedType = IndexedSeq[Value[ElemType]]
-
   override val typeCode = SCollection.TypeCode
 
   override def equals(obj: scala.Any) = obj match {
     case that: SCollection[_] => that.elemType == elemType
     case _ => false
   }
+
   override def hashCode() = (31 + typeCode) * 31 + elemType.hashCode()
 }
 
 object SCollection {
   val TypeCode = 80: Byte
-
-  //todo: SCollection[SCollection[]] is not possible!
-  def collectionOf(typeCode: TypeCode) = (TypeCode + typeCode).toByte
 }

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1,6 +1,7 @@
 package sigmastate
 
 import java.math.BigInteger
+import java.util.Objects
 
 import edu.biu.scapi.primitives.dlog.GroupElement
 import sigmastate.SType.TypeCode
@@ -80,6 +81,12 @@ case class  SCollection[ElemType <: SType]()(implicit val elemType: ElemType) ex
   override type WrappedType = IndexedSeq[Value[ElemType]]
 
   override val typeCode = SCollection.TypeCode
+
+  override def equals(obj: scala.Any) = obj match {
+    case that: SCollection[_] => that.elemType == elemType
+    case _ => false
+  }
+  override def hashCode() = (31 + typeCode) * 31 + elemType.hashCode()
 }
 
 object SCollection {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -16,6 +16,14 @@ sealed trait SType {
 
 object SType {
   type TypeCode = Byte
+  implicit val typeInt = SInt
+  implicit val typeBigInt = SBigInt
+  implicit val typeBoolean = SBoolean
+  implicit val typeByteArray = SByteArray
+  implicit val typeAvlTree = SAvlTree
+  implicit val typeGroupElement = SGroupElement
+  implicit val typeBox = SBox
+  implicit def typeCollection[V <: SType](implicit tV: V): SCollection[V] = SCollection[V]
 }
 
 case object SInt extends SType {
@@ -60,10 +68,10 @@ case object SBox extends SType {
   override val typeCode: Byte = 7: Byte
 }
 
-case class  SCollection[ElemType <: SType]()(implicit val w: ElemType) extends SType {
+case class  SCollection[ElemType <: SType]()(implicit val elemType: ElemType) extends SType {
   override type WrappedType = IndexedSeq[Value[ElemType]]
 
-  override val typeCode = SCollection.collectionOf(w.typeCode)
+  override val typeCode = SCollection.collectionOf(elemType.typeCode)
 }
 
 object SCollection {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -79,12 +79,12 @@ case object SBox extends SType {
 case class  SCollection[ElemType <: SType]()(implicit val elemType: ElemType) extends SType {
   override type WrappedType = IndexedSeq[Value[ElemType]]
 
-  override val typeCode = SCollection.collectionOf(elemType.typeCode)
+  override val typeCode = SCollection.TypeCode
 }
 
 object SCollection {
-  val Base = 80: Byte
+  val TypeCode = 80: Byte
 
   //todo: SCollection[SCollection[]] is not possible!
-  def collectionOf(typeCode: TypeCode) = (Base + typeCode).toByte
+  def collectionOf(typeCode: TypeCode) = (TypeCode + typeCode).toByte
 }

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -10,8 +10,8 @@ import sigmastate.utxo.SigmaStateBox
 
 sealed trait SType {
   type WrappedType
-
   val typeCode: SType.TypeCode
+  def isPrimitive: Boolean = SType.allPrimitiveTypes.contains(this)
 }
 
 object SType {
@@ -24,6 +24,14 @@ object SType {
   implicit val typeGroupElement = SGroupElement
   implicit val typeBox = SBox
   implicit def typeCollection[V <: SType](implicit tV: V): SCollection[V] = SCollection[V]
+
+  val allPrimitiveTypes = Seq(SInt, SBigInt, SBoolean, SByteArray, SAvlTree, SGroupElement, SBox)
+  val typeCodeToType = allPrimitiveTypes.map(t => t.typeCode -> t).toMap
+}
+
+/** Primitive type recognizer to pattern match on TypeCode */
+object PrimType {
+  def unapply(tc: TypeCode): Option[SType] = SType.typeCodeToType.get(tc)
 }
 
 case object SInt extends SType {

--- a/src/main/scala/sigmastate/utxo/SigmaStateTransaction.scala
+++ b/src/main/scala/sigmastate/utxo/SigmaStateTransaction.scala
@@ -40,14 +40,15 @@ object Box {
   * same box.
   *
   * @param value
-  * @param proposition
+  * @param proposition guarding script, which should be evaluated to true in order to open this box
   * @param additionalRegisters
-  * @param nonce
+  * @param nonce to differentiate this instance from otherwise identical instances
   */
-class SigmaStateBox(override val value: Long,
-                         override val proposition: Value[SBoolean.type],
-                         additionalRegisters: Map[NonMandatoryIdentifier, _ <: Value[SType]] = Map(),
-                         nonce: Array[Byte] = Array.fill(32)(0:Byte)) extends Box[Value[SBoolean.type]] {
+class SigmaStateBox private(
+    override val value: Long,
+    override val proposition: Value[SBoolean.type],
+    additionalRegisters: Map[NonMandatoryIdentifier, _ <: Value[SType]] = Map(),
+    nonce: Array[Byte]) extends Box[Value[SBoolean.type]] {
   import sigmastate.utxo.SigmaStateBox._
 
   def get(identifier: RegisterIdentifier): Option[Value[SType]] = {

--- a/src/main/scala/sigmastate/utxo/UtxoContext.scala
+++ b/src/main/scala/sigmastate/utxo/UtxoContext.scala
@@ -30,10 +30,12 @@ case object Height extends NotReadyValueInt {
 
 case object Inputs extends LazyCollection[SBox.type] {
   val cost = 1
+  val tpe = SCollection()(SBox)
 }
 
 case object Outputs extends LazyCollection[SBox.type] {
   val cost = 1
+  val tpe = SCollection()(SBox)
 }
 
 case object LastBlockUtxoRootHash extends NotReadyValueAvlTree

--- a/src/main/scala/sigmastate/values.scala
+++ b/src/main/scala/sigmastate/values.scala
@@ -20,6 +20,7 @@ import scala.collection.immutable
 trait Value[+S <: SType] extends Product {
   val opCode: ValueSerializer.OpCode = 0: Byte
   def tpe: S
+  def typeCode: SType.TypeCode = tpe.typeCode
   def cost: Int
 
   /** Returns true if this value represent some constant or sigma statement, false otherwise */
@@ -45,9 +46,7 @@ trait NotReadyValue[S <: SType] extends Value[S] {
 
 trait TaggedVariable[S <: SType] extends NotReadyValue[S] {
   override val opCode: OpCode = ValueSerializer.TaggedVariableCode
-
   val id: Byte
-  val typeCode: SType.TypeCode
 }
 
 
@@ -71,7 +70,6 @@ case object UnknownInt extends NotReadyValueInt {
 
 case class TaggedInt(override val id: Byte) extends TaggedVariable[SInt.type] with NotReadyValueInt {
   override val cost = 1
-  override val typeCode: TypeCode = SInt.typeCode
 }
 
 
@@ -88,7 +86,6 @@ trait NotReadyValueBigInt extends NotReadyValue[SBigInt.type] {
 }
 
 case class TaggedBigInt(override val id: Byte) extends TaggedVariable[SBigInt.type] with NotReadyValueBigInt {
-  override val typeCode: TypeCode = SBigInt.typeCode
 }
 
 
@@ -113,7 +110,6 @@ case object UnknownByteArray extends NotReadyValueByteArray
 
 
 case class TaggedByteArray(override val id: Byte) extends TaggedVariable[SByteArray.type] with NotReadyValueByteArray {
-  override val typeCode: TypeCode = SByteArray.typeCode
 }
 
 
@@ -137,7 +133,6 @@ trait NotReadyValueAvlTree extends NotReadyValue[SAvlTree.type] {
 }
 
 case class TaggedAvlTree(override val id: Byte) extends TaggedVariable[SAvlTree.type] with NotReadyValueAvlTree {
-  override val typeCode: TypeCode = SAvlTree.typeCode
 }
 
 
@@ -161,7 +156,6 @@ trait NotReadyValueGroupElement extends NotReadyValue[SGroupElement.type] {
 
 case class TaggedGroupElement(override val id: Byte)
   extends TaggedVariable[SGroupElement.type] with NotReadyValueGroupElement {
-  override val typeCode: TypeCode = SGroupElement.typeCode
 }
 
 
@@ -193,7 +187,6 @@ trait NotReadyValueBoolean extends NotReadyValue[SBoolean.type] {
 
 case class TaggedBoolean(override val id: Byte) extends TaggedVariable[SBoolean.type] with NotReadyValueBoolean {
   override def cost = 1
-  override val typeCode: TypeCode = SBoolean.typeCode
 }
 
 /**
@@ -215,7 +208,6 @@ trait NotReadyValueBox extends NotReadyValue[SBox.type] {
 }
 
 case class TaggedBox(override val id: Byte) extends TaggedVariable[SBox.type] with NotReadyValueBox {
-  override val typeCode: TypeCode = SBox.typeCode
   override def tpe = SBox
 }
 

--- a/src/test/scala/sigmastate/serialization/BooleanLeafsSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/BooleanLeafsSerializerSpecification.scala
@@ -1,0 +1,14 @@
+package sigmastate.serialization
+
+import sigmastate._
+
+class BooleanLeafsSerializerSpecification extends TableSerializationSpecification {
+  override val objects =
+    Table(
+      ("object", "bytes"),
+      (FalseLeaf, Array[Byte](13)),
+      (TrueLeaf, Array[Byte](12))
+    )
+  tableRoundTripTest("Boolean leafs serializers roundtrip")
+  tablePredefinedBytesTest("Boolean leafs deserialize from predefined bytes")
+}

--- a/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
@@ -1,0 +1,21 @@
+package sigmastate.serialization
+
+import scorex.crypto.encode.Base58
+import sigmastate._
+
+class ConcreteCollectionSerializerSpecification extends SerializationSpecification {
+
+  property("ConcreteCollection serializer roundtrip") {
+    roundTripTest(ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1))))))
+  }
+
+  property("ConcreteCollection serializer roundtrip with different types seq") {
+    roundTripTest(ConcreteCollection(IndexedSeq(IntConstant(5), TaggedInt(21))))
+  }
+
+  property("ConcreteCollection deserialize from predefined bytes") {
+    val col = ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))
+    val bytes = Base58.decode("yo18XXEkLgyWrJvWUX4t").get
+    predefinedBytesTest(bytes, col)
+  }
+}

--- a/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
@@ -15,7 +15,6 @@ class ConcreteCollectionSerializerSpecification extends SerializationSpecificati
 
   property("ConcreteCollection deserialize from predefined bytes") {
     val col = ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))
-    val bytes = Base58.decode("yo18XXEkLgyWrJvWUX4t").get
-    predefinedBytesTest(bytes, col)
+    roundTripTest(col)
   }
 }

--- a/src/test/scala/sigmastate/serialization/IntConstantSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/IntConstantSerializerSpecification.scala
@@ -1,0 +1,16 @@
+package sigmastate.serialization
+
+import scorex.crypto.encode.Base58
+import sigmastate.IntConstant
+
+class IntConstantSerializerSpecification extends SerializationSpecification {
+  property("IntConstant serializer roundtrip") {
+    roundTripTest(IntConstant(1))
+  }
+
+  property("IntConstant deserialize from predefined bytes") {
+    val value = IntConstant(1)
+    val bytes = Base58.decode("981jCC8syJPa").get
+    predefinedBytesTest(bytes, value)
+  }
+}

--- a/src/test/scala/sigmastate/serialization/RelationSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/RelationSerializerSpecification.scala
@@ -1,0 +1,28 @@
+package sigmastate.serialization
+
+import scorex.crypto.encode.Base58
+import sigmastate._
+import sigmastate.serialization.SigmaSerializer.deserialize
+
+class RelationSerializerSpecification extends TableSerializationSpecification {
+
+  override val objects =
+    Table(
+      ("object", "bytes"),
+      (LT(IntConstant(2), IntConstant(3)), Base58.decode("4rSL7c2zGG9UMVp7sCiUkULyV4").get),
+      (LE(IntConstant(2), IntConstant(3)), Base58.decode("534BTm8S6piPbJymrgrtX8dpBL").get),
+      (GT(IntConstant(6), IntConstant(5)), Base58.decode("5Dg2ovDswPHJqMBQqM9ia9UCXN").get),
+      (GE(IntConstant(6), IntConstant(5)), Base58.decode("5QHtA5KKmwrE5AM4pqJ8Lom3De").get),
+      (EQ(TrueLeaf, FalseLeaf), Base58.decode("9QxU").get),
+      (NEQ(TrueLeaf, FalseLeaf), Base58.decode("9kSQ").get)
+    )
+
+  tableRoundTripTest("Relation serializers roundtrip")
+  tablePredefinedBytesTest("Relations deserialize from predefined bytes")
+
+  property("serialization LT(bool, bool) must fail") {
+    assertThrows[Error] {
+      deserialize(Array[Byte](21, 12, 13))
+    }
+  }
+}

--- a/src/test/scala/sigmastate/serialization/RelationSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/RelationSerializerSpecification.scala
@@ -2,7 +2,7 @@ package sigmastate.serialization
 
 import scorex.crypto.encode.Base58
 import sigmastate._
-import sigmastate.serialization.SigmaSerializer.deserialize
+import sigmastate.serialization.ValueSerializer._
 
 class RelationSerializerSpecification extends TableSerializationSpecification {
 

--- a/src/test/scala/sigmastate/serialization/SerializationSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/SerializationSpecification.scala
@@ -1,0 +1,22 @@
+package sigmastate.serialization
+
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks, TableDrivenPropertyChecks}
+import org.scalatest.{Assertion, Matchers, PropSpec}
+import sigmastate.{SType, Value}
+
+trait SerializationSpecification extends PropSpec
+  with PropertyChecks
+  with GeneratorDrivenPropertyChecks
+  with TableDrivenPropertyChecks
+  with Matchers {
+
+  protected def roundTripTest[V <: Value[_ <: SType]](v: V): Assertion = {
+    val bytes = SigmaSerializer.serialize(v)
+    val t = SigmaSerializer.deserialize(bytes)
+    t shouldBe v
+  }
+
+  protected def predefinedBytesTest[V <: Value[_ <: SType]](bytes: Array[Byte], v: V): Assertion = {
+    SigmaSerializer.deserialize(bytes) shouldBe v
+  }
+}

--- a/src/test/scala/sigmastate/serialization/SerializationSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/SerializationSpecification.scala
@@ -11,12 +11,12 @@ trait SerializationSpecification extends PropSpec
   with Matchers {
 
   protected def roundTripTest[V <: Value[_ <: SType]](v: V): Assertion = {
-    val bytes = SigmaSerializer.serialize(v)
-    val t = SigmaSerializer.deserialize(bytes)
+    val bytes = ValueSerializer.serialize(v)
+    val t = ValueSerializer.deserialize(bytes)
     t shouldBe v
   }
 
   protected def predefinedBytesTest[V <: Value[_ <: SType]](bytes: Array[Byte], v: V): Assertion = {
-    SigmaSerializer.deserialize(bytes) shouldBe v
+    ValueSerializer.deserialize(bytes) shouldBe v
   }
 }

--- a/src/test/scala/sigmastate/serialization/TableSerializationSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TableSerializationSpecification.scala
@@ -1,0 +1,20 @@
+package sigmastate.serialization
+
+import org.scalatest.prop.TableFor2
+import sigmastate.{SType, Value}
+
+trait TableSerializationSpecification extends SerializationSpecification {
+  def objects: TableFor2[_ <: Value[_ <: SType], Array[Byte]]
+
+  def tableRoundTripTest(title: String) = property(title) {
+    forAll(objects) { (relationObject, _) =>
+      roundTripTest(relationObject)
+    }
+  }
+
+  def tablePredefinedBytesTest(title: String) = property(title) {
+    forAll(objects) { (value, bytes) =>
+      predefinedBytesTest(bytes, value)
+    }
+  }
+}

--- a/src/test/scala/sigmastate/serialization/TaggedVariableSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TaggedVariableSerializerSpecification.scala
@@ -1,0 +1,14 @@
+package sigmastate.serialization
+
+import scorex.crypto.encode.Base58
+import sigmastate._
+
+class TaggedVariableSerializerSpecification extends SerializationSpecification {
+  property("TaggedVariable serializer roundtrip") {
+    roundTripTest(TaggedBox(21))
+  }
+
+  property("TaggedVariable deserialize from predefined bytes") {
+    predefinedBytesTest(Base58.decode("M21").get, TaggedBox(10))
+  }
+}

--- a/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
@@ -1099,8 +1099,8 @@ class UtxoInterpreterSpecification extends PropSpec
 
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = Exists(Outputs, 21, EQ(ExtractRegisterAs(TaggedBox(21), R3),
-      Plus(ExtractRegisterAs(Self, R3), IntConstant(1))))
+    val prop = Exists(Outputs, 21, EQ(ExtractRegisterAs(TaggedBox(21), R3)(SInt),
+      Plus(ExtractRegisterAs(Self, R3)(SInt), IntConstant(1))))
 
     val newBox1 = SigmaStateBox(10, pubkey, Map(R3 -> IntConstant(3)))
     val newBox2 = SigmaStateBox(10, pubkey, Map(R3 -> IntConstant(6)))

--- a/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
@@ -106,7 +106,7 @@ class OracleExamplesSpecification extends PropSpec
 
     val treeData = new AvlTreeData(lastBlockUtxoDigest, 32, None)
 
-    def extract[T <: SType](Rn: RegisterIdentifier) = ExtractRegisterAs[T](TaggedBox(22: Byte), Rn)
+    def extract[T <: SType](Rn: RegisterIdentifier)(implicit tT: T) = ExtractRegisterAs[T](TaggedBox(22: Byte), Rn)
 
     def withinTimeframe(sinceHeight:Int,
                         timeoutHeight: Int,


### PR DESCRIPTION
Each Value can have type descriptor 

```
trait Value[+S <: SType> {
  def tpe: S
}
```
Related subtasks:
- [x] remove TaggedVariable.typeCode
- [x] implement serialization for any SType (including Collection[Collection[]])


