### PR TITLE
Fix code inspection issues in particular #74

### DIFF
--- a/src/main/scala/scapi/sigma/BcDlogFp.scala
+++ b/src/main/scala/scapi/sigma/BcDlogFp.scala
@@ -438,7 +438,7 @@ abstract class BcDlogFp[ElemType <: ECPoint](val x9params: X9ECParameters) exten
     * encoding a binary string of length in bytes up to k.
     * This is because the encoding-decoding functionality is not a bijection, that is, it is a 1-1 function
     * but is not onto. Therefore, any string of length in bytes up to k can be encoded to a group element but not any
-    * group element can be decoded to a binary sting in the group of binary strings of length up to 2^k.
+    * group element can be decoded to a binary sting in the group of binary strings of length up to `2^k`.
     *
     *
     * @param point the element to convert
@@ -450,7 +450,7 @@ abstract class BcDlogFp[ElemType <: ECPoint](val x9params: X9ECParameters) exten
 
     val b2 = new Array[Byte](bOriginalSize)
     System.arraycopy(xByteArray, xByteArray.length - 1 - bOriginalSize, b2, 0, bOriginalSize)
-    return b2
+    b2
   }
 
   /**
@@ -473,9 +473,9 @@ abstract class BcDlogFp[ElemType <: ECPoint](val x9params: X9ECParameters) exten
 
   /**
     *
-    * Checks if the order of this group is greater than 2^numBits
+    * Checks if the order of this group is greater than `2^numBits`
     * @param numBits
-    * @return <code>true</code> if the order is greater than 2^numBits;<p>
+    * @return <code>true</code> if the order is greater than `2^numBits`;<p>
     *         <code>false</code> otherwise.
     **/
   override def orderGreaterThan(numBits: Int): Boolean =

--- a/src/main/scala/scapi/sigma/DlogGroup.scala
+++ b/src/main/scala/scapi/sigma/DlogGroup.scala
@@ -15,7 +15,7 @@ import scala.util.Try
   *
   * The discrete logarithm problem is as follows: given a generator g of a finite
   * group G and a random element h in G, find the (unique) integer x such that
-  * g^x = h.
+  * `g^x = h`.
   *
   * In cryptography, we are interested in groups for which the discrete logarithm problem
   * (Dlog for short) is assumed to be hard. The most known groups of that kind are some Elliptic curve groups.
@@ -70,9 +70,9 @@ trait DlogGroup[ElemType <: ECPoint] {
   def isMember(element: ElemType): Boolean
 
   /**
-    * Checks if the order of this group is greater than 2^numBits
+    * Checks if the order of this group is greater than `2^numBits`
     * @param numBits
-    * @return <code>true</code> if the order is greater than 2^numBits;<p>
+    * @return <code>true</code> if the order is greater than `2^numBits`;<p>
     * 		   <code>false</code> otherwise.
     */
   def orderGreaterThan(numBits: Int): Boolean
@@ -117,12 +117,12 @@ trait DlogGroup[ElemType <: ECPoint] {
   def createRandomGenerator(): ElemType = {
     // in prime order groups every element except the identity is a generator.
     // get a random element in the group
-    var randGen = createRandomElement
+    var randGen = createRandomElement()
 
     // if the given element is the identity, get a new random element
     while ( {
       randGen.isInfinity
-    }) randGen = createRandomElement
+    }) randGen = createRandomElement()
 
     randGen
   }
@@ -170,10 +170,15 @@ trait DlogGroup[ElemType <: ECPoint] {
 
   /**
     * This function takes any string of length up to k bytes and encodes it to a Group Element.
-    * k can be obtained by calling getMaxLengthOfByteArrayForEncoding() and it is calculated upon construction of this group; it depends on the length in bits of p.<p>
-    * The encoding-decoding functionality is not a bijection, that is, it is a 1-1 function but is not onto.
-    * Therefore, any string of length in bytes up to k can be encoded to a group element but not every group element can be decoded to a binary string in the group of binary strings of length up to 2^k.<p>
-    * Thus, the right way to use this functionality is first to encode a byte array and then to decode it, and not the opposite.
+    * k can be obtained by calling getMaxLengthOfByteArrayForEncoding() and it is calculated upon
+    * construction of this group; it depends on the length in bits of p.<p>
+    * The encoding-decoding functionality is not a bijection, that is, it is a 1-1 function
+    * but is not onto.
+    * Therefore, any string of length in bytes up to k can be encoded to a group element
+    * but not every group element can be decoded to a binary string in the group of binary strings
+    * of length up to `2^k`.<p>
+    * Thus, the right way to use this functionality is first to encode a byte array and then to
+    * decode it, and not the opposite.
     *
     * @param binaryString the byte array to encode
     * @return the encoded group Element <B> or null </B>if element could not be encoded
@@ -181,11 +186,12 @@ trait DlogGroup[ElemType <: ECPoint] {
   def encodeByteArrayToGroupElement(binaryString: Array[Byte]): Try[ElemType]
 
   /**
-    * This function decodes a group element to a byte array. This function is guaranteed to work properly ONLY if the group element was obtained as a result of
+    * This function decodes a group element to a byte array. This function is guaranteed
+    * to work properly ONLY if the group element was obtained as a result of
     * encoding a binary string of length in bytes up to k.<p>
     * This is because the encoding-decoding functionality is not a bijection, that is, it is a 1-1 function but is not onto.
     * Therefore, any string of length in bytes up to k can be encoded to a group element but not any group element can be decoded
-    * to a binary sting in the group of binary strings of length up to 2^k.
+    * to a binary sting in the group of binary strings of length up to `2^k`.
     *
     * @param groupElement the element to decode
     * @return the decoded byte array

--- a/src/main/scala/scapi/sigma/SigmaProtocolFunctions.scala
+++ b/src/main/scala/scapi/sigma/SigmaProtocolFunctions.scala
@@ -125,10 +125,12 @@ trait ActorVerifier[SP <: SigmaProtocol[SP], CI <: SigmaProtocolCommonInput[SP]]
   var started = false
   var transcript_ : Option[ST] = None
 
-  override def transcript = started match {
-    case false => Future(None)
-    case true => ???
-  }
+  override def transcript =
+    if (started) {
+      ???
+    } else {
+      Future(None)
+    }
 
   def construct(x: CI, a: SP#A, e: Challenge, z: SP#Z): ST
 

--- a/src/main/scala/sigmastate/SchnorrSigner.scala
+++ b/src/main/scala/sigmastate/SchnorrSigner.scala
@@ -12,14 +12,12 @@ case class SchnorrSigner(override val publicInput: ProveDlog, privateInputOpt: O
   def prove(challenge: Array[Byte]): SchnorrNode = {
     val prover = new DLogInteractiveProver(publicInput, privateInputOpt)
 
-    val (fm, sm) = privateInputOpt.isDefined match {
-      //real proving
-      case true =>
-        val firstMsg = prover.firstMessage
-        val e = Blake2b256(firstMsg.ecData.getEncoded(true) ++ challenge)
-        firstMsg -> prover.secondMessage(Challenge(e))
-      //simulation
-      case false => prover.simulate(Challenge(challenge))
+    val (fm, sm) = if (privateInputOpt.isDefined) {
+      val firstMsg = prover.firstMessage
+      val e = Blake2b256(firstMsg.ecData.getEncoded(true) ++ challenge)
+      firstMsg -> prover.secondMessage(Challenge(e))
+    } else {
+      prover.simulate(Challenge(challenge))
     }
 
     //val sb = SchnorrSigner.serialize(fm, sm)

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -7,14 +7,14 @@ import org.bitbucket.inkytonik.kiama.relation.Tree
 import org.bitbucket.inkytonik.kiama.rewriting.Rewritable
 import scorex.crypto.authds.SerializedAdProof
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
-import scorex.crypto.hash.{Blake2b256, Digest32}
+import scorex.crypto.hash.{Digest32, Blake2b256}
 import sigmastate.interpreter.GroupSettings
 import sigmastate.serialization.OpCodes._
 import sigmastate.utils.Overloading.Overload1
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utxo.ErgoBox
-
 import scala.collection.immutable
+import scala.language.implicitConversions
 
 object Values {
 

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -78,7 +78,7 @@ class SigmaBinder(env: Map[String, Any]) {
       if (newLam != lam) Some(newLam) else None
 
     // Rule: { e } --> e
-    case Block(Seq(), e) => Some(e)
+    case Block(Seq(), body) => Some(body)
     
     case block @ Block(binds, t) =>
       val newBinds = for (Let(n, t, b) <- binds) yield {

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -32,13 +32,14 @@ object SigmaParser extends Exprs with Types with Core {
 
   val BlockDef = P( Dcl )
 
+  val Constr = P( AnnotType ~~ (NotNewline ~ ParenArgList ).repX )
   val Constrs = P( (WL ~ Constr).rep(1, `with`.~/) )
   val EarlyDefTmpl = P( TmplBody ~ (`with` ~/ Constr).rep ~ TmplBody.? )
   val NamedTmpl = P( Constrs ~ TmplBody.? )
 
-  val DefTmpl = P( (`extends` | `<:`) ~ AnonTmpl | TmplBody )
   val AnonTmpl = P( EarlyDefTmpl | NamedTmpl | TmplBody ).ignore
-  val Constr = P( AnnotType ~~ (NotNewline ~ ParenArgList ).repX )
+  val DefTmpl = P( (`extends` | `<:`) ~ AnonTmpl | TmplBody )
+
 
   val logged = mutable.Buffer.empty[String]
   implicit val logger = Logger(logged.append(_))

--- a/src/main/scala/sigmastate/lang/SigmaPrinter.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPrinter.scala
@@ -33,8 +33,9 @@ class SigmaPrinter extends org.bitbucket.inkytonik.kiama.output.PrettyPrinter {
     t match {
       case IntConstant(d) => value(d)
       case Ident(i,_) => i
-      case Lambda(i, t, Some(e)) => parens('\\' <> parens(lsep(i.map { case (n, t) => n <+> ": " <+> typedeclToDoc(t) }.to, comma)) <>
-          typedeclToDoc(t) <+> '.' <+>
+      case Lambda(args, tLam, Some(e)) =>
+        parens('\\' <> parens(lsep(args.map { case (n, targ) => n <+> ": " <+> typedeclToDoc(targ) }.to, comma)) <>
+          typedeclToDoc(tLam) <+> '.' <+>
           group(nest(toDoc(e))))
       case Apply(e, args)        => parens(toDoc(e) <+> parens(lsep(args.map(toDoc).to, comma)))
 

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -35,7 +35,7 @@ class SigmaTyper {
     case Block(bs, res) =>
       var curEnv = env
       val bs1 = ArrayBuffer[Let]()
-      for (Let(n, t, b) <- bs) {
+      for (Let(n, _, b) <- bs) {
         if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
         val b1 = assignType(curEnv, b)
         curEnv = curEnv + (n -> b1.tpe)
@@ -53,7 +53,7 @@ class SigmaTyper {
         error(s"All element of array $c should have the same type but found $types"))
       ConcreteCollection(newItems)(tItem)
 
-    case v @ Ident(n, _) =>
+    case Ident(n, _) =>
       env.get(n) match {
         case Some(t) => Ident(n, t)
         case None => error(s"Cannot assign type for variable '$n' because it is not found in env $env")
@@ -334,7 +334,7 @@ object SigmaTyper {
 
   def applySubst(tpe: SType, subst: STypeSubst): SType = tpe match {
     case SFunc(args, res, tvars) =>
-      val remainingVars = tvars.filterNot(subst.contains(_))
+      val remainingVars = tvars.filterNot(subst.contains)
       SFunc(args.map(applySubst(_, subst)), applySubst(res, subst), remainingVars)
     case _ =>
       val substRule = rule[SType] {

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -7,6 +7,7 @@ import sigmastate.lang.Terms.Ident
 import sigmastate.lang.syntax.Core
 import syntax.Basic.error
 
+//noinspection ForwardReference
 trait Types extends Core {
   import WhitespaceApi._
   def TypeExpr: P[Value[SType]]

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -2,39 +2,41 @@ package sigmastate.lang.syntax
 
 import fastparse.all._
 import fastparse.CharPredicates._
+import fastparse.all
 import fastparse.core.Parsed.Failure
 import sigmastate.lang.{SigmaException, SourceContext}
 
 object Basic {
-  val UnicodeEscape = P( "u" ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit )
+  val digits = "0123456789"
+  val Digit: Parser[Unit] = P( CharIn(digits) )
+  val hexDigits: String = digits + "abcdefABCDEF"
+  val HexDigit: Parser[Unit] = P( CharIn(hexDigits) )
+  val UnicodeEscape: Parser[Unit] = P( "u" ~ HexDigit ~ HexDigit ~ HexDigit ~ HexDigit )
 
   //Numbers and digits
 
-  val digits = "0123456789"
-  val Digit = P( CharIn(digits) )
-  val hexDigits = digits + "abcdefABCDEF"
-  val HexDigit = P( CharIn(hexDigits) )
-  val HexNum = P( "0x" ~ CharsWhileIn(hexDigits) )
-  val DecNum = P( CharsWhileIn(digits) )
-  val Exp = P( CharIn("Ee") ~ CharIn("+-").? ~ DecNum )
-  val FloatType = P( CharIn("fFdD") )
 
-  val WSChars = P( CharsWhileIn("\u0020\u0009") )
-  val Newline = P( StringIn("\r\n", "\n") )
-  val Semi = P( ";" | Newline.rep(1) )
-  val OpChar = P ( CharPred(isOpChar) )
+  val HexNum: Parser[Unit] = P( "0x" ~ CharsWhileIn(hexDigits) )
+  val DecNum: Parser[Unit] = P( CharsWhileIn(digits) )
+  val Exp: Parser[Unit] = P( CharIn("Ee") ~ CharIn("+-").? ~ DecNum )
+  val FloatType: Parser[Unit] = P( CharIn("fFdD") )
 
-  def isOpChar(c: Char) = c match{
+  val WSChars: Parser[Unit] = P( CharsWhileIn("\u0020\u0009") )
+  val Newline: Parser[Unit] = P( StringIn("\r\n", "\n") )
+  val Semi: Parser[Unit] = P( ";" | Newline.rep(1) )
+  val OpChar: Parser[Unit] = P ( CharPred(isOpChar) )
+
+  def isOpChar(c: Char): Boolean = c match{
     case '!' | '#' | '%' | '&' | '*' | '+' | '-' | '/' |
          ':' | '<' | '=' | '>' | '?' | '@' | '\\' | '^' | '|' | '~' => true
     case _ => isOtherSymbol(c) || isMathSymbol(c)
   }
-  val Letter = P( CharPred(c => isLetter(c) | isDigit(c) | c == '$' | c == '_' ) )
-  val LetterDigitDollarUnderscore =  P(
+  val Letter: Parser[Unit] = P( CharPred(c => isLetter(c) | isDigit(c) | c == '$' | c == '_' ) )
+  val LetterDigitDollarUnderscore: Parser[Unit] =  P(
     CharPred(c => isLetter(c) | isDigit(c) | c == '$' | c == '_' )
   )
-  val Lower = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
-  val Upper = P( CharPred(isUpper) )
+  val Lower: Parser[Unit] = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
+  val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
   def error(msg: String, parseError: Option[Failure[_,_]] = None) =
     throw new ParserException(msg, parseError)

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -51,7 +51,7 @@ trait Exprs extends Core with Types {
 //      }
       val PostfixLambda = P( PostfixExpr ~ ((`=>` ~ LambdaRhs.?) | SuperPostfixSuffix) ).map {
         case (e, None) => e
-        case (Tuple(args), Some(body)) => mkLambda(args.toSeq, body)
+        case (Tuple(args), Some(body)) => mkLambda(args, body)
         case (e, Some(body)) => error(s"Invalid declaration of lambda $e => $body")
       }
       val SmallerExprOrLambda = P( /*ParenedLambda |*/ PostfixLambda )
@@ -219,10 +219,10 @@ trait Exprs extends Core with Types {
 
   def extractBlockStats(stats: Seq[SValue]): (Seq[Let], SValue) = {
     if (stats.nonEmpty) {
-      val lets = stats.iterator.take(stats.size - 1).map(_ match {
+      val lets = stats.iterator.take(stats.size - 1).map {
         case l: Let => l
         case _ => error(s"Block should contain a list of Let bindings and one expression: but was $stats")
-      })
+      }
       (lets.toList, stats.last)
     }
     else

--- a/src/main/scala/sigmastate/lang/syntax/Identifiers.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Identifiers.scala
@@ -4,29 +4,29 @@ import fastparse.CharPredicates.{isDigit, isLetter}
 import fastparse.all._
 import sigmastate.lang.syntax.Basic._
 
+//noinspection ForwardReference
 object Identifiers {
   case class NamedFunction(f: Char => Boolean)
       (implicit name: sourcecode.Name) extends (Char => Boolean){
     def apply(t: Char) = f(t)
-    override def toString() = name.value
-
+    override def toString: String = name.value
   }
   val OpCharNotSlash = NamedFunction(x => isOpChar(x) && x != '/')
   val NotBackTick = NamedFunction(_ != '`')
 
-  val Operator = P(
+  val Operator: Parser[Unit] = P(
     !Keywords ~ (!("/*" | "//") ~ (CharsWhile(OpCharNotSlash) | "/")).rep(1)
   )
 
-  val VarId = VarId0(true)
+  val VarId: Parser[Unit] = VarId0(true)
 
-  def VarId0(dollar: Boolean) = P( !Keywords ~ Lower ~ IdRest(dollar) )
-  val PlainId = P( !Keywords ~ Upper ~ IdRest(true) | VarId | Operator ~ (!OpChar | &("/*" | "//")) )
-  val PlainIdNoDollar = P( !Keywords ~ Upper ~ IdRest(false) | VarId0(false) | Operator )
-  val BacktickId = P( "`" ~ CharsWhile(NotBackTick) ~ "`" )
+  def VarId0(dollar: Boolean): Parser[Unit] = P( !Keywords ~ Lower ~ IdRest(dollar) )
+  val PlainId: Parser[Unit] = P( !Keywords ~ Upper ~ IdRest(true) | VarId | Operator ~ (!OpChar | &("/*" | "//")) )
+  val PlainIdNoDollar: Parser[Unit] = P( !Keywords ~ Upper ~ IdRest(false) | VarId0(false) | Operator )
+  val BacktickId: Parser[Unit] = P( "`" ~ CharsWhile(NotBackTick) ~ "`" )
   val Id: P0 = P( BacktickId | PlainId )
 
-  def IdRest(allowDollar: Boolean) = {
+  def IdRest(allowDollar: Boolean): Parser[Unit] = {
 
     val IdCharacter =
       if(allowDollar) NamedFunction(c => c == '$' || isLetter(c) || isDigit(c))
@@ -39,18 +39,18 @@ object Identifiers {
   val alphaKeywords = Seq(
     "case", "else", "false", "function", "if", "match", "return", "then", "true"
   )
-  val AlphabetKeywords = P {
+  val AlphabetKeywords: Parser[Unit] = P {
     StringIn(alphaKeywords:_*) ~ !Letter
   }
 
   val symbolKeywords = Seq(
     ":", ";", "=>", "=", "#", "@"
   )
-  val SymbolicKeywords = P{
+  val SymbolicKeywords: Parser[Unit] = P{
     StringIn(symbolKeywords:_*) ~ !OpChar
   }
 
-  val keywords = alphaKeywords ++ symbolKeywords
+  val keywords: Seq[String] = alphaKeywords ++ symbolKeywords
 
-  val Keywords = P( AlphabetKeywords | SymbolicKeywords )
+  val Keywords: Parser[Unit] = P( AlphabetKeywords | SymbolicKeywords )
 }

--- a/src/main/scala/sigmastate/serialization/FalseLeafSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/FalseLeafSerializer.scala
@@ -1,7 +1,7 @@
 package sigmastate.serialization
 
 import sigmastate.Values._
-import sigmastate.{SBoolean}
+import sigmastate.SBoolean
 import sigmastate.SType.TypeCode
 import sigmastate.serialization.ValueSerializer.Position
 import sigmastate.serialization.OpCodes._

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1,15 +1,14 @@
 package sigmastate
 
 import java.math.BigInteger
-
 import sigmastate.SType.TypeCode
 import sigmastate.interpreter.GroupSettings
 import sigmastate.utils.Overloading.Overload1
 import sigmastate.utxo.ErgoBox
 import sigmastate.Values._
 import sigmastate.lang.SigmaTyper
-
 import scala.collection.mutable
+import scala.language.implicitConversions
 
 /** Base type for all AST nodes of sigma lang. */
 trait SigmaNode extends Product

--- a/src/main/scala/sigmastate/utils/Extensions.scala
+++ b/src/main/scala/sigmastate/utils/Extensions.scala
@@ -1,6 +1,7 @@
 package sigmastate.utils
 
 import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
 import scala.reflect.ClassTag
 
 object Extensions {
@@ -20,7 +21,7 @@ object Extensions {
         val y = f(x)
         if (y.isDefined) return y
       }
-      return None
+      None
     }
 
     def cast[B:ClassTag](implicit cbf: CanBuildFrom[Source[A], B, Source[B]]): Source[B] = {

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -1,14 +1,15 @@
 package sigmastate.helpers
 
-import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.{PropertyChecks, GeneratorDrivenPropertyChecks}
+import org.scalatest.{PropSpec, Matchers}
 import scorex.crypto.hash.Blake2b256
-import sigmastate.Values.{GroupElementConstant, TrueLeaf, Value}
+import sigmastate.Values.{TrueLeaf, Value, GroupElementConstant}
 import sigmastate.interpreter.GroupSettings
 import sigmastate.lang.SigmaCompiler
 import sigmastate.utxo.ErgoBox
 import sigmastate.utxo.ErgoBox.NonMandatoryIdentifier
-import sigmastate.{SBoolean, SGroupElement, SType}
+import sigmastate.{SGroupElement, SBoolean, SType}
+import scala.language.implicitConversions
 
 trait SigmaTestingCommons extends PropSpec
   with PropertyChecks

--- a/src/test/scala/sigmastate/serialization/TableSerializationSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TableSerializationSpecification.scala
@@ -2,7 +2,7 @@ package sigmastate.serialization
 
 import org.scalatest.prop.TableFor2
 import sigmastate.Values._
-import sigmastate.{SType}
+import sigmastate.SType
 
 trait TableSerializationSpecification extends SerializationSpecification {
   def objects: TableFor2[_ <: Value[_ <: SType], Array[Byte]]

--- a/src/test/scala/sigmastate/serialization/generators/ConcreteCollectionGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ConcreteCollectionGenerators.scala
@@ -5,15 +5,13 @@ import sigmastate.SInt
 import sigmastate.Values.ConcreteCollection
 
 trait ConcreteCollectionGenerators { self: ValueGeneratots =>
-
   val minCollLength = 1
   val maxCollLength = 10
-
-  implicit val arbCCOfIntConstant: Arbitrary[ConcreteCollection[SInt.type]] = Arbitrary(intConstCollectionGen)
 
   val intConstCollectionGen: Gen[ConcreteCollection[SInt.type]] = for {
     size <- Gen.chooseNum(minCollLength, maxCollLength)
     listOfConstInts <- Gen.listOfN(size, intConstGen)
   } yield ConcreteCollection(listOfConstInts.toIndexedSeq)
 
+  implicit val arbCCOfIntConstant: Arbitrary[ConcreteCollection[SInt.type]] = Arbitrary(intConstCollectionGen)
 }

--- a/src/test/scala/sigmastate/serialization/generators/ValueGeneratots.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGeneratots.scala
@@ -6,11 +6,6 @@ import sigmastate.Values.{ByteArrayConstant, IntConstant, TaggedBox, TaggedInt}
 
 trait ValueGeneratots {
 
-  implicit val arbIntConstants: Arbitrary[IntConstant] = Arbitrary(intConstGen)
-  implicit val arbTaggedInt: Arbitrary[TaggedInt] = Arbitrary(taggedIntGen)
-  implicit val arbTaggedBox: Arbitrary[TaggedBox] = Arbitrary(taggedBoxGen)
-  implicit val arbByteArrayConstant: Arbitrary[ByteArrayConstant] = Arbitrary(byteArrayConstantGen)
-
   val intConstGen: Gen[IntConstant] = arbLong.arbitrary.map{v => IntConstant(v)}
   val taggedIntGen: Gen[TaggedInt] = arbByte.arbitrary.map{v => TaggedInt(v)}
   val taggedBoxGen: Gen[TaggedBox] = arbByte.arbitrary.map{v => TaggedBox(v)}
@@ -19,5 +14,9 @@ trait ValueGeneratots {
     bytes <- Gen.listOfN(length, arbByte.arbitrary)
   } yield ByteArrayConstant(bytes.toArray)
 
+  implicit val arbIntConstants: Arbitrary[IntConstant] = Arbitrary(intConstGen)
+  implicit val arbTaggedInt: Arbitrary[TaggedInt] = Arbitrary(taggedIntGen)
+  implicit val arbTaggedBox: Arbitrary[TaggedBox] = Arbitrary(taggedBoxGen)
+  implicit val arbByteArrayConstant: Arbitrary[ByteArrayConstant] = Arbitrary(byteArrayConstantGen)
 
 }

--- a/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
@@ -31,20 +31,20 @@ class OracleExamplesSpecification extends SigmaTestingCommons {
     * and Bob are referencing to the coin by using Merkle proofs against UTXO set root hash of the latest known block.
     *
     * A tricky moment is how Alice and Bob can be sure that a coin is indeed created by the service, having just the
-    * coin (and also service's public key x = g^w, where service's secret w is not known.
+    * coin (and also service's public key `x = g^w`, where service's secret w is not known.
     *
     *
     * For that, we consider that the service creates a coin with registers of following semantics (R0 & R1 are standard):
     *
     * R1 - coin amount
-    * R2 - protecting script, which is the pubkey of the service, x =  g^w
+    * R2 - protecting script, which is the pubkey of the service, `x =  g^w`
     * R3 - temperature data, number
-    * R4 - a = g^r, where r is secret random nonce
+    * R4 - `a = g^r`, where r is secret random nonce
     * R5 - z = r + ew mod q
     * R6 - timestamp
     *
     * Then Alice and Bob are requiring from the coin that the following equation holds:
-    * (g^z = a * x^e, where e = hash(R3 ++ R6)
+    * (`g^z = a * x^e`, where e = hash(R3 ++ R6)
     *
     * Thus Alice, for example, is created a coin with the following statement (we skip timeouts for simplicity):
     * "the coin is spendable by presenting a proof of Alice's private key knowledge if against UTXO set root hash for


### PR DESCRIPTION
Resolves #74 
Forward references in `val` definitions are correct, because method `P` takes by-name argument, which is executed during parsing, not during initializations.
