### PR TITLE
Preliminary support of Some and None constructors of Option values

### DIFF
--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -38,6 +38,7 @@ class SigmaBinder(env: Map[String, Any]) {
           case "LastBlockUtxoRootHash" => Some(LastBlockUtxoRootHash)
           case "EmptyByteArray" => Some(ByteArrayConstant(Array.emptyByteArray))
           case "SELF" => Some(Self)
+          case "None" => Some(NoneValue(NoType))
           case _ => None
         }
       }
@@ -49,11 +50,11 @@ class SigmaBinder(env: Map[String, Any]) {
       Some(ConcreteCollection(args)(tpe))
 
     // Rule: Some(x) -->
-//    case Apply(Ident("Some", _), args) =>
-//      val arg =
-//        if (args.length == 1) args(0)
-//        else error(s"Invalid arguments of Some: expected one argument but found $args")
-//      Some(SomeValue(arg))
+    case Apply(Ident("Some", _), args) =>
+      val arg =
+        if (args.length == 1) args(0)
+        else error(s"Invalid arguments of Some: expected one argument but found $args")
+      Some(SomeValue(arg))
 
     // Rule: col(i) --> ByIndex(col, i)
     case Apply(Typed(obj, tCol: SCollection[_]), Seq(IntConstant(i))) =>

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -48,6 +48,13 @@ class SigmaBinder(env: Map[String, Any]) {
       val tpe = if (args.isEmpty) NoType else args(0).tpe
       Some(ConcreteCollection(args)(tpe))
 
+    // Rule: Some(x) -->
+//    case Apply(Ident("Some", _), args) =>
+//      val arg =
+//        if (args.length == 1) args(0)
+//        else error(s"Invalid arguments of Some: expected one argument but found $args")
+//      Some(SomeValue(arg))
+
     // Rule: col(i) --> ByIndex(col, i)
     case Apply(Typed(obj, tCol: SCollection[_]), Seq(IntConstant(i))) =>
       Some(ByIndex(obj.asValue[SCollection[SType]], i.toInt))

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -112,6 +112,9 @@ class SigmaSpecializer {
       val taggedOp = mkTagged(opArg, tOp, 22)
       val body1 = eval(env ++ Seq(zeroArg -> taggedZero, opArg -> taggedOp), body)
       Some(Fold(col.asValue[SCollection[SType]], taggedZero.id, zero, taggedOp.id, body1)(body1.tpe))
+
+    case opt: OptionValue[_] =>
+      error(s"Option values are not supported: $opt")
   })))(e)
 
   def specialize(typed: SValue): SValue = {

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -298,10 +298,10 @@ object SigmaTyper {
       unifyTypes(e1.elemType, e2.elemType)
     case (e1: SOption[_], e2: SOption[_]) =>
       unifyTypes(e1.elemType, e2.elemType)
-    case (e1: SOption[_], e2: SSome[_]) =>
-      unifyTypes(e1.elemType, e2.elemType)
-    case (e1: SOption[_], e2: SNone[_]) =>
-      unifyTypes(e1.elemType, e2.elemType)
+//    case (e1: SOption[_], e2: SSome[_]) =>
+//      unifyTypes(e1.elemType, e2.elemType)
+//    case (e1: SOption[_], e2: SNone[_]) =>
+//      unifyTypes(e1.elemType, e2.elemType)
     case (e1: STuple, e2: STuple) if e1.items.length == e2.items.length =>
       unifyTypeLists(e1.items, e2.items)
     case (e1: SFunc, e2: SFunc) if e1.tDom.length == e2.tDom.length =>

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -288,13 +288,19 @@ object SigmaTyper {
       None
   }
 
-  /** Finds a substitution of type variables such that applySubst(t1, subst) shouldBe t2 */
+  /** Finds a substitution `subst` of type variables such that unifyTypes(applySubst(t1, subst), t2) shouldBe Some(emptySubst) */
   def unifyTypes(t1: SType, t2: SType): Option[STypeSubst] = (t1, t2) match {
     case (id1 @ STypeIdent(n1), id2 @ STypeIdent(n2)) =>
-      if (n1 == n2) Some(Map(id1 -> t2)) else None
+      if (n1 == n2) Some(emptySubst) else None
     case (id1 @ STypeIdent(n), _) =>
       Some(Map(id1 -> t2))
     case (e1: SCollection[_], e2: SCollection[_]) =>
+      unifyTypes(e1.elemType, e2.elemType)
+    case (e1: SOption[_], e2: SOption[_]) =>
+      unifyTypes(e1.elemType, e2.elemType)
+    case (e1: SOption[_], e2: SSome[_]) =>
+      unifyTypes(e1.elemType, e2.elemType)
+    case (e1: SOption[_], e2: SNone[_]) =>
       unifyTypes(e1.elemType, e2.elemType)
     case (e1: STuple, e2: STuple) if e1.items.length == e2.items.length =>
       unifyTypeLists(e1.items, e2.items)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -142,7 +142,7 @@ class SigmaTyper {
     case app @ ApplyTypes(sel: Select, targs) =>
       val newSel @ Select(obj, n, _) = assignType(env, sel)
       newSel.tpe match {
-        case genFunTpe @ SFunc(argTypes, tRes, tyVars) =>
+        case genFunTpe @ SFunc(_, _, tyVars) =>
           if (tyVars.length != targs.length)
             error(s"Wrong number of type arguments $app: expected $tyVars but provided $targs")
           val subst = tyVars.zip(targs).toMap
@@ -268,6 +268,8 @@ object SigmaTyper {
   type STypeSubst = Map[STypeIdent, SType]
   val emptySubst = Map.empty[STypeIdent, SType]
 
+  /** Performs pairwise type unification making sure each type variable is equally
+    * substituted in all items. */
   def unifyTypeLists(items1: Seq[SType], items2: Seq[SType]): Option[STypeSubst] = {
     // unify items pairwise independently
     val itemsUni = (items1, items2).zipped.map((t1, t2) => unifyTypes(t1,t2))
@@ -286,6 +288,7 @@ object SigmaTyper {
       None
   }
 
+  /** Finds a substitution of type variables such that applySubst(t1, subst) shouldBe t2 */
   def unifyTypes(t1: SType, t2: SType): Option[STypeSubst] = (t1, t2) match {
     case (id1 @ STypeIdent(n1), id2 @ STypeIdent(n2)) =>
       if (n1 == n2) Some(Map(id1 -> t2)) else None

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -90,6 +90,7 @@ trait Types extends Core {
     P( BasicType ~ TypeArgs.rep ).map {
       case (t: STuple, Seq()) => t
       case (STypeApply("Array", IndexedSeq()), Seq(Seq(t))) => SCollection(t)
+      case (STypeApply("Option", IndexedSeq()), Seq(Seq(t))) => SOption(t)
       case (SPrimType(t), Seq()) => t
       case (STypeApply(tn, IndexedSeq()), args) if args.isEmpty => STypeIdent(tn)
       case t => error(s"Unsupported type $t")

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -40,6 +40,8 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
   val TupleCode = 36: Byte
   val AndCode = 37: Byte
   val OrCode = 38: Byte
+  val SomeValueCode = 39: Byte
+  val NoneValueCode = 40: Byte
 
   val table = Seq[ValueSerializer[_ <: Value[SType]]](
     RelationSerializer(GtCode, GT.apply, Seq(Constraints.onlyInt2)),

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -245,48 +245,6 @@ object SOption {
   def unapply[T <: SType](tOpt: SOption[T]): Option[T] = Some(tOpt.elemType)
 }
 
-//case class SSome[ElemType <: SType](elemType: ElemType) extends SProduct {
-//  override type WrappedType = Some[Value[ElemType]]
-//  override val typeCode: TypeCode = SSome.TypeCode
-//
-//  val ancestors = Seq(SOption(elemType))
-//
-//  override lazy val fields = {
-//    val subst = Map(SSome.tT -> elemType)
-//    SSome.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
-//  }
-//  override def toString = s"Some[$elemType]"
-//}
-//
-//object SSome {
-//  val TypeCode: TypeCode = 82: Byte
-//  private val tT = STypeIdent("T")
-//  val fields: Seq[(String, SType)] = SOption.createFields(tT)
-//  def apply[T <: SType](implicit elemType: T, ov: Overload1): SSome[T] = SSome(elemType)
-//  def unapply[T <: SType](tOpt: SSome[T]): Option[T] = Some(tOpt.elemType)
-//}
-//
-//case class SNone[ElemType <: SType](elemType: ElemType) extends SProduct {
-//  override type WrappedType = None.type
-//  override val typeCode: TypeCode = SNone.TypeCode
-//
-//  val ancestors = Seq(SOption(elemType))
-//
-//  override lazy val fields = {
-//    val subst = Map(SNone.tT -> elemType)
-//    SNone.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
-//  }
-//  override def toString = s"None[$elemType]"
-//}
-
-//object SNone {
-//  val TypeCode: TypeCode = 83: Byte
-//  private val tT = STypeIdent("T")
-//  val fields: Seq[(String, SType)] = SOption.createFields(tT)
-//  def apply[T <: SType](implicit elemType: T, ov: Overload1): SNone[T] = SNone(elemType)
-//  def unapply[T <: SType](tOpt: SNone[T]): Option[T] = Some(tOpt.elemType)
-//}
-
 case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeArgs: Seq[STypeIdent] = Nil) extends SType {
   override type WrappedType = Seq[Any] => tRange.WrappedType
   override val typeCode = SFunc.TypeCode

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -245,47 +245,47 @@ object SOption {
   def unapply[T <: SType](tOpt: SOption[T]): Option[T] = Some(tOpt.elemType)
 }
 
-case class SSome[ElemType <: SType](elemType: ElemType) extends SProduct {
-  override type WrappedType = Some[Value[ElemType]]
-  override val typeCode: TypeCode = SSome.TypeCode
+//case class SSome[ElemType <: SType](elemType: ElemType) extends SProduct {
+//  override type WrappedType = Some[Value[ElemType]]
+//  override val typeCode: TypeCode = SSome.TypeCode
+//
+//  val ancestors = Seq(SOption(elemType))
+//
+//  override lazy val fields = {
+//    val subst = Map(SSome.tT -> elemType)
+//    SSome.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
+//  }
+//  override def toString = s"Some[$elemType]"
+//}
+//
+//object SSome {
+//  val TypeCode: TypeCode = 82: Byte
+//  private val tT = STypeIdent("T")
+//  val fields: Seq[(String, SType)] = SOption.createFields(tT)
+//  def apply[T <: SType](implicit elemType: T, ov: Overload1): SSome[T] = SSome(elemType)
+//  def unapply[T <: SType](tOpt: SSome[T]): Option[T] = Some(tOpt.elemType)
+//}
+//
+//case class SNone[ElemType <: SType](elemType: ElemType) extends SProduct {
+//  override type WrappedType = None.type
+//  override val typeCode: TypeCode = SNone.TypeCode
+//
+//  val ancestors = Seq(SOption(elemType))
+//
+//  override lazy val fields = {
+//    val subst = Map(SNone.tT -> elemType)
+//    SNone.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
+//  }
+//  override def toString = s"None[$elemType]"
+//}
 
-  val ancestors = Seq(SOption(elemType))
-
-  override lazy val fields = {
-    val subst = Map(SSome.tT -> elemType)
-    SSome.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
-  }
-  override def toString = s"Some[$elemType]"
-}
-
-object SSome {
-  val TypeCode: TypeCode = 82: Byte
-  private val tT = STypeIdent("T")
-  val fields: Seq[(String, SType)] = SOption.createFields(tT)
-  def apply[T <: SType](implicit elemType: T, ov: Overload1): SSome[T] = SSome(elemType)
-  def unapply[T <: SType](tOpt: SSome[T]): Option[T] = Some(tOpt.elemType)
-}
-
-case class SNone[ElemType <: SType](elemType: ElemType) extends SProduct {
-  override type WrappedType = None.type
-  override val typeCode: TypeCode = SNone.TypeCode
-
-  val ancestors = Seq(SOption(elemType))
-
-  override lazy val fields = {
-    val subst = Map(SNone.tT -> elemType)
-    SNone.fields.map { case (n, t) => (n, SigmaTyper.applySubst(t, subst)) }
-  }
-  override def toString = s"None[$elemType]"
-}
-
-object SNone {
-  val TypeCode: TypeCode = 83: Byte
-  private val tT = STypeIdent("T")
-  val fields: Seq[(String, SType)] = SOption.createFields(tT)
-  def apply[T <: SType](implicit elemType: T, ov: Overload1): SNone[T] = SNone(elemType)
-  def unapply[T <: SType](tOpt: SNone[T]): Option[T] = Some(tOpt.elemType)
-}
+//object SNone {
+//  val TypeCode: TypeCode = 83: Byte
+//  private val tT = STypeIdent("T")
+//  val fields: Seq[(String, SType)] = SOption.createFields(tT)
+//  def apply[T <: SType](implicit elemType: T, ov: Overload1): SNone[T] = SNone(elemType)
+//  def unapply[T <: SType](tOpt: SNone[T]): Option[T] = Some(tOpt.elemType)
+//}
 
 case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeArgs: Seq[STypeIdent] = Nil) extends SType {
   override type WrappedType = Seq[Any] => tRange.WrappedType

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -218,6 +218,8 @@ object SCollection {
   def unapply[T <: SType](tCol: SCollection[T]): Option[T] = Some(tCol.elemType)
 }
 
+/** Type description of optional values. Instances of `Option`
+  *  are either constructed by `Some` or by `None` constructors. */
 case class SOption[ElemType <: SType](elemType: ElemType) extends SProduct {
   override type WrappedType = Option[Value[ElemType]]
   override val typeCode: TypeCode = SOption.TypeCode

--- a/src/main/scala/sigmastate/values.scala
+++ b/src/main/scala/sigmastate/values.scala
@@ -263,14 +263,17 @@ object Values {
     def apply(items: Seq[Value[SType]])(implicit o: Overload1): Tuple = Tuple(items.toIndexedSeq)
   }
 
-  case class SomeValue[T <: SType](x: Value[T]) extends EvaluatedValue[SOption[T]] {
+  trait OptionValue[T <: SType] extends EvaluatedValue[SOption[T]] {
+  }
+
+  case class SomeValue[T <: SType](x: Value[T]) extends OptionValue[T] {
     override val opCode = ValueSerializer.SomeValueCode
     def cost: Int = x.cost + 1
     val tpe = SOption(x.tpe)
     lazy val value = Some(x)
   }
 
-  case class NoneValue[T <: SType](elemType: T) extends EvaluatedValue[SOption[T]] {
+  case class NoneValue[T <: SType](elemType: T) extends OptionValue[T] {
     override val opCode = ValueSerializer.NoneValueCode
     def cost: Int = 1
     val tpe = SOption(elemType)

--- a/src/main/scala/sigmastate/values.scala
+++ b/src/main/scala/sigmastate/values.scala
@@ -263,6 +263,20 @@ object Values {
     def apply(items: Seq[Value[SType]])(implicit o: Overload1): Tuple = Tuple(items.toIndexedSeq)
   }
 
+  case class SomeValue[T <: SType](x: Value[T]) extends EvaluatedValue[SOption[T]] {
+    override val opCode = ValueSerializer.SomeValueCode
+    def cost: Int = x.cost + 1
+    val tpe = SOption(x.tpe)
+    lazy val value = Some(x)
+  }
+
+  case class NoneValue[T <: SType](elemType: T) extends EvaluatedValue[SOption[T]] {
+    override val opCode = ValueSerializer.NoneValueCode
+    def cost: Int = 1
+    val tpe = SOption(elemType)
+    lazy val value = None
+  }
+
   case class ConcreteCollection[V <: SType](value: IndexedSeq[Value[V]])(implicit val tItem: V)
     extends EvaluatedValue[SCollection[V]] with Rewritable {
     override val opCode = ValueSerializer.ConcreteCollectionCode

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -33,26 +33,25 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
         AND(ConcreteCollection(Vector(TrueLeaf, FalseLeaf)))
   }
 
-    property("let constructs") {
-      bind(env, "{let X = 10; X > 2}") shouldBe
-        Block(Let("X", SInt, IntConstant(10)), GT(IntIdent("X"), 2))
-      bind(env, "{let X = 10; X >= X}") shouldBe
-        Block(Let("X", SInt, IntConstant(10)), GE(IntIdent("X"), IntIdent("X")))
-      bind(env, "{let X = 10 + 1; X >= X}") shouldBe
-          Block(Let("X", SInt, Plus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
-      bind(env,
-        """{let X = 10
-         |let Y = 11
-         |X > Y}
-        """.stripMargin) shouldBe Block(
-        Seq(Let("X", SInt, IntConstant(10)), Let("Y", SInt, IntConstant(11))),
-        GT(IntIdent("X"), IntIdent("Y")))
-      bind(env, "{let X = (10, true); X._1 > 2 && X._2}") shouldBe
-          Block(
-            Let("X", STuple(SInt, SBoolean), Tuple(IntConstant(10), TrueLeaf)),
-            AND(GT(Select(IntIdent("X"), "_1").asValue[SInt.type], 2), Select(IntIdent("X"), "_2").asValue[SBoolean.type]))
-    }
-
+  property("let constructs") {
+    bind(env, "{let X = 10; X > 2}") shouldBe
+      Block(Let("X", SInt, IntConstant(10)), GT(IntIdent("X"), 2))
+    bind(env, "{let X = 10; X >= X}") shouldBe
+      Block(Let("X", SInt, IntConstant(10)), GE(IntIdent("X"), IntIdent("X")))
+    bind(env, "{let X = 10 + 1; X >= X}") shouldBe
+        Block(Let("X", SInt, Plus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
+    bind(env,
+      """{let X = 10
+       |let Y = 11
+       |X > Y}
+      """.stripMargin) shouldBe Block(
+      Seq(Let("X", SInt, IntConstant(10)), Let("Y", SInt, IntConstant(11))),
+      GT(IntIdent("X"), IntIdent("Y")))
+    bind(env, "{let X = (10, true); X._1 > 2 && X._2}") shouldBe
+        Block(
+          Let("X", STuple(SInt, SBoolean), Tuple(IntConstant(10), TrueLeaf)),
+          AND(GT(Select(IntIdent("X"), "_1").asValue[SInt.type], 2), Select(IntIdent("X"), "_2").asValue[SBoolean.type]))
+  }
 
   property("predefined Exists with lambda argument") {
     val minToRaise = IntConstant(1000)

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -99,6 +99,15 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
           If(EQ(IntConstant(10), IntConstant(11)), IntConstant(2), IntConstant(3)))
   }
 
+  property("Option constructors") {
+    bind(env, "None") shouldBe NoneValue(NoType)
+    bind(env, "Some(None)") shouldBe SomeValue(NoneValue(NoType))
+    bind(env, "Some(10)") shouldBe SomeValue(IntConstant(10))
+    bind(env, "Some(X)") shouldBe SomeValue(Ident("X"))
+    bind(env, "Some(Some(X + 1))") shouldBe
+      SomeValue(SomeValue(Plus(Ident("X").asValue[SInt.type], IntConstant(1))))
+  }
+
   property("array indexed access") {
     val col =
     bind(env, "Array(1)(0)") shouldBe ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0)

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -194,6 +194,16 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
                   Plus(Ident("X").asValue[SInt.type], IntConstant(1))))))
   }
 
+  property("Option constructors") {
+    parse("None") shouldBe Ident("None")
+    parse("Some(None)") shouldBe Apply(Ident("Some"), IndexedSeq(Ident("None")))
+    parse("Some(10)") shouldBe Apply(Ident("Some"), IndexedSeq(IntConstant(10)))
+    parse("Some(X)") shouldBe Apply(Ident("Some"), IndexedSeq(Ident("X")))
+    parse("Some(Some(X + 1))") shouldBe Apply(Ident("Some"),
+      IndexedSeq(Apply(Ident("Some"), IndexedSeq(
+                  Plus(Ident("X").asValue[SInt.type], IntConstant(1))))))
+  }
+
   property("array indexed access") {
     parse("Array()(0)") shouldBe Apply(Apply(Ident("Array"), IndexedSeq.empty), IndexedSeq(IntConstant(0)))
     parse("Array()(0)(0)") shouldBe Apply(Apply(Apply(Ident("Array"), IndexedSeq.empty), IndexedSeq(IntConstant(0))), IndexedSeq(IntConstant(0)))

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -9,7 +9,7 @@ import sigmastate.lang.Terms.Ident
 
 class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers with LangTests {
 
-  def typed(env: Map[String, Any], x: String): SValue = {
+  def typed(env: Map[String, SValue], x: String): SValue = {
     val parsed = SigmaParser(x).get.value
     val binder = new SigmaBinder(env)
     val bound = binder.bind(parsed)
@@ -23,6 +23,18 @@ class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers wi
   }
   def spec(code: String): SValue = {
     spec(Map(), typed(Map(), code))
+  }
+  def fail(env: Map[String, SValue], code: String, messageSubstr: String = ""): Unit = {
+    try {
+      spec(env, typed(env, code))
+      assert(false, s"Should fail: $code")
+    } catch {
+      case e: SpecializerException =>
+        if (messageSubstr.nonEmpty)
+          if (!e.getMessage.contains(messageSubstr)) {
+            throw new AssertionError(s"Error message '${e.getMessage}' doesn't contain '$messageSubstr'.", e)
+          }
+    }
   }
 
   property("resolve let-bound names and substitute") {
@@ -41,5 +53,14 @@ class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers wi
     spec("{ let X = 10; let Y = X; let Z = Y; Z }") shouldBe IntConstant(10)
     spec("{ let X = 10; let Y = X + 1; let Z = Y + X; Z + Y + X }") shouldBe
       Plus(Plus(/*Z=*/Plus(/*Y=*/Plus(10, 1), 10), /*Y=*/Plus(10, 1)), 10)
+  }
+
+  property("Option constructors") {
+    fail(Map(), "None", "Option values are not supported")
+    fail(Map(), "Some(10)", "Option values are not supported")
+    //    bind(env, "Some(None)") shouldBe SomeValue(NoneValue(NoType))
+//    bind(env, "Some(X)") shouldBe SomeValue(Ident("X"))
+//    bind(env, "Some(Some(X + 1))") shouldBe
+//        SomeValue(SomeValue(Plus(Ident("X").asValue[SInt.type], IntConstant(1))))
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.{PropSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.lang.SigmaPredef._
 import sigmastate.lang.Terms.Ident
 
 class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers with LangTests {
@@ -58,9 +57,5 @@ class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers wi
   property("Option constructors") {
     fail(Map(), "None", "Option values are not supported")
     fail(Map(), "Some(10)", "Option values are not supported")
-    //    bind(env, "Some(None)") shouldBe SomeValue(NoneValue(NoType))
-//    bind(env, "Some(X)") shouldBe SomeValue(Ident("X"))
-//    bind(env, "Some(Some(X + 1))") shouldBe
-//        SomeValue(SomeValue(Plus(Ident("X").asValue[SInt.type], IntConstant(1))))
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -128,6 +128,13 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typefail(env, "Array(1, false)")
   }
 
+  property("Option constructors") {
+    typecheck(env, "Some(10)") shouldBe SOption(SInt)
+    typecheck(env, "Some(x)") shouldBe SOption(SInt)
+    typecheck(env, "Some(x + 1)") shouldBe SOption(SInt)
+    typecheck(env, "Some(Some(10))") shouldBe SOption(SOption(SInt))
+  }
+
   property("array indexed access") {
     typefail(env, "Array()(0)", "should have the same type")
     typecheck(env, "Array(0)(0)") shouldBe SInt
@@ -237,10 +244,10 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     check("Array[Array[A]]", "Array[Array[B]]", None)
 
     // NOTE: types SNone and SSome are only exist in IR but cannot be used in concrete syntax
-    checkTypes(SOption(SInt), SNone(SInt), Some(emptySubst))
-    checkTypes(SOption(SOption(SInt)), SOption(SNone(SInt)), Some(emptySubst))
-    checkTypes(SOption(SInt), SSome(SInt), Some(emptySubst))
-    checkTypes(SOption(SOption(SInt)), SOption(SSome(SInt)), Some(emptySubst))
+//    checkTypes(SOption(SInt), SNone(SInt), Some(emptySubst))
+//    checkTypes(SOption(SOption(SInt)), SOption(SNone(SInt)), Some(emptySubst))
+//    checkTypes(SOption(SInt), SSome(SInt), Some(emptySubst))
+//    checkTypes(SOption(SOption(SInt)), SOption(SSome(SInt)), Some(emptySubst))
 
     unify("A", "Option[Boolean]", ("A", ty("Option[Boolean]")))
     unify("Option[A]", "Option[Int]", ("A", SInt))

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -172,14 +172,17 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   
   property("compute unifying type substitution") {
     import SigmaTyper._
-    def check(s1: String, s2: String, exp: Option[STypeSubst] = Some(emptySubst)): Unit = {
-      val t1 = ty(s1); val t2 = ty(s2)
+    def checkTypes(t1: SType, t2: SType, exp: Option[STypeSubst]): Unit = {
       unifyTypes(t1, t2) shouldBe exp
       exp match {
         case Some(subst) =>
-          applySubst(t1, subst) shouldBe t2
+          unifyTypes(applySubst(t1, subst), t2) shouldBe Some(emptySubst)
         case None =>
       }
+    }
+    def check(s1: String, s2: String, exp: Option[STypeSubst] = Some(emptySubst)): Unit = {
+      val t1 = ty(s1); val t2 = ty(s2)
+      checkTypes(t1, t2, exp)
     }
     def unify(s1: String, s2: String, subst: (STypeIdent, SType)*): Unit =
       check(s1, s2, Some(subst.toMap))
@@ -201,19 +204,25 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     check("Array[(Int,Box)]", "Array[Int]", None)
     check("Array[(Int,Box)]", "Array[(Int,Box)]")
     check("Array[Array[Int]]", "Array[Array[Int]]")
+    
+    check("Option[Int]", "Option[Boolean]", None)
+    check("Option[Int]", "Option[Int]")
+    check("Option[(Int,Box)]", "Option[Int]", None)
+    check("Option[(Int,Box)]", "Option[(Int,Box)]")
+    check("Option[Option[Int]]", "Option[Option[Int]]")
 
     check("Int => Int", "Int => Boolean", None)
     check("Int => Int", "Int => Int")
     check("(Int, Boolean) => Int", "Int => Int", None)
     check("(Int, Boolean) => Int", "(Int,Boolean) => Int")
 
-    unify("A", "A", ("A", STypeIdent("A")))
+    unify("A", "A")
     check("A", "B", None)
 
     check("(Int, A)", "Int", None)
-    unify("(Int, A)", "(Int, A)", ("A", STypeIdent("A")))
+    unify("(Int, A)", "(Int, A)")
     unify("(Int, A)", "(Int, Int)", ("A", SInt))
-    unify("(A, B)", "(A, B)", ("A", STypeIdent("A")), ("B", STypeIdent("B")))
+    unify("(A, B)", "(A, B)")
     unify("(A, B)", "(Int, Boolean)", ("A", SInt), ("B", SBoolean))
     check("(A, B)", "(Int, Boolean, Box)", None)
     check("(A, Boolean)", "(Int, B)", None)
@@ -224,8 +233,22 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     unify("Array[A]", "Array[(Int, Box)]", ("A", ty("(Int, Box)")))
     unify("Array[(Int, A)]", "Array[(Int, Box)]", ("A", SBox))
     unify("Array[Array[A]]", "Array[Array[Int]]", ("A", SInt))
-    unify("Array[Array[A]]", "Array[Array[A]]", ("A", STypeIdent("A")))
+    unify("Array[Array[A]]", "Array[Array[A]]")
     check("Array[Array[A]]", "Array[Array[B]]", None)
+
+    // NOTE: types SNone and SSome are only exist in IR but cannot be used in concrete syntax
+    checkTypes(SOption(SInt), SNone(SInt), Some(emptySubst))
+    checkTypes(SOption(SOption(SInt)), SOption(SNone(SInt)), Some(emptySubst))
+    checkTypes(SOption(SInt), SSome(SInt), Some(emptySubst))
+    checkTypes(SOption(SOption(SInt)), SOption(SSome(SInt)), Some(emptySubst))
+
+    unify("A", "Option[Boolean]", ("A", ty("Option[Boolean]")))
+    unify("Option[A]", "Option[Int]", ("A", SInt))
+    unify("Option[A]", "Option[(Int, Box)]", ("A", ty("(Int, Box)")))
+    unify("Option[(Int, A)]", "Option[(Int, Box)]", ("A", SBox))
+    unify("Option[Option[A]]", "Option[Option[Int]]", ("A", SInt))
+    unify("Option[Option[A]]", "Option[Option[A]]")
+    check("Option[Option[A]]", "Option[Option[B]]", None)
 
     unify("A => Int", "Int => Int", ("A", SInt))
     check("A => Int", "Int => Boolean", None)
@@ -238,7 +261,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     unify(
       "((A,Int), Array[B] => Array[(Array[C], B)]) => A",
       "((Int,Int), Array[Boolean] => Array[(Array[C], Boolean)]) => Int",
-      ("A", SInt), ("B", SBoolean), ("C", ty("C")))
+      ("A", SInt), ("B", SBoolean))
   }
 
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -243,12 +243,6 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     unify("Array[Array[A]]", "Array[Array[A]]")
     check("Array[Array[A]]", "Array[Array[B]]", None)
 
-    // NOTE: types SNone and SSome are only exist in IR but cannot be used in concrete syntax
-//    checkTypes(SOption(SInt), SNone(SInt), Some(emptySubst))
-//    checkTypes(SOption(SOption(SInt)), SOption(SNone(SInt)), Some(emptySubst))
-//    checkTypes(SOption(SInt), SSome(SInt), Some(emptySubst))
-//    checkTypes(SOption(SOption(SInt)), SOption(SSome(SInt)), Some(emptySubst))
-
     unify("A", "Option[Boolean]", ("A", ty("Option[Boolean]")))
     unify("Option[A]", "Option[Int]", ("A", SInt))
     unify("Option[A]", "Option[(Int, Box)]", ("A", ty("(Int, Box)")))


### PR DESCRIPTION
This constructors are implemented throughout all frontend phases up to Specializer.
Currently Speciaizer throws exception when encounter OptionValue node with message "Option values are not supported".
This can be removed after Option is supported in the interpreter.
