### PR TITLE
Accessing registers of Box values

### DIFF
--- a/src/main/scala/scapi/sigma/DLogProtocol.scala
+++ b/src/main/scala/scapi/sigma/DLogProtocol.scala
@@ -2,7 +2,6 @@ package scapi.sigma
 
 import java.math.BigInteger
 import java.security.SecureRandom
-
 import org.bouncycastle.util.BigIntegers
 import sigmastate.Values._
 import Value.PropositionCode
@@ -10,11 +9,8 @@ import sigmastate.utxo.CostTable.Cost
 import sigmastate._
 import sigmastate.interpreter.GroupSettings
 import sigmastate.interpreter.GroupSettings.EcPointType
-
 import scala.concurrent.Future
 import scala.util.Try
-
-
 
 object DLogProtocol {
 
@@ -30,8 +26,6 @@ object DLogProtocol {
 
     override val cost: Int = Cost.Dlog
     override val soundness: Int = 256
-
-//    override def fields = ProveDlog.fields
 
     //todo: fix, we should consider that class parameter could be not evaluated
     lazy val h: EcPointType = value.asInstanceOf[GroupElementConstant].value
@@ -52,9 +46,6 @@ object DLogProtocol {
       val h = dlogGroup.reconstructElement(bCheckMembership = true, xy).get //todo: .get
       ProveDlog(h)
     }
-//    val fields = Seq(
-//      "propBytes" -> SByteArray,
-//    )
   }
 
 

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -47,9 +47,6 @@ class SigmaBinder(env: Map[String, Any]) {
       val tpe = if (args.isEmpty) NoType else args(0).tpe
       Some(ConcreteCollection(args)(tpe))
 
-    // Rule: col.size --> SizeOf(col)
-    case Select(obj, "size") if obj.tpe.isCollection =>
-      Some(SizeOf(obj.asValue[SCollection[SType]]))
 
     // Rule: col(i) --> ByIndex(col, i)
     case Apply(Typed(obj, tCol: SCollection[_]), Seq(IntConstant(i))) =>

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -42,11 +42,11 @@ class SigmaBinder(env: Map[String, Any]) {
         }
       }
     }
+
     // Rule: Array(...) -->
     case Apply(Ident("Array", _), args) =>
       val tpe = if (args.isEmpty) NoType else args(0).tpe
       Some(ConcreteCollection(args)(tpe))
-
 
     // Rule: col(i) --> ByIndex(col, i)
     case Apply(Typed(obj, tCol: SCollection[_]), Seq(IntConstant(i))) =>

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -33,9 +33,9 @@ object SigmaPredef {
     "taggedAvlTree" -> Lambda(Vector("input" -> SInt), SAvlTree, None),
     "taggedBoolean" -> Lambda(Vector("input" -> SInt), SBoolean, None),
 
-    "ProveDiffieHellmanTuple" -> Lambda(Vector(
+    "proveDHTuple" -> Lambda(Vector(
       "g" -> SGroupElement, "h" -> SGroupElement, "u" -> SGroupElement, "v" -> SGroupElement), SBoolean, None),
-    "ProveDlog" -> Lambda(Vector("value" -> SGroupElement), SBoolean, None),
+    "proveDlog" -> Lambda(Vector("value" -> SGroupElement), SBoolean, None),
     "isMember" -> Lambda(Vector(
        "tree" -> SAvlTree, "key" -> SByteArray, "proof" -> SByteArray), SBoolean, None),
   ).toMap
@@ -58,4 +58,6 @@ object SigmaPredef {
 
   val Blake2b256Sym = PredefIdent("blake2b256")
   val IsMemberSym = PredefIdent("isMember")
+  val ProveDlogSym = PredefIdent("proveDlog")
+  val ProveDHTupleSym = PredefIdent("proveDHTuple")
 }

--- a/src/main/scala/sigmastate/lang/SigmaPrinter.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPrinter.scala
@@ -67,7 +67,7 @@ class SigmaPrinter extends org.bitbucket.inkytonik.kiama.output.PrettyPrinter {
   def typeToDoc(t : SType) : Doc =
     t match {
       case SInt       => "Int"
-      case SFunc(dom, t2) => parens(lsep(dom.map(typeToDoc).to, comma)) <+> "->" <+> typeToDoc(t2)
+      case SFunc(dom, t2, _) => parens(lsep(dom.map(typeToDoc).to, comma)) <+> "->" <+> typeToDoc(t2)
       case NoType        => "NoType" // Not used
       case _ => s"<unknown type $t>"
     }

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -59,19 +59,23 @@ class SigmaSpecializer {
 
     case SelectGen(obj, "value", SInt) if obj.tpe == SBox =>
       Some(ExtractAmount(obj.asValue[SBox.type]))
-    case Apply(SelectGen(col,"exists", tpe), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
+
+    case Apply(SelectGen(col,"exists", _), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
       val tagged = mkTagged(n, t, 21)
       val body1 = eval(env + (n -> tagged), body)
       Some(Exists(col.asValue[SCollection[SType]], tagged.id, body1.asValue[SBoolean.type]))
-    case Apply(SelectGen(col,"forall", tpe), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
+
+    case Apply(SelectGen(col,"forall", _), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
       val tagged = mkTagged(n, t, 21)
       val body1 = eval(env + (n -> tagged), body)
       Some(ForAll(col.asValue[SCollection[SType]], tagged.id, body1.asValue[SBoolean.type]))
-    case Apply(SelectGen(col,"map", tpe), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
+
+    case Apply(SelectGen(col,"map", _), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
       val tagged = mkTagged(n, t, 21)
       val body1 = eval(env + (n -> tagged), body)
       Some(MapCollection(col.asValue[SCollection[SType]], tagged.id, body1)(body1.tpe))
-    case Apply(SelectGen(col,"fold", tpe), Seq(zero, Lambda(Seq((zeroArg, tZero), (opArg, tOp)), _, Some(body)))) =>
+
+    case Apply(SelectGen(col,"fold", _), Seq(zero, Lambda(Seq((zeroArg, tZero), (opArg, tOp)), _, Some(body)))) =>
       val taggedZero = mkTagged(zeroArg, tZero, 21)
       val taggedOp = mkTagged(opArg, tOp, 22)
       val body1 = eval(env ++ Seq(zeroArg -> taggedZero, opArg -> taggedOp), body)

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -1,7 +1,5 @@
 package sigmastate.lang
 
-import java.math.BigInteger
-
 import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{strategy, rewrite, reduce}
 import scapi.sigma.DLogProtocol.ProveDlog
 import sigmastate.Values.Value.Typed
@@ -9,7 +7,6 @@ import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.SigmaPredef._
 import sigmastate.lang.Terms.{Lambda, Let, Apply, ValueOps, Select, Block, Ident}
-import sigmastate.utxo.ErgoBox.R3
 import sigmastate.utxo._
 
 class SigmaSpecializer {
@@ -84,6 +81,7 @@ class SigmaSpecializer {
           None  // leave it as it is and handle on a level of parent node
         case _ => error(s"Invalid access to Box property in $sel: field $field is not found")
       }
+
     case Select(obj: SigmaBoolean, field, _) =>
       field match {
         case SigmaBoolean.PropBytes => Some(ByteArrayConstant(obj.propBytes))
@@ -123,7 +121,6 @@ class SigmaSpecializer {
     val res = eval(env, typed)
     res
   }
-
 }
 
 class SpecializerException(msg: String) extends Exception(msg)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -5,7 +5,6 @@ import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.Terms._
 import sigmastate.utxo._
-
 import scala.collection.mutable.ArrayBuffer
 
 /**

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -1,6 +1,5 @@
 package sigmastate.lang
 
-import org.bitbucket.inkytonik.kiama.attribution.Attribution
 import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
 import sigmastate._
 import sigmastate.Values._
@@ -16,237 +15,10 @@ import scala.collection.mutable.ArrayBuffer
   * from the AST, and one (tipe2) that represents names by references to the
   * nodes of their binding lambda expressions.
   */
-class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribution {
+class SigmaTyper {
   import SigmaTyper._
-  import org.bitbucket.inkytonik.kiama.util.Messaging.{check, collectMessages, message, Messages}
 
-  /** The semantic error messages for the tree based on the inferred attributes. */
-//  lazy val errors : Messages =
-//    collectMessages(tree) {
-//      case e : SValue =>
-//        check(e) {
-//          case e @ Ident(x, _) =>
-//            message(e, s"unknown name '$x'", tipe(e) == NoType)
-//          case e: SValue =>
-//            message(e, s"Expression ${e} doesn't have type: context ${tree.parent(e)}", tipe(e) == NoType)
-//        }
-//    }
-
-  /**
-    * The variables that are free in the given expression.
-    */
-//  val fv : SValue => List[Idn] =
-//    attr {
-//      case IntConstant(_)            => List()
-//      case Ident(v, _)               => List(v)
-//      case Lambda(args, _, Some(e))  =>
-//        val argNames = args.map(_._1).toList
-//        fv(e).filterNot(argNames.contains(_))
-//      case Apply(e1, args)           => args.foldLeft(fv(e1))((acc, e) => acc ++ fv(e))
-//      case Let(i, t, e) => fv(e)
-//      case Block(bs, e) => {
-//        val fbv = bs.map(_.body).map(fv).flatten
-//        val bvars = bs.map(_.name)
-//        fbv.toList ++ (fv(e).filterNot(bvars.contains(_)))
-//      }
-//    }
-
-  /**
-    * The environment of an expression is the list of variable names that
-    * are visible in that expression and their types.
-    */
-//  val scope : SValue => List[(Idn, SType)] =
-//    attr {
-//      // Inside a lambda expression the bound variable is now visible
-//      // in addition to everything that is visible from above. Note
-//      // that an inner declaration of a var hides an outer declaration
-//      // of the same var since we add inner bindings at the beginning
-//      // of the env and we search the env list below in tipe from
-//      // beginning to end
-//      case e @ tree.parent(p @ Lambda(args, t, Some(body))) if e eq body =>
-//        (args ++ scope(p)).toList
-//
-//      // Inside the result expression of a block all bindings are visible
-//      case e @ tree.parent(p @ Block(bs, res)) if e eq res =>
-//        val fromLets = bs.map(l => (l.name, l.givenType.?:(tipe(l.body))))
-//        val res = (fromLets ++ scope(p))
-//        res.toList
-//
-//      // Inside any binding of a block all the previous names are visible
-//      case e @ tree.parent(p @ Block(bs, res)) if bs.exists(_ eq e) =>
-//        val iLet = bs.indexWhere(_ eq e)
-//        val boundNames = bs.take(iLet).map(l => (l.name, l.givenType.?:(tipe(l.body))))
-//        val res = (boundNames ++ scope(p))
-//        res.toList
-//
-//      // Other expressions do not bind new identifiers so they just
-//      // get their environment from their parent
-//      case tree.parent(p : SValue) =>
-//        scope(p)
-//
-//      // global level contains all predefined names
-//      case _ =>
-//        val predef = SigmaPredef.predefinedEnv.mapValues(_.tpe).toList
-//        predef ++ globalEnv.mapValues(SType.typeOfData).toList
-//    }
-
-  /**
-    * The type of an expression.  Checks constituent names and types.  Uses
-    * the env attribute to get the bound variables and their types.
-    */
-//  val tipe : SValue => SType =
-//    attr {
-//      // this case should be before general EvaluatedValue
-//      case c @ ConcreteCollection(items) =>  {
-//        val types = items.map(tipe).distinct
-//        val eItem =
-//          if (types.isEmpty) NoType
-//          else
-//          if (types.size == 1) types(0)
-//          else
-//            error(s"All element of array $c should have the same type but found $types")
-//        SCollection(eItem)
-//      }
-//
-//      // this case should be before general EvaluatedValue
-//      case Tuple(items) =>
-//        STuple(items.map(tipe))
-//
-//      case v: EvaluatedValue[_] => v.tpe
-//      case v: NotReadyValueInt => v.tpe
-//      case Inputs => Inputs.tpe
-//
-//      // An operation must be applied to two arguments of the same type
-//      case op @ GT(e1, e2) => binOpTipe(op, e1, e2)(SInt, SBoolean)
-//      case op @ LT(e1, e2) => binOpTipe(op, e1, e2)(SInt, SBoolean)
-//      case op @ GE(e1, e2) => binOpTipe(op, e1, e2)(SInt, SBoolean)
-//      case op @ LE(e1, e2) => binOpTipe(op, e1, e2)(SInt, SBoolean)
-//      case op @ EQ(e1, e2) => binOpTipe(op, e1, e2)(tipe(e1), SBoolean)
-//      case op @ NEQ(e1, e2) => binOpTipe(op, e1, e2)(tipe(e1), SBoolean)
-//
-//      case op @ AND(xs) =>
-//        val xsT = checkTyped(op, tipe(xs), SCollection(SBoolean))
-//        xsT.elemType
-//      case op @ OR(xs) =>
-//        val xsT = checkTyped(op, tipe(xs), SCollection(SBoolean))
-//        xsT.elemType
-//
-//      case ite @ If(c, t, e) =>
-//        val tCond = tipe(c)
-//        if (tCond != SBoolean) error(s"Invalid type of condition in $ite: expected Boolean; actual: $tCond")
-//        val tThen = tipe(t)
-//        val tElse = tipe(e)
-//        if (tThen != tElse) error(s"Invalid type of condition $ite: both branches should have the same type but was $tThen and $tElse")
-//        tThen
-//      // An identifier is looked up in the environement of the current
-//      // expression.  If we find it, then we use the type that we find.
-//      // Otherwise it's an error.
-//      case e @ Ident(x,_) =>
-//        scope(e).collectFirst {
-//          case (y, t) if x == y => t
-//        }.getOrElse {
-//          NoType
-//        }
-//
-//      // A lambda expression is a function from the type of its argument
-//      // to the type of the body expression
-//      case lam @ Lambda(args, t, body) =>
-//        for ((name, t) <- args)
-//          if (t == NoType)
-//            error(s"Invalid function $lam: undefined type of argument $name")
-//        val argTypes = args.map(_._2)
-//        if (t == NoType) {
-//          val tRes = body.fold(NoType: SType)(tipe)
-//          if (tRes == NoType)
-//            error(s"Invalid function $lam: undefined type of result")
-//          SFunc(argTypes, tRes)
-//        }
-//        else {
-//          if (body.isDefined && t != tipe(body.get))
-//            error(s"Invalid function $lam: resulting expression type ${tipe(body.get)} doesn't equal expected type $t")
-//          SFunc(argTypes, t)
-//        }
-//
-//      // For an application we first determine the type of the expression
-//      // being applied.
-//      case app @ Apply(f, args) =>
-//        tipe(f) match {
-//          case SFunc(argTypes, tRes) =>
-//            // If it's a function then the application has type of that function's return type.
-//            val actualTypes = args.map(tipe)
-//            unifyTypeLists(argTypes, actualTypes) match {
-//              case Some(subst) =>
-//                val newRes = applySubst(tRes, subst)
-//                newRes
-//              case None =>
-//                error(s"Invalid argument type of application $app: expected $argTypes; actual: $actualTypes")
-//            }
-//
-//          case tCol: SCollection[_] =>
-//            // If it's a collection then the application has type of that collection's element.
-//            // Only constant indices are supported so far
-//            args match {
-//              case Seq(IntConstant(i)) =>
-//                tCol.elemType
-//              case _ =>
-//                error(s"Invalid argument of array application $app: expected integer constant; actual: $args")
-//            }
-//          case t =>
-//            error(s"Invalid function/array application $app: function/array type is expected but was $t")
-//        }
-//
-//      case ByIndex(col, i) =>
-//        val tItem = col.tpe.elemType
-//        if (tItem == NoType) error(s"Invalid type in $col: undefined element type")
-//        tItem
-//
-//      // A block returns the type of the result expression
-//      case Block(bs, e) =>
-//        tipe(e)
-//
-//      // Let can be thought as an expression with the side effect of introducing a new variable
-//      case Let(_, _, body) => tipe(body)
-//
-//      case sel: Select => typeOfSelect(sel)
-//
-////      case ApplyTypes(input, targs) =>
-//      case v: SValue if v.tpe != NoType => v.tpe
-//
-//      case e => error(s"Don't know how to compute type for $e")
-//    }
-
-//  def typeOfSelect(sel: Select): SType = (sel.obj, tipe(sel.obj)) match {
-//    case (_, s: SProduct) =>
-//      val iField = s.fieldIndex(sel.field)
-//      if (iField != -1) {
-//        s.fields(iField)._2
-//      }
-//      else
-//        error(s"Cannot find field '${sel.field}' in product type with fields ${s.fields}")
-//    case (obj: SigmaBoolean, SBoolean) =>
-//      val iField = obj.fields.indexWhere(_._1 == sel.field)
-//      if (iField != -1) {
-//        obj.fields(iField)._2
-//      }
-//      else
-//        error(s"Cannot find field '${sel.field}' in Sigma type with fields ${obj.fields}")
-//    case (_, t) =>
-//      error(s"Cannot get field '${sel.field}' of non-product type $t")
-//  }
-
-//  def binOpTipe(op: SValue, e1: SValue, e2: SValue)(arg: SType, res: SType): SType =
-//    if ((tipe(e1) == arg) && (tipe(e2) == arg))
-//      res
-//    else
-//      error(s"Invalid binary operation $op: expected argument types ($arg, $arg); actual: (${tipe(e1)}, ${tipe(e2)})")
-
-  def checkTyped[T <: SType](op: SValue, t: SType, expected: T): T =
-    if (t == expected)
-      t.asInstanceOf[T]
-    else
-      error(s"Invalid argument type $t of $op")
-
-  /** Most Specific General(MSG) type of ts.
+  /** Most Specific Generalized (MSG) type of ts.
     * Currently just the type of the first element as long as all the elements have the same type. */
   def msgTypeOf(ts: Seq[SType]): Option[SType] = {
     val types = ts.distinct
@@ -256,6 +28,10 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
     else None
   }
 
+  /**
+    * Rewrite tree to typed tree.  Checks constituent names and types.  Uses
+    * the env map to resolve bound variables and their types.
+    */
   def assignType(env: Map[String, SType], bound: SValue): SValue = bound match {
     case Block(bs, res) =>
       var curEnv = env
@@ -284,14 +60,44 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
         case None => error(s"Cannot assign type for variable '$n' because it is not found in env $env")
       }
 
-    case sel @ Select(o, n) => Select(assignType(env, o), n)
+    case sel @ Select(obj: SigmaBoolean, n, None) =>
+      val newObj = assignType(env, obj).asSigmaValue
+      val iField = newObj.fields.indexWhere(_._1 == n)
+      val tRes = if (iField != -1) {
+        obj.fields(iField)._2
+      }
+      else
+        error(s"Cannot find field '${n}' in the object $obj of Sigma type with fields ${obj.fields}")
+      Select(newObj, n, Some(tRes))
 
-    case Lambda(args, t, body) =>
+    case sel @ Select(obj, n, None) =>
+      val newObj = assignType(env, obj)
+      newObj.tpe match {
+        case s: SProduct =>
+          val iField = s.fieldIndex(n)
+          val tRes = if (iField != -1) {
+            s.fields(iField)._2
+          } else
+            error(s"Cannot find field '${n}' in in the object $obj of Product type with fields ${s.fields}")
+          Select(newObj, n, Some(tRes))
+        case t =>
+          error(s"Cannot get field '${n}' in in the object $obj of non-product type $t")
+      }
+
+    case lam @ Lambda(args, t, body) =>
+      for ((name, t) <- args)
+        if (t == NoType)
+          error(s"Invalid function $lam: undefined type of argument $name")
       val lambdaEnv = env ++ args
       val newBody = body.map(assignType(lambdaEnv, _))
-      Lambda(args, newBody.fold(t)(_.tpe), newBody)
+      if (t != NoType) {
+        if (newBody.isDefined && t != newBody.get.tpe)
+          error(s"Invalid function $lam: resulting expression type ${newBody.get.tpe} doesn't equal declared type $t")
+      }
+      val res = Lambda(args, newBody.fold(t)(_.tpe), newBody)
+      res
 
-    case app @ Apply(sel @ Select(obj, n), args) =>
+    case app @ Apply(sel @ Select(obj, n, _), args) =>
       val newSel = assignType(env, sel)
       val newArgs = args.map(assignType(env, _))
       newSel.tpe match {
@@ -302,7 +108,7 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
             case Some(subst) =>
               val concrFunTpe = applySubst(genFunTpe, subst)
               val newObj = assignType(env, obj)
-              val newApply = Apply(SelectGen(newObj, n, concrFunTpe), newArgs)
+              val newApply = Apply(Select(newObj, n, Some(concrFunTpe)), newArgs)
               newApply
             case None =>
               error(s"Invalid argument type of application $app: expected $argTypes; actual: $actualTypes")
@@ -315,6 +121,12 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
       val new_f = assignType(env, f)
       val newArgs = args.map(assignType(env, _))
       f.tpe match {
+        case SFunc(argTypes, tRes) =>
+          // If it's a pre-defined function application
+          val actualTypes = newArgs.map(_.tpe)
+          if (actualTypes != argTypes)
+            error(s"Invalid argument type of application $app: expected $argTypes; actual: $actualTypes")
+          Apply(new_f, newArgs)
         case tCol: SCollection[_] =>
           // If it's a collection then the application has type of that collection's element.
           // Only constant indices are supported so far
@@ -329,27 +141,59 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
       }
 
     case If(c, t, e) =>
-      If(assignType(env, c).asValue[SBoolean.type], assignType(env, t), assignType(env, e))
+      val c1 = assignType(env, c).asValue[SBoolean.type]
+      val t1 = assignType(env, t)
+      val e1 = assignType(env, e)
+      val ite = If(c1, t1, e1)
+      if (c1.tpe != SBoolean)
+        error(s"Invalid type of condition in $ite: expected Boolean; actual: ${c1.tpe}")
+      if (t1.tpe != e1.tpe)
+        error(s"Invalid type of condition $ite: both branches should have the same type but was ${t1.tpe} and ${e1.tpe}")
+      ite
 
-    case AND(input) => AND(assignType(env, input).asValue[SCollection[SBoolean.type]])
-    case OR(input) => OR(assignType(env, input).asValue[SCollection[SBoolean.type]])
+    case op @ AND(input) =>
+      val input1 = assignType(env, input).asValue[SCollection[SBoolean.type]]
+      if (!(input1.tpe.isCollection && input1.tpe.elemType == SBoolean))
+        error(s"Invalid operation AND: $op")
+      AND(input1)
 
-    case GE(l, r) => bimap(env, l, r)(GE)
-    case LE(l, r) => bimap(env, l, r)(LE)
-    case GT(l, r) => bimap(env, l, r)(GT)
-    case LT(l, r) => bimap(env, l, r)(LT)
-    case EQ(l, r) => bimap(env, l, r)(EQ[SType])
-    case NEQ(l, r) => bimap(env, l, r)(NEQ)
+    case op @ OR(input) =>
+      val input1 = assignType(env, input).asValue[SCollection[SBoolean.type]]
+      if (!(input1.tpe.isCollection && input1.tpe.elemType == SBoolean))
+        error(s"Invalid operation OR: $op")
+      OR(input1)
 
-    case Plus(l, r) => bimap(env, l, r)(Plus)
-    case Minus(l, r) => bimap(env, l, r)(Minus)
-    case Xor(l, r) => bimap(env, l, r)(Xor)
-    case MultiplyGroup(l, r) => bimap(env, l, r)(MultiplyGroup)
-    case AppendBytes(l, r) => bimap(env, l, r)(AppendBytes)
+    case GE(l, r) => bimap(env, ">=", l, r)(GE)(SInt, SBoolean)
+    case LE(l, r) => bimap(env, "<=", l, r)(LE)(SInt, SBoolean)
+    case GT(l, r) => bimap(env, ">", l, r)(GT)(SInt, SBoolean)
+    case LT(l, r) => bimap(env, "<", l, r)(LT)(SInt, SBoolean)
+    case EQ(l, r) => bimap2(env, "==", l, r)(EQ[SType])((l,r) => l == r)
+    case NEQ(l, r) => bimap2(env, "!=", l, r)(NEQ)((l,r) => l == r)
 
-    case Exponentiate(l, r) => Exponentiate(assignType(env, l).asGroupElement, assignType(env, r).asBigInt)
-    case ByIndex(col, i) => ByIndex(assignType(env, col).asCollection, i)
-    case SizeOf(col) => SizeOf(assignType(env, col).asCollection)
+    case Plus(l, r) => bimap(env, "+", l, r)(Plus)(SInt, SInt)
+    case Minus(l, r) => bimap(env, "-", l, r)(Minus)(SInt, SInt)
+    case Xor(l, r) => bimap(env, "|", l, r)(Xor)(SByteArray, SByteArray)
+    case MultiplyGroup(l, r) => bimap(env, "*", l, r)(MultiplyGroup)(SGroupElement, SGroupElement)
+    case AppendBytes(l, r) => bimap(env, "++", l, r)(AppendBytes)(SByteArray, SByteArray)
+
+    case Exponentiate(l, r) =>
+      val l1 = assignType(env, l).asGroupElement
+      val r1 = assignType(env, r).asBigInt
+      if (l1.tpe != SGroupElement || r1.tpe != SBigInt)
+        error(s"Invalid binary operation Exponentiate: expected argument types ($SGroupElement, $SBigInt); actual: (${l.tpe}, ${r.tpe})")
+      Exponentiate(l1, r1)
+
+    case ByIndex(col, i) =>
+      val c1 = assignType(env, col).asCollection[SType]
+      if (!c1.tpe.isCollection)
+        error(s"Invalid operation ByIndex: expected argument types ($SCollection); actual: (${col.tpe})")
+      ByIndex(c1, i)
+
+    case SizeOf(col) =>
+      val c1 = assignType(env, col).asCollection[SType]
+      if (!c1.tpe.isCollection)
+        error(s"Invalid operation SizeOf: expected argument types ($SCollection); actual: (${col.tpe})")
+      SizeOf(c1)
     
     case Height => Height
     case Self => Self
@@ -361,15 +205,31 @@ class SigmaTyper(globalEnv: Map[String, Any], tree : SigmaTree) extends Attribut
     case v => error(s"Don't know how to assignType($v)")
   }
 
-  def bimap[T <: SType](env: Map[String, SType], l: Value[T], r: Value[T])(f: (Value[T], Value[T]) => SValue): SValue = {
-    f(assignType(env, l).asValue[T], assignType(env, r).asValue[T])
+  def bimap[T <: SType]
+      (env: Map[String, SType], op: String, l: Value[T], r: Value[T])
+      (f: (Value[T], Value[T]) => SValue)
+      (tArg: SType, tRes: SType): SValue = {
+    val l1 = assignType(env, l).asValue[T]
+    val r1 = assignType(env, r).asValue[T]
+    if ((l1.tpe == tArg) && (r1.tpe == tArg))
+      f(l1, r1)
+    else
+      error(s"Invalid binary operation $op: expected argument types ($tArg, $tArg); actual: (${l1.tpe }, ${r1.tpe })")
+  }
+
+  def bimap2[T <: SType]
+      (env: Map[String, SType], op: String, l: Value[T], r: Value[T])
+          (f: (Value[T], Value[T]) => SValue)
+          (check: (SType, SType) => Boolean): SValue = {
+    val l1 = assignType(env, l).asValue[T]
+    val r1 = assignType(env, r).asValue[T]
+    if (check(l1.tpe, r1.tpe))
+      f(l1, r1)
+    else
+      error(s"Invalid binary operation $op ($l1, $r1)")
   }
 
   def typecheck(bound: SValue): SValue = {
-    Apply(ByIndex(ConcreteCollection(Vector(IntConstant(0))),0),Vector(IntConstant(0)))
-//    val t = tipe(bound)
-//    if (t == NoType) error(s"No type can be assigned to expression $bound")
-//    if(errors.nonEmpty) error(s"Errors found while typing expression $bound:\n${errors.mkString("\n")}\n")
     val assigned = assignType(SigmaPredef.predefinedEnv.mapValues(_.tpe), bound)
     if (assigned.tpe == NoType) error(s"No type can be assigned to expression $assigned")
 

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -67,18 +67,12 @@ object Terms {
     }
   }
 
-//  case class ApplyGen(func: Value[SType], args: IndexedSeq[Value[SType]]) extends Value[SType] {
-//    override def cost: Int = ???
-//    override def evaluated: Boolean = false
-//    lazy val tpe: SType = func.tpe match {
-//      case SFunc(_, r) => SigmaTyper.applySubst(r, tpeArgs)
-//      case tCol: SCollection[_] => SigmaTyper.applySubst(tCol.elemType, tpeArgs)
-//      case _ => NoType
-//    }
-//  }
-//  object Apply {
-//    def apply(func: Value[SType], args: IndexedSeq[Value[SType]]): Apply = Apply(func, args, SigmaTyper.emptySubst)
-//  }
+  /** Apply types for type parameters of input value. */
+  case class ApplyTypes(input: Value[SType], tpeArgs: STypeSubst) extends Value[SType] {
+    override def cost: Int = ???
+    override def evaluated: Boolean = false
+    lazy val tpe: SType = SigmaTyper.applySubst(input.tpe, tpeArgs)
+  }
 
   case class MethodCall(obj: Value[SType], name: String, args: IndexedSeq[Value[SType]], tpe: SType = NoType) extends Value[SType] {
     override def cost: Int = ???

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -25,29 +25,29 @@ object Terms {
     def apply(name: String, value: SValue): Let = Let(name, NoType, value)
   }
 
-  case class Select(obj: Value[SType], field: String) extends Value[SType] {
+  case class Select(obj: Value[SType], field: String, resType: Option[SType] = None) extends Value[SType] {
     override def cost: Int = ???
     override def evaluated: Boolean = ???
-    val tpe: SType = obj.tpe match {
+    val tpe: SType = resType.getOrElse(obj.tpe match {
       case p: SProduct =>
         val i = p.fieldIndex(field)
         if (i == -1) NoType
         else p.fields(i)._2
       case _ => NoType
-    }
+    })
   }
 
-  case class SelectGen(obj: Value[SType], field: String, tpe: SType) extends Value[SType] {
-    override def cost: Int = ???
-    override def evaluated: Boolean = ???
-//    val tpe: SType = obj.tpe match {
-//      case p: SProduct =>
-//        val i = p.fieldIndex(field)
-//        if (i == -1) NoType
-//        else SigmaTyper.applySubst(p.fields(i)._2, tpeArgs)
-//      case _ => NoType
-//    }
-  }
+//  case class SelectGen(obj: Value[SType], field: String, tpe: SType) extends Value[SType] {
+//    override def cost: Int = ???
+//    override def evaluated: Boolean = ???
+////    val tpe: SType = obj.tpe match {
+////      case p: SProduct =>
+////        val i = p.fieldIndex(field)
+////        if (i == -1) NoType
+////        else SigmaTyper.applySubst(p.fields(i)._2, tpeArgs)
+////      case _ => NoType
+////    }
+//  }
 
   case class Ident(name: String, tpe: SType = NoType) extends Value[SType] {
     override def cost: Int = ???
@@ -93,6 +93,8 @@ object Terms {
   implicit class ValueOps(v: Value[SType]) {
     def asValue[T <: SType]: Value[T] = v.asInstanceOf[Value[T]]
     def asBoolValue: Value[SBoolean.type] = v.asInstanceOf[Value[SBoolean.type]]
+    def asIntValue: Value[SInt.type] = v.asInstanceOf[Value[SInt.type]]
+    def asSigmaValue: SigmaBoolean = v.asInstanceOf[SigmaBoolean]
     def asGroupElement: Value[SGroupElement.type] = v.asInstanceOf[Value[SGroupElement.type]]
     def asByteArray: Value[SByteArray.type] = v.asInstanceOf[Value[SByteArray.type]]
     def asBigInt: Value[SBigInt.type] = v.asInstanceOf[Value[SBigInt.type]]

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -1,7 +1,6 @@
 package sigmastate.lang
 
 import sigmastate.Values._
-import sigmastate.lang.SigmaTyper.STypeSubst
 import sigmastate.utils.Overloading.Overload1
 import sigmastate._
 
@@ -36,18 +35,6 @@ object Terms {
       case _ => NoType
     })
   }
-
-//  case class SelectGen(obj: Value[SType], field: String, tpe: SType) extends Value[SType] {
-//    override def cost: Int = ???
-//    override def evaluated: Boolean = ???
-////    val tpe: SType = obj.tpe match {
-////      case p: SProduct =>
-////        val i = p.fieldIndex(field)
-////        if (i == -1) NoType
-////        else SigmaTyper.applySubst(p.fields(i)._2, tpeArgs)
-////      case _ => NoType
-////    }
-//  }
 
   case class Ident(name: String, tpe: SType = NoType) extends Value[SType] {
     override def cost: Int = ???

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -61,17 +61,22 @@ object Terms {
     override def cost: Int = ???
     override def evaluated: Boolean = false
     lazy val tpe: SType = func.tpe match {
-      case SFunc(_, r) => r
+      case SFunc(_, r, _) => r
       case tCol: SCollection[_] => tCol.elemType
       case _ => NoType
     }
   }
 
   /** Apply types for type parameters of input value. */
-  case class ApplyTypes(input: Value[SType], tpeArgs: STypeSubst) extends Value[SType] {
+  case class ApplyTypes(input: Value[SType], tpeArgs: Seq[SType]) extends Value[SType] {
     override def cost: Int = ???
     override def evaluated: Boolean = false
-    lazy val tpe: SType = SigmaTyper.applySubst(input.tpe, tpeArgs)
+    lazy val tpe: SType = input.tpe match {
+      case funcType: SFunc =>
+        val subst = funcType.tpeArgs.zip(tpeArgs).toMap
+        SigmaTyper.applySubst(input.tpe, subst)
+      case _ => input.tpe
+    }
   }
 
   case class MethodCall(obj: Value[SType], name: String, args: IndexedSeq[Value[SType]], tpe: SType = NoType) extends Value[SType] {

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -100,6 +100,7 @@ object Terms {
     def asBoolValue: Value[SBoolean.type] = v.asInstanceOf[Value[SBoolean.type]]
     def asIntValue: Value[SInt.type] = v.asInstanceOf[Value[SInt.type]]
     def asSigmaValue: SigmaBoolean = v.asInstanceOf[SigmaBoolean]
+    def asBox: Value[SBox.type] = v.asInstanceOf[Value[SBox.type]]
     def asGroupElement: Value[SGroupElement.type] = v.asInstanceOf[Value[SGroupElement.type]]
     def asByteArray: Value[SByteArray.type] = v.asInstanceOf[Value[SByteArray.type]]
     def asBigInt: Value[SBigInt.type] = v.asInstanceOf[Value[SBigInt.type]]

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -108,7 +108,7 @@ trait Core extends syntax.Literals {
 //    val ThisSuper = P( `this` | `super` ~ ClassQualifier.? )
 //    val ThisPath: P0 = P( ThisSuper ~ ("." ~ PostDotCheck ~/ Id).rep )
     val IdPath = P( Id.! ~ ("." ~ PostDotCheck ~/ (`this`.! | Id.!)).rep /*~ ("." ~ ThisPath).?*/ ).map {
-      case (h, t) => t.foldLeft[SValue](Ident(h))(Select)
+      case (h, t) => t.foldLeft[SValue](Ident(h))(Select(_, _))
     }
     P( /*ThisPath |*/ IdPath )
   }

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -126,8 +126,8 @@ trait Exprs extends Core with Types {
   }
 
   def mkApplyTypes(input: Value[SType], targs: IndexedSeq[SType]): Value[SType] = {
-    val subst = targs.zipWithIndex.map { case (t, i) => (STypeIdent(s"_${i + 1}") -> t) }.toMap
-    ApplyTypes(input, subst)
+//    val subst = targs.zipWithIndex.map { case (t, i) => (STypeIdent(s"_${i + 1}") -> t) }.toMap
+    ApplyTypes(input, targs)
   }
 
   /** The precedence of an infix operator is determined by the operator's first character.

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -58,6 +58,7 @@ object SType {
         val okRange = f1.tRange.canBeTypedAs(f2.tRange)
         okDom && okRange
     }
+    def asFunc: SFunc = tpe.asInstanceOf[SFunc]
   }
 
   def typeOfData(x: Any): SType = x match {
@@ -149,6 +150,10 @@ case object SGroupElement extends SProduct {
 case object SBox extends SProduct {
   override type WrappedType = ErgoBox
   override val typeCode: TypeCode = 7: Byte
+  private val tT = STypeIdent("T")
+  def registers(): Seq[(String, SType)] = {
+    (1 to 10).map(i => s"R$i" -> SFunc(IndexedSeq(), SOption(tT), Seq(tT)))
+  }
   val PropositionBytes = "propositionBytes"
   val Value = "value"
   val Id = "id"
@@ -158,7 +163,7 @@ case object SBox extends SProduct {
     PropositionBytes -> SByteArray,  // see ExtractScriptBytes
     Bytes -> SByteArray,             // see ExtractBytes
     Id -> SByteArray                 // see ExtractId
-  )
+  ) ++ registers()
 }
 
 /** The type with single inhabitant value `()` */
@@ -194,19 +199,46 @@ object SCollection {
   private val tOV = STypeIdent("OV")
   val fields = Seq(
     "size" -> SInt,
-    "map" -> SFunc(SFunc(tIV, tOV), SCollection(tOV)),
-    "exists" -> SFunc(SFunc(tIV, SBoolean), SBoolean),
-    "fold" -> SFunc(IndexedSeq(tIV, SFunc(IndexedSeq(tIV, tIV), tIV)), tIV),
-    "forall" -> SFunc(SFunc(tIV, SBoolean), SBoolean)
+    "map" -> SFunc(IndexedSeq(SFunc(tIV, tOV)), SCollection(tOV), Seq(tIV, tOV)),
+    "exists" -> SFunc(IndexedSeq(SFunc(tIV, SBoolean)), SBoolean, Seq(tIV)),
+    "fold" -> SFunc(IndexedSeq(tIV, SFunc(IndexedSeq(tIV, tIV), tIV)), tIV, Seq(tIV)),
+    "forall" -> SFunc(IndexedSeq(SFunc(tIV, SBoolean)), SBoolean, Seq(tIV))
   )
   def apply[T <: SType](implicit elemType: T, ov: Overload1): SCollection[T] = SCollection(elemType)
   def unapply[T <: SType](tCol: SCollection[T]): Option[T] = Some(tCol.elemType)
 }
 
-case class SFunc(tDom: IndexedSeq[SType],  tRange: SType) extends SType {
+case class SOption[ElemType <: SType](elemType: ElemType) extends SProduct {
+  override type WrappedType = Option[Value[ElemType]]
+  override val typeCode: TypeCode = SOption.TypeCode
+  override def fields = SOption.fields
+
+  override def equals(obj: scala.Any) = obj match {
+    case that: SOption[_] => that.elemType == elemType
+    case _ => false
+  }
+  override def hashCode() = (31 + typeCode) * 31 + elemType.hashCode()
+  override def toString = s"Option[$elemType]"
+}
+
+object SOption {
+  val TypeCode: TypeCode = 81: Byte
+  private val tT = STypeIdent("T")
+  val fields = Seq(
+    "isDefined" -> SBoolean,
+    "value" -> tT
+  )
+  def apply[T <: SType](implicit elemType: T, ov: Overload1): SOption[T] = SOption(elemType)
+  def unapply[T <: SType](tOpt: SOption[T]): Option[T] = Some(tOpt.elemType)
+}
+
+case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeArgs: Seq[STypeIdent] = Nil) extends SType {
   override type WrappedType = Seq[Any] => tRange.WrappedType
   override val typeCode = SFunc.TypeCode
-  override def toString = s"(${tDom.mkString(",")}) => $tRange"
+  override def toString = {
+    val args = if (tpeArgs.isEmpty) "" else tpeArgs.mkString("[", ",", "]")
+    s"$args(${tDom.mkString(",")}) => $tRange"
+  }
 }
 
 object SFunc {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1,11 +1,13 @@
 package sigmastate
 
 import java.math.BigInteger
+
 import sigmastate.SType.TypeCode
 import sigmastate.interpreter.GroupSettings
 import sigmastate.utils.Overloading.Overload1
 import sigmastate.utxo.ErgoBox
 import sigmastate.Values._
+import sigmastate.lang.SigmaTyper
 
 import scala.collection.mutable
 
@@ -211,7 +213,10 @@ object SCollection {
 case class SOption[ElemType <: SType](elemType: ElemType) extends SProduct {
   override type WrappedType = Option[Value[ElemType]]
   override val typeCode: TypeCode = SOption.TypeCode
-  override def fields = SOption.fields
+  override lazy val fields = {
+    val subst = Map(SOption.tT -> elemType)
+    SOption.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
+  }
 
   override def equals(obj: scala.Any) = obj match {
     case that: SOption[_] => that.elemType == elemType
@@ -224,7 +229,7 @@ case class SOption[ElemType <: SType](elemType: ElemType) extends SProduct {
 object SOption {
   val TypeCode: TypeCode = 81: Byte
   private val tT = STypeIdent("T")
-  val fields = Seq(
+  val fields: Seq[(String, SType)] = Seq(
     "isDefined" -> SBoolean,
     "value" -> tT
   )

--- a/src/main/scala/sigmastate/utxo/ErgoTransaction.scala
+++ b/src/main/scala/sigmastate/utxo/ErgoTransaction.scala
@@ -100,6 +100,8 @@ object ErgoBox {
   object R7 extends RegisterIdentifier with NonMandatoryIdentifier {override val number = 7}
   object R8 extends RegisterIdentifier with NonMandatoryIdentifier {override val number = 8}
   object R9 extends RegisterIdentifier with NonMandatoryIdentifier {override val number = 9}
+  val allRegisters = Vector(R0, R1, R2, R3, R4, R5, R6, R7, R8, R9)
+  val registerByName = allRegisters.map(r => (s"R${r.number}" -> r)).toMap
 }
 
 case class ErgoTransaction(inputs: IndexedSeq[ErgoBox], outputs: IndexedSeq[ErgoBox]) {

--- a/src/main/scala/sigmastate/values.scala
+++ b/src/main/scala/sigmastate/values.scala
@@ -2,7 +2,6 @@ package sigmastate
 
 import java.math.BigInteger
 import java.util
-
 import org.bitbucket.inkytonik.kiama.relation.Tree
 import org.bitbucket.inkytonik.kiama.rewriting.Rewritable
 import scorex.crypto.authds.SerializedAdProof
@@ -14,7 +13,6 @@ import sigmastate.serialization.ValueSerializer.OpCode
 import sigmastate.utils.Overloading.Overload1
 import sigmastate.utxo.ErgoBox
 import sigmastate.utxo.CostTable.Cost
-
 import scala.collection.immutable
 
 object Values {
@@ -120,8 +118,6 @@ object Values {
 
     override def hashCode(): Int = util.Arrays.hashCode(value)
   }
-
-//  object EmptyByteArray extends ByteArrayConstant(Array.emptyByteArray)
 
   trait NotReadyValueByteArray extends NotReadyValue[SByteArray.type] {
     override lazy val cost: Int = Cost.ByteArrayDeclaration

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -136,15 +136,15 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("type parameters") {
-    bind(env, "X[Int]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt))
-    bind(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
-    bind(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
-    bind(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
-    bind(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt))
-    bind(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
-    bind(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
-    bind(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt))
-    bind(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+    bind(env, "X[Int]") shouldBe ApplyTypes(Ident("X"), Seq(SInt))
+    bind(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Seq(SInt)), "isDefined")
+    bind(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Seq(STuple(SInt, SBoolean)))
+    bind(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Seq(SInt, SBoolean))
+    bind(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Seq(SInt))
+    bind(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Seq(SInt)),"isDefined")
+    bind(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Seq(SInt)), IndexedSeq(IntConstant(10)))
+    bind(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Seq(SInt))
+    bind(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Seq(SInt)), IndexedSeq(IntConstant(10)))
   }
 
 }

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -1,7 +1,5 @@
 package sigmastate.lang
 
-import java.math.BigInteger
-
 import org.scalatest.{PropSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import sigmastate._
@@ -12,15 +10,9 @@ import sigmastate.utxo._
 class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with LangTests {
 
   def bind(env: Map[String, Any], x: String): SValue = {
-    try {
-      val ast = SigmaParser(x).get.value
-      val binder = new SigmaBinder(env)
-      binder.bind(ast)
-    } catch {
-      case e: Exception =>
-//        SigmaParser.logged.foreach(println)
-        throw e
-    }
+    val ast = SigmaParser(x).get.value
+    val binder = new SigmaBinder(env)
+    binder.bind(ast)
   }
 
   property("simple expressions") {
@@ -29,7 +21,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "c1 && c2") shouldBe AND(TrueLeaf, FalseLeaf)
     bind(env, "arr1") shouldBe ByteArrayConstant(Array(1, 2))
     bind(env, "HEIGHT + 1") shouldBe Plus(Height, 1)
-    bind(env, "INPUTS.size > 1") shouldBe GT(SizeOf(Inputs), 1)
+    bind(env, "INPUTS.size > 1") shouldBe GT(Select(Inputs, "size").asIntValue, 1)
     bind(env, "arr1 | arr2") shouldBe Xor(Array[Byte](1, 2), Array[Byte](10,20))
     bind(env, "arr1 ++ arr2") shouldBe AppendBytes(Array[Byte](1, 2), Array[Byte](10,20))
     bind(env, "g1 ^ n") shouldBe Exponentiate(g1, n)

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -142,4 +142,17 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "fun (box: Box): ByteArray = box.bytes") shouldBe Lambda(IndexedSeq("box" -> SBox), SByteArray, Select(Ident("box"), "bytes"))
     bind(env, "fun (box: Box): ByteArray = box.id") shouldBe Lambda(IndexedSeq("box" -> SBox), SByteArray, Select(Ident("box"), "id"))
   }
+
+  property("type parameters") {
+    bind(env, "X[Int]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt))
+    bind(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
+    bind(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
+    bind(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
+    bind(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt))
+    bind(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
+    bind(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+    bind(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt))
+    bind(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+  }
+
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -256,4 +256,16 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("fun (box: Box): ByteArray = box.id") shouldBe Lambda(IndexedSeq("box" -> SBox), SByteArray, Select(Ident("box"), "id"))
   }
 
+  property("type parameters") {
+    parse("X[Int]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt))
+    parse("X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
+    parse("X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
+    parse("X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
+    parse("SELF.R1[Int]") shouldBe ApplyTypes(Select(Ident("SELF"), "R1"), Map(STypeIdent("_1") -> SInt))
+    parse("SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Ident("SELF"), "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
+    parse("f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+    parse("INPUTS.map[Int]") shouldBe ApplyTypes(Select(Ident("INPUTS"), "map"), Map(STypeIdent("_1") -> SInt))
+    parse("INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Ident("INPUTS"), "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+  }
+
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -257,15 +257,15 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("type parameters") {
-    parse("X[Int]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt))
-    parse("X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
-    parse("X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
-    parse("X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
-    parse("SELF.R1[Int]") shouldBe ApplyTypes(Select(Ident("SELF"), "R1"), Map(STypeIdent("_1") -> SInt))
-    parse("SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Ident("SELF"), "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
-    parse("f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
-    parse("INPUTS.map[Int]") shouldBe ApplyTypes(Select(Ident("INPUTS"), "map"), Map(STypeIdent("_1") -> SInt))
-    parse("INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Ident("INPUTS"), "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+    parse("X[Int]") shouldBe ApplyTypes(Ident("X"), Seq(SInt))
+    parse("X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Seq(SInt)), "isDefined")
+    parse("X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Seq(STuple(SInt, SBoolean)))
+    parse("X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Seq(SInt, SBoolean))
+    parse("SELF.R1[Int]") shouldBe ApplyTypes(Select(Ident("SELF"), "R1"), Seq(SInt))
+    parse("SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Ident("SELF"), "R1"), Seq(SInt)),"isDefined")
+    parse("f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Seq(SInt)), IndexedSeq(IntConstant(10)))
+    parse("INPUTS.map[Int]") shouldBe ApplyTypes(Select(Ident("INPUTS"), "map"), Seq(SInt))
+    parse("INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Ident("INPUTS"), "map"), Seq(SInt)), IndexedSeq(IntConstant(10)))
   }
 
 }

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -13,7 +13,7 @@ class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers wi
     val parsed = SigmaParser(x).get.value
     val binder = new SigmaBinder(env)
     val bound = binder.bind(parsed)
-    val typer = new SigmaTyper(env, new SigmaTree(bound))
+    val typer = new SigmaTyper
     val typed = typer.typecheck(bound)
     typed
   }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -16,7 +16,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
       val binder = new SigmaBinder(env)
       val bound = binder.bind(parsed)
       val st = new SigmaTree(bound)
-      val typer = new SigmaTyper(env, st)
+      val typer = new SigmaTyper
       val typed = typer.typecheck(bound)
      typed.tpe
     } catch {
@@ -30,7 +30,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
       val binder = new SigmaBinder(env)
       val bound = binder.bind(parsed)
       val st = new SigmaTree(bound)
-      val typer = new SigmaTyper(env, st)
+      val typer = new SigmaTyper
       val typed = typer.typecheck(bound)
       assert(false, s"Should not typecheck: $x")
     } catch {
@@ -144,7 +144,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "fun (p: (Int, GroupElement), box: Box): Boolean = p._1 > box.value && p._2.isIdentity") shouldBe
       SFunc(IndexedSeq(STuple(SInt, SGroupElement), SBox), SBoolean)
 
-    typefail(env, "fun (a) = a + 1", "Errors found")
+    typefail(env, "fun (a) = a + 1", "undefined type of argument")
   }
 
   property("function definitions") {

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -6,7 +6,7 @@ import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.Terms._
 import sigmastate.lang.SigmaPredef._
-import sigmastate.utxo.Outputs
+import sigmastate.utxo.{Outputs, Self, Inputs}
 
 class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with LangTests {
 
@@ -30,14 +30,15 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
       val binder = new SigmaBinder(env)
       val bound = binder.bind(parsed)
       val st = new SigmaTree(bound)
-      val an = new SigmaTyper(env, st)
-      an.tipe(bound)
-      an.errors shouldBe empty
+      val typer = new SigmaTyper(env, st)
+      val typed = typer.typecheck(bound)
       assert(false, s"Should not typecheck: $x")
     } catch {
       case e: TyperException =>
         if (messageSubstr.nonEmpty)
-          assert(e.getMessage.contains(messageSubstr)/*, s"error message '${e.getMessage}' does't contain '${messageSubstr}'"*/)
+          if (!e.getMessage.contains(messageSubstr)) {
+            throw new AssertionError(s"Error message '${e.getMessage}' doesn't contain '$messageSubstr'.", e)
+          }
     }
   }
 
@@ -115,9 +116,9 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("array literals") {
-    typecheck(env, "Array()") shouldBe SCollection(NoType)
-    typecheck(env, "Array(Array())") shouldBe SCollection(SCollection(NoType))
-    typecheck(env, "Array(Array(Array()))") shouldBe SCollection(SCollection(SCollection(NoType)))
+    typefail(env, "Array()", "should have the same type")
+    typefail(env, "Array(Array())", "should have the same type")
+    typefail(env, "Array(Array(Array()))", "should have the same type")
 
     typecheck(env, "Array(1)") shouldBe SCollection(SInt)
     typecheck(env, "Array(1, x)") shouldBe SCollection(SInt)
@@ -128,9 +129,9 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("array indexed access") {
-    typefail(env, "Array()(0)", "undefined element type")
+    typefail(env, "Array()(0)", "should have the same type")
     typecheck(env, "Array(0)(0)") shouldBe SInt
-    typefail(env, "Array(0)(0)(0)", "function/array type is expected")
+    typefail(env, "Array(0)(0)(0)", "array type is expected")
   }
 
   property("lambdas") {
@@ -143,7 +144,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "fun (p: (Int, GroupElement), box: Box): Boolean = p._1 > box.value && p._2.isIdentity") shouldBe
       SFunc(IndexedSeq(STuple(SInt, SGroupElement), SBox), SBoolean)
 
-    typefail(env, "fun (a) = a + 1", "undefined type of argument")
+    typefail(env, "fun (a) = a + 1", "Errors found")
   }
 
   property("function definitions") {
@@ -158,6 +159,18 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "fun (box: Box): ByteArray = box.id") shouldBe SFunc(IndexedSeq(SBox), SByteArray)
   }
 
+  property("type parameters") {
+//    typecheck(env, "X[Int]") shouldBe SInt
+//    typecheck(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
+//    typecheck(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
+//    typecheck(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
+//    typecheck(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt))
+//    typecheck(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
+//    typecheck(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+//    typecheck(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt))
+//    typecheck(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+  }
+  
   property("compute unifying type substitution") {
     import SigmaTyper._
     def check(s1: String, s2: String, exp: Option[STypeSubst] = Some(emptySubst)): Unit = {

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -161,15 +161,13 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("type parameters") {
     typecheck(env, "SELF.R1[Int]") shouldBe SOption(SInt)
-//    typecheck(env, "X[Int]") shouldBe SInt
-//    typecheck(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
-//    typecheck(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))
-//    typecheck(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt, STypeIdent("_2") -> SBoolean))
-//    typecheck(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt))
-//    typecheck(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Map(STypeIdent("_1") -> SInt)),"isDefined")
-//    typecheck(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
-//    typecheck(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt))
-//    typecheck(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Map(STypeIdent("_1") -> SInt)), IndexedSeq(IntConstant(10)))
+    typecheck(env, "SELF.R1[Int].isDefined") shouldBe SBoolean
+    typecheck(env, "SELF.R1[Int].value") shouldBe SInt
+    typefail(env, "X[Int]", "expression doesn't have type parameters")
+    typefail(env, "arr1[Int]", "expression doesn't have type parameters")
+    typecheck(env, "SELF.R1[(Int,Boolean)]") shouldBe SOption(STuple(SInt, SBoolean))
+    typecheck(env, "SELF.R1[(Int,Boolean)].value") shouldBe STuple(SInt, SBoolean)
+    typefail(env, "SELF.R1[Int,Boolean].value", "Wrong number of type arguments")
   }
   
   property("compute unifying type substitution") {

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -160,6 +160,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("type parameters") {
+    typecheck(env, "SELF.R1[Int]") shouldBe SOption(SInt)
 //    typecheck(env, "X[Int]") shouldBe SInt
 //    typecheck(env, "X[Int].isDefined") shouldBe Select(ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> SInt)), "isDefined")
 //    typecheck(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Map(STypeIdent("_1") -> STuple(SInt, SBoolean)))

--- a/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
@@ -1186,7 +1186,10 @@ class UtxoInterpreterSpecification extends PropSpec
 
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = AND(pubkey, EQ(SizeOf(Outputs), Plus(SizeOf(Inputs), IntConstant(1))))
+    val env = Map("pubkey" -> pubkey)
+    val prop = compile(env, """pubkey && OUTPUTS.size == INPUTS.size + 1""").asBoolValue
+    val propTree = AND(pubkey, EQ(SizeOf(Outputs), Plus(SizeOf(Inputs), IntConstant(1))))
+    prop shouldBe propTree
 
     val newBox1 = ErgoBox(11, pubkey)
     val newBox2 = ErgoBox(10, pubkey)
@@ -1274,7 +1277,9 @@ class UtxoInterpreterSpecification extends PropSpec
 
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = ForAll(Outputs, 21, EQ(ExtractAmount(TaggedBox(21)), IntConstant(10)))
+    val prop = compile(Map(), "OUTPUTS.forall(fun (box: Box) = box.value == 10)").asBoolValue
+    val propTree = ForAll(Outputs, 21, EQ(ExtractAmount(TaggedBox(21)), IntConstant(10)))
+    prop shouldBe propTree
 
     val newBox1 = ErgoBox(10, pubkey)
     val newBox2 = ErgoBox(11, pubkey)
@@ -1300,7 +1305,7 @@ class UtxoInterpreterSpecification extends PropSpec
 
 //    val compiledProp = compile(Map(),
 //      """OUTPUTS.exists(fun (box: Box) = {
-//        |  box.R3.get == SELF.R3.get + 1
+//        |  box.R3[Int] == SELF.R3[Int] + 1
 //         })""".stripMargin)
 
     val prop = Exists(Outputs, 21, EQ(ExtractRegisterAs(TaggedBox(21), R3)(SInt),
@@ -1381,7 +1386,7 @@ class UtxoInterpreterSpecification extends PropSpec
     val treeData = new AvlTreeData(digest, 32, None)
 
 //    val env = Map("key" -> key, "proof" -> proof)
-//    val compiledProp = compile(env, """isMember(SELF.R3, key, proof)""")
+//    val compiledProp = compile(env, """isMember(SELF.R3[AvlTree], key, proof)""")
 
     val prop = IsMember(ExtractRegisterAs(Self, R3),
       ByteArrayConstant(key),

--- a/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/UtxoInterpreterSpecification.scala
@@ -35,7 +35,7 @@ class UtxoInterpreterSpecification extends PropSpec
     val binder = new SigmaBinder(env)
     val bound = binder.bind(parsed)
     val st = new SigmaTree(bound)
-    val typer = new SigmaTyper(env, st)
+    val typer = new SigmaTyper
     val typed = typer.typecheck(bound)
     val spec = new SigmaSpecializer
     val ir = spec.specialize(typed)


### PR DESCRIPTION
The following syntax is supported:
```
SELF.R3[Int].value     // access R3 register, cast its value to Int and return it
SELF.R3.isDefined      // check that value of R3  is defined
SELF.R3[Int].isDefined // check that value of R3  is defined and has type Int
```
Note, that Option[T] is introduced at frontend to represent the type of register value
```
SELF.R3: Option[T]   // where T is type variable
SELF.R3[Int]: Option[Int]   
```
However, Option is not supported by `Interpreter`, so all `Option` operations are eliminated by `SigmaSpecializer`
