### PR TITLE
Slice and Where operations for Arrays

### DIFF
--- a/src/main/scala/sigmastate/lang/SigmaCompiler.scala
+++ b/src/main/scala/sigmastate/lang/SigmaCompiler.scala
@@ -7,8 +7,6 @@ import fastparse.core.Parsed.Success
 import sigmastate.Values.{Value, SValue, SigmaTree}
 
 class SigmaCompiler {
-  import SigmaCompiler._
-
   def parse(x: String): SValue = {
     SigmaParser(x) match {
       case Success(v, i) => v
@@ -21,7 +19,6 @@ class SigmaCompiler {
     val parsed = parse(code)
     val binder = new SigmaBinder(env)
     val bound = binder.bind(parsed)
-    val st = new SigmaTree(bound)
     val typer = new SigmaTyper
     val typed = typer.typecheck(bound)
     val spec = new SigmaSpecializer

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -113,6 +113,14 @@ class SigmaSpecializer {
     case Select(obj, "value", Some(SInt)) if obj.tpe == SBox =>
       Some(ExtractAmount(obj.asValue[SBox.type]))
 
+    case Apply(Select(col, "slice", _), Seq(from, until)) =>
+      Some(Slice(col.asValue[SCollection[SType]], from.asIntValue, until.asIntValue))
+
+    case Apply(Select(col, "where", _), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
+      val tagged = mkTagged(n, t, 21)
+      val body1 = eval(env + (n -> tagged), body)
+      Some(Where(col.asValue[SCollection[SType]], tagged.id, body1.asValue[SBoolean.type]))
+
     case Apply(Select(col,"exists", _), Seq(Lambda(Seq((n, t)), _, Some(body)))) =>
       val tagged = mkTagged(n, t, 21)
       val body1 = eval(env + (n -> tagged), body)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -144,12 +144,19 @@ class SigmaTyper {
       val newArgs = args.map(assignType(env, _))
       newObj.tpe match {
         case SByteArray => (m, newArgs) match {
-          case ("++", Seq(r)) => AppendBytes(newObj.asValue[SByteArray.type], r.asValue[SByteArray.type])
-          case _ => error(s"Unknown symbol $m, which is used as operation with arguments $newArgs")
+          case ("++", Seq(r)) if r.tpe == SByteArray =>
+            AppendBytes(newObj.asValue[SByteArray.type], r.asValue[SByteArray.type])
+          case _ =>
+            error(s"Unknown symbol $m, which is used as operation with arguments $newArgs")
         }
         case tCol: SCollection[a] => (m, newArgs) match {
-          case ("++", Seq(r)) => Append(newObj.asCollection[a], r.asCollection[a])
-          case _ => error(s"Unknown symbol $m, which is used as operation with arguments $newObj and $newArgs")
+          case ("++", Seq(r)) =>
+            if (r.tpe == tCol)
+              Append(newObj.asCollection[a], r.asCollection[a])
+            else
+              error(s"Invalid argument type for $m, expected $tCol but was ${r.tpe}")
+          case _ =>
+            error(s"Unknown symbol $m, which is used as operation with arguments $newObj and $newArgs")
         }
         case t =>
           error(s"Invalid operation $mc on type $t")

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -102,11 +102,11 @@ class SigmaTyper {
       newSel.tpe match {
         case genFunTpe @ SFunc(argTypes, tRes, _) =>
           // If it's a function then the application has type of that function's return type.
-          val actualTypes = newArgs.map(_.tpe)
+          val newObj = assignType(env, obj)
+          val actualTypes = newObj.tpe +: newArgs.map(_.tpe)
           unifyTypeLists(argTypes, actualTypes) match {
             case Some(subst) =>
               val concrFunTpe = applySubst(genFunTpe, subst)
-              val newObj = assignType(env, obj)
               val newApply = Apply(Select(newObj, n, Some(concrFunTpe)), newArgs)
               newApply
             case None =>

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -210,10 +210,12 @@ object SCollection {
   private val tOV = STypeIdent("OV")
   val fields = Seq(
     "size" -> SInt,
-    "map" -> SFunc(IndexedSeq(SFunc(tIV, tOV)), SCollection(tOV), Seq(tIV, tOV)),
-    "exists" -> SFunc(IndexedSeq(SFunc(tIV, SBoolean)), SBoolean, Seq(tIV)),
-    "fold" -> SFunc(IndexedSeq(tIV, SFunc(IndexedSeq(tIV, tIV), tIV)), tIV, Seq(tIV)),
-    "forall" -> SFunc(IndexedSeq(SFunc(tIV, SBoolean)), SBoolean, Seq(tIV))
+    "map" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, tOV)), SCollection(tOV), Seq(tIV, tOV)),
+    "exists" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(tIV)),
+    "fold" -> SFunc(IndexedSeq(SCollection(tIV), tIV, SFunc(IndexedSeq(tIV, tIV), tIV)), tIV, Seq(tIV)),
+    "forall" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(tIV)),
+    "slice" -> SFunc(IndexedSeq(SCollection(tIV), SInt, SInt), SCollection(tIV), Seq(tIV)),
+    "where" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SCollection(tIV), Seq(tIV))
   )
   def apply[T <: SType](implicit elemType: T, ov: Overload1): SCollection[T] = SCollection(elemType)
   def unapply[T <: SType](tCol: SCollection[T]): Option[T] = Some(tCol.elemType)
@@ -238,7 +240,7 @@ object SOption {
     Seq(
       "isDefined" -> SBoolean,
       "value" -> tArg,
-      "valueOrElse" -> SFunc(tArg, tArg)
+      "valueOrElse" -> SFunc(IndexedSeq(SOption(tArg), tArg), tArg, Seq(tT))
     )
   private val tT = STypeIdent("T")
   val fields: Seq[(String, SType)] = createFields(tT)

--- a/src/main/scala/sigmastate/utils/Helpers.scala
+++ b/src/main/scala/sigmastate/utils/Helpers.scala
@@ -5,6 +5,17 @@ object Helpers {
 
   def xor(bas: Array[Byte]*): Array[Byte] =
     bas.reduce({case (ba, ba1) => xor(ba, ba1)}: ((Array[Byte], Array[Byte]) => Array[Byte]))
+
+  def concatBytes(seq: Traversable[Array[Byte]]): Array[Byte] = {
+    val length: Int = seq.foldLeft(0)((acc, arr) => acc + arr.length)
+    val result: Array[Byte] = new Array[Byte](length)
+    var pos: Int = 0
+    seq.foreach{ array =>
+      System.arraycopy(array, 0, result, pos, array.length)
+      pos += array.length
+    }
+    result
+  }
 }
 
 object Overloading {

--- a/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/src/main/scala/sigmastate/utxo/transformers.scala
@@ -73,7 +73,45 @@ case class Append[IV <: SType](input: Value[SCollection[IV]], col2: Value[SColle
     ConcreteCollection(cl.value ++ col2.asInstanceOf[EvaluatedValue[SCollection[IV]]].value)(tpe.elemType)
   }
 
-  override def cost: Int = input.cost * col2.cost
+  override def cost: Int = input.cost + col2.cost
+}
+
+case class Slice[IV <: SType](input: Value[SCollection[IV]], from: Value[SInt.type], until: Value[SInt.type])
+  extends Transformer[SCollection[IV], SCollection[IV]]{
+  val tpe = input.tpe
+
+  override def transformationReady: Boolean =
+    ConcreteCollection.isEvaluated(input) && from.evaluated && until.evaluated
+
+  override def function(cl: EvaluatedValue[SCollection[IV]]): Value[SCollection[IV]] = {
+    val fromValue = from.asInstanceOf[EvaluatedValue[SInt.type]].value
+    val untilValue = until.asInstanceOf[EvaluatedValue[SInt.type]].value
+    ConcreteCollection(cl.value.slice(fromValue.toInt, untilValue.toInt))(tpe.elemType)
+  }
+
+  override def cost: Int = input.cost * 2 + from.cost + until.cost
+}
+
+case class Where[IV <: SType](input: Value[SCollection[IV]],
+                               id: Byte,
+                               condition: Value[SBoolean.type])
+  extends Transformer[SCollection[IV], SCollection[IV]] {
+  override def tpe: SCollection[IV] = input.tpe
+  override def transformationReady: Boolean = ConcreteCollection.isEvaluated(input)
+
+  override def cost: Int = input.cost * condition.cost + input.cost * Cost.OrDeclaration
+
+  override def function(input: EvaluatedValue[SCollection[IV]]): ConcreteCollection[IV] = {
+    def rl(arg: Value[IV]) = everywherebu(rule[Value[IV]] {
+      case t: TaggedVariable[IV] if t.id == id => arg
+    })
+    def p(x: Value[IV]): Boolean = {
+      val res = rl(x)(condition).get
+      res.asInstanceOf[EvaluatedValue[SBoolean.type]].value
+    }
+    val filtered = input.value.filter(p)
+    ConcreteCollection(filtered)(tpe.elemType)
+  }
 }
 
 case class Exists[IV <: SType](input: Value[SCollection[IV]],
@@ -81,8 +119,7 @@ case class Exists[IV <: SType](input: Value[SCollection[IV]],
                                condition: Value[SBoolean.type])
   extends Transformer[SCollection[IV], SBoolean.type] {
   override def tpe = SBoolean
-  override def transformationReady: Boolean =
-    input.evaluated && input.asInstanceOf[ConcreteCollection[IV]].value.forall(_.evaluated)
+  override def transformationReady: Boolean = ConcreteCollection.isEvaluated(input)
 
   override val cost: Int = input.cost * condition.cost + input.cost * Cost.OrDeclaration
 

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -80,23 +80,29 @@ class TestingInterpreterSpecification extends PropSpec
     compiler.compile(env, code)
   }
 
-  property("Evaluate ops") {
+  def testeval(code: String) = {
     val dk1 = ProveDlog(secrets(0).publicImage.h)
-
     val ctx = TestingContext(99)
-
     val env = Map("dk1" -> dk1)
-    val prop = compile(env,
-      """{
-        |  let arr = Array(1, 2) ++ Array(3, 4)
-        |  arr.size == 4
-        |}""".stripMargin
-    ).asBoolValue
-
+    val prop = compile(env, code).asBoolValue
     val challenge = Array.fill(32)(Random.nextInt(100).toByte)
-
     val proof1 = TestingInterpreter.prove(prop, ctx, challenge).get.proof
     verify(prop, ctx, proof1, challenge).getOrElse(false) shouldBe true
+  }
+
+  property("Evaluate array ops") {
+    testeval("""{
+              |  let arr = Array(1, 2) ++ Array(3, 4)
+              |  arr.size == 4
+              |}""".stripMargin)
+    testeval("""{
+              |  let arr = Array(1, 2, 3)
+              |  arr.slice(1, 3) == Array(2, 3)
+              |}""".stripMargin)
+//    testeval("""{
+//              |  let arr = Array(1, 2, 3)
+//              |  arr.where(fun (i: Int) = i < 3) == Array(1, 2)
+//              |}""".stripMargin)
   }
 
   property("Evaluation example #1") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -227,9 +227,11 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
         Select(Apply(Ident("Array"), Vector(IntConstant(1), IntConstant(2))), "fold"),
         Vector(IntConstant(0), Lambda(Vector(("n1",SInt), ("n2",SInt)), Plus(IntIdent("n1"), IntIdent("n2"))))
       )
-
-//    parse("OUTPUTS.slice(0, 10)") shouldBe
-//        Apply(Select(Ident("OUTPUTS"), "slice"), Vector(IntConstant(0), IntConstant(10)))
+    parse("OUTPUTS.slice(0, 10)") shouldBe
+        Apply(Select(Ident("OUTPUTS"), "slice"), Vector(IntConstant(0), IntConstant(10)))
+    parse("OUTPUTS.where(fun (out: Box) = out.value > 0)") shouldBe
+        Apply(Select(Ident("OUTPUTS"), "where"),
+          Vector(Lambda(Vector(("out",SBox)), GT(Select(Ident("out"),"value").asIntValue, 0))))
   }
 
   property("global functions") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -212,6 +212,26 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("Array()(0)(0)") shouldBe Apply(Apply(Apply(Ident("Array"), IndexedSeq.empty), IndexedSeq(IntConstant(0))), IndexedSeq(IntConstant(0)))
   }
 
+  property("generic methods of arrays") {
+    parse("OUTPUTS.map(fun (out: Box) = out.value)") shouldBe
+      Apply(Select(Ident("OUTPUTS"), "map"),
+            Vector(Lambda(Vector(("out",SBox)), Select(Ident("out"),"value"))))
+    parse("OUTPUTS.exists(fun (out: Box) = out.value > 0)") shouldBe
+      Apply(Select(Ident("OUTPUTS"), "exists"),
+            Vector(Lambda(Vector(("out",SBox)), GT(Select(Ident("out"),"value").asIntValue, 0))))
+    parse("OUTPUTS.forall(fun (out: Box) = out.value > 0)") shouldBe
+      Apply(Select(Ident("OUTPUTS"), "forall"),
+            Vector(Lambda(Vector(("out",SBox)), GT(Select(Ident("out"),"value").asIntValue, 0))))
+    parse("Array(1,2).fold(0, fun (n1: Int, n2: Int) = n1 + n2)") shouldBe
+      Apply(
+        Select(Apply(Ident("Array"), Vector(IntConstant(1), IntConstant(2))), "fold"),
+        Vector(IntConstant(0), Lambda(Vector(("n1",SInt), ("n2",SInt)), Plus(IntIdent("n1"), IntIdent("n2"))))
+      )
+
+//    parse("OUTPUTS.slice(0, 10)") shouldBe
+//        Apply(Select(Ident("OUTPUTS"), "slice"), Vector(IntConstant(0), IntConstant(10)))
+  }
+
   property("global functions") {
     parse("f(x)") shouldBe Apply(Ident("f"), IndexedSeq(Ident("x")))
     parse("f((x, y))") shouldBe Apply(Ident("f"), IndexedSeq(Tuple(IndexedSeq(Ident("x"), Ident("y")))))

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.prop.PropertyChecks
 import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.Terms.Ident
+import sigmastate.utxo._
 
 class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers with LangTests {
 
@@ -58,4 +59,21 @@ class SigmaSpecializerTest extends PropSpec with PropertyChecks with Matchers wi
     fail(Map(), "None", "Option values are not supported")
     fail(Map(), "Some(10)", "Option values are not supported")
   }
+
+  property("generic methods of arrays") {
+    spec("OUTPUTS.map(fun (out: Box) = { out.value >= 10 })") shouldBe
+      MapCollection(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), IntConstant(10)))(SBoolean)
+    spec("OUTPUTS.exists(fun (out: Box) = { out.value >= 10 })") shouldBe
+        Exists(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), IntConstant(10)))
+    spec("OUTPUTS.forall(fun (out: Box) = { out.value >= 10 })") shouldBe
+        ForAll(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), IntConstant(10)))
+    spec("{ let arr = Array(1,2); arr.fold(0, fun (n1: Int, n2: Int) = n1 + n2)}") shouldBe
+        Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
+             21, IntConstant(0), 22, Plus(TaggedInt(21), TaggedInt(22)))
+    spec("OUTPUTS.slice(0, 10)") shouldBe
+        Slice(Outputs, IntConstant(0), IntConstant(10))
+    spec("OUTPUTS.where(fun (out: Box) = { out.value >= 10 })") shouldBe
+        Where(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), IntConstant(10)))
+  }
+
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -86,6 +86,8 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "OUTPUTS.exists(fun (out: Box) = { out.value >= minToRaise })") shouldBe SBoolean
     typecheck(env, "OUTPUTS.forall(fun (out: Box) = { out.value >= minToRaise })") shouldBe SBoolean
     typecheck(env, "{ let arr = Array(1,2,3); arr.fold(0, fun (n1: Int, n2: Int) = n1 + n2)}") shouldBe SInt
+    typecheck(env, "OUTPUTS.slice(0, 10)") shouldBe ty("Array[Box]")
+    typecheck(env, "OUTPUTS.where(fun (out: Box) = { out.value >= minToRaise })") shouldBe ty("Array[Box]")
   }
 
   property("tuple constructor") {

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -77,15 +77,15 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "{let X = (Array(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
   }
 
-  property("generic methods of collection") {
+  property("generic methods of arrays") {
     val minToRaise = IntConstant(1000)
     val env = this.env ++ Map(
-      "minToRaise" -> minToRaise,
+      "minToRaise" -> minToRaise
     )
-    typecheck(env, "OUTPUTS.exists(fun (out: Box) = { out.value >= minToRaise })") shouldBe SBoolean
     typecheck(env, "OUTPUTS.map(fun (out: Box) = { out.value >= minToRaise })") shouldBe ty("Array[Boolean]")
-    typecheck(env, "{ let arr = Array(1,2,3); arr.fold(0, fun (n1: Int, n2: Int) = n1 + n2)}") shouldBe SInt
+    typecheck(env, "OUTPUTS.exists(fun (out: Box) = { out.value >= minToRaise })") shouldBe SBoolean
     typecheck(env, "OUTPUTS.forall(fun (out: Box) = { out.value >= minToRaise })") shouldBe SBoolean
+    typecheck(env, "{ let arr = Array(1,2,3); arr.fold(0, fun (n1: Int, n2: Int) = n1 + n2)}") shouldBe SInt
   }
 
   property("tuple constructor") {


### PR DESCRIPTION
Resolves #71 
Implementation of filtering with `arr.where(fun (i: Int) = i > 0)` require recursive reduceToCrypto and corresponding refactoring of reduction process.