### PR TITLE
Check/improve test coverage for new serializers added in PR #124. Part 2. 

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBox.scala
@@ -16,9 +16,6 @@ import scala.annotation.tailrec
 import scala.runtime.ScalaRunTime
 import scala.util.Try
 
-
-
-
 /**
   * Box (aka coin, or an unspent output) is a basic concept of a UTXO-based cryptocurrency. In bitcoin, such an object
   * is associated with some monetary value (arbitrary, but with predefined precision, so we use integer arithmetic to

--- a/src/main/scala/org/ergoplatform/ErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBox.scala
@@ -79,6 +79,10 @@ class ErgoBox private(override val value: Long,
 
 object ErgoBox {
   type BoxId = ADKey
+  object BoxId {
+    val size: Short = 32
+  }
+
   type Amount = Long
 
   def apply(value: Long,

--- a/src/main/scala/org/ergoplatform/Input.scala
+++ b/src/main/scala/org/ergoplatform/Input.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform
 
+import org.ergoplatform.ErgoBox.BoxId
 import scorex.crypto.authds.ADKey
 import sigmastate.interpreter.SerializedProverResult
 import sigmastate.serialization.Serializer
@@ -8,7 +9,9 @@ import sigmastate.serialization.Serializer.{Consumed, Position}
 import scala.util.Try
 
 
-class UnsignedInput(val boxId: ADKey)
+class UnsignedInput(val boxId: BoxId) {
+  require(boxId.size == BoxId.size, s"incorrect boxId size, expected: $BoxId.size, got: ${boxId.size}")
+}
 
 object UnsignedInput {
   object serializer extends Serializer[UnsignedInput, UnsignedInput] {
@@ -20,7 +23,7 @@ object UnsignedInput {
       Try(parseBody(bytes, 0)._1)
 
     override def parseBody(bytes: Array[Byte], pos: Position): (UnsignedInput, Consumed) = {
-      new UnsignedInput(ADKey @@ bytes.slice(pos, pos+32)) -> 32
+      new UnsignedInput(ADKey @@ bytes.slice(pos, pos + BoxId.size)) -> BoxId.size
     }
 
     @inline
@@ -28,7 +31,7 @@ object UnsignedInput {
   }
 }
 
-case class Input(override val boxId: ADKey, spendingProof: SerializedProverResult)
+case class Input(override val boxId: BoxId, spendingProof: SerializedProverResult)
   extends UnsignedInput(boxId) {
 }
 
@@ -39,9 +42,9 @@ object Input {
     }
 
     override def parseBody(bytes: Array[Byte], pos: Position): (Input, Consumed) = {
-      val boxId = bytes.slice(pos, pos + 32)
-      val (spendingProof, consumed) = SerializedProverResult.serializer.parseBody(bytes, pos + 32)
-      Input(ADKey @@ boxId, spendingProof) -> (consumed + 32)
+      val boxId = bytes.slice(pos, pos + BoxId.size)
+      val (spendingProof, consumed) = SerializedProverResult.serializer.parseBody(bytes, pos + BoxId.size)
+      Input(ADKey @@ boxId, spendingProof) -> (consumed + BoxId.size)
     }
   }
 }

--- a/src/main/scala/org/ergoplatform/Input.scala
+++ b/src/main/scala/org/ergoplatform/Input.scala
@@ -1,5 +1,7 @@
 package org.ergoplatform
 
+import java.util
+
 import org.ergoplatform.ErgoBox.BoxId
 import scorex.crypto.authds.ADKey
 import sigmastate.interpreter.SerializedProverResult
@@ -11,6 +13,11 @@ import scala.util.Try
 
 class UnsignedInput(val boxId: BoxId) {
   require(boxId.size == BoxId.size, s"incorrect boxId size, expected: $BoxId.size, got: ${boxId.size}")
+
+  override def equals(obj: Any): Boolean = obj match {
+    case x: UnsignedInput => util.Arrays.equals(boxId, x.boxId)
+    case _ => false
+  }
 }
 
 object UnsignedInput {

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -343,7 +343,7 @@ trait Interpreter {
              proverResult: SerializedProverResult,
              message: Array[Byte]): Try[VerificationResult] = {
     val ctxv = context.withExtension(proverResult.extension)
-    verify(exp, ctxv, proverResult.prooBytes, message)
+    verify(exp, ctxv, proverResult.proofBytes.toArray, message)
   }
 
 

--- a/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
@@ -27,15 +27,15 @@ class ProverResult(val proof: UncheckedTree, val extension: ContextExtension) {
     new SerializedProverResult(SigSerializer.toBytes(proof), extension)
 }
 
-class SerializedProverResult(val prooBytes: Array[Byte], val extension: ContextExtension)
+case class SerializedProverResult(proofBytes: IndexedSeq[Byte], extension: ContextExtension)
 
 object SerializedProverResult {
   object serializer extends Serializer[SerializedProverResult, SerializedProverResult] {
     override def toBytes(pr: SerializedProverResult): Array[Byte] = {
       val ceBytes = ContextExtension.serializer.toBytes(pr.extension)
-      val sigBytesCount = pr.prooBytes.length.toShort
+      val sigBytesCount = pr.proofBytes.length.toShort
 
-      Shorts.toByteArray(sigBytesCount) ++ pr.prooBytes ++ ceBytes
+      Shorts.toByteArray(sigBytesCount) ++ pr.proofBytes ++ ceBytes
     }
 
     override def parseBytes(bytes: Array[Byte]): Try[SerializedProverResult] = Try {
@@ -46,7 +46,7 @@ object SerializedProverResult {
       val sigBytesCount = Shorts.fromByteArray(bytes.slice(pos, pos + 2))
       val proofBytes = bytes.slice(pos + 2, pos + 2 + sigBytesCount)
       val (ce, ceConsumed) = ContextExtension.serializer.parseBody(bytes, pos + 2 + sigBytesCount)
-      new SerializedProverResult(proofBytes, ce) -> (2 + sigBytesCount + ceConsumed)
+      SerializedProverResult(proofBytes, ce) -> (2 + sigBytesCount + ceConsumed)
     }
   }
 }

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -11,7 +11,7 @@ import scorex.crypto.authds.ADDigest
 import scorex.crypto.hash.Digest32
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.interpreter.{ContextExtension, CryptoConstants}
+import sigmastate.interpreter.{ContextExtension, CryptoConstants, SerializedProverResult}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -42,6 +42,7 @@ trait ValueGenerators extends TypeGenerators {
   implicit val arbBoxCandidate = Arbitrary(ergoBoxCandidateGen)
   implicit val arbTransactionEmptyInputs  = Arbitrary(ergoTransactionEmptyInputsGen)
   implicit val arbContextExtension = Arbitrary(contextExtensionGen)
+  implicit val arbSerializedProverResult = Arbitrary(serializedProverResultGen)
 
   val byteConstGen: Gen[ByteConstant] = arbByte.arbitrary.map { v => ByteConstant(v) }
   val booleanConstGen: Gen[Value[SBoolean.type]] = Gen.oneOf(TrueLeaf, FalseLeaf)
@@ -131,6 +132,12 @@ trait ValueGenerators extends TypeGenerators {
   val contextExtensionGen: Gen[ContextExtension] = for {
     values <- Gen.sequence(contextExtensionValuesGen(0, 3))
   } yield ContextExtension(values.asScala.toMap)
+
+  val serializedProverResultGen: Gen[SerializedProverResult] = for {
+    length <- Gen.chooseNum(1, 100)
+    bytes <- Gen.listOfN(length, arbByte.arbitrary)
+    contextExt <- contextExtensionGen
+  } yield SerializedProverResult(bytes.toArray, contextExt)
 
   def avlTreeDataGen: Gen[AvlTreeData] = for {
     digest <- Gen.listOfN(32, arbByte.arbitrary).map(_.toArray)

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -1,7 +1,7 @@
 package sigmastate.serialization.generators
 
 import org.ergoplatform
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTransaction, UnsignedInput}
+import org.ergoplatform._
 import org.ergoplatform.ErgoBox._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Arbitrary, Gen}
@@ -44,6 +44,7 @@ trait ValueGenerators extends TypeGenerators {
   implicit val arbContextExtension = Arbitrary(contextExtensionGen)
   implicit val arbSerializedProverResult = Arbitrary(serializedProverResultGen)
   implicit val arbUnsignedInput = Arbitrary(unsignedInputGen)
+  implicit val arbInput = Arbitrary(inputGen)
 
   val byteConstGen: Gen[ByteConstant] = arbByte.arbitrary.map { v => ByteConstant(v) }
   val booleanConstGen: Gen[Value[SBoolean.type]] = Gen.oneOf(TrueLeaf, FalseLeaf)
@@ -147,6 +148,11 @@ trait ValueGenerators extends TypeGenerators {
   val unsignedInputGen: Gen[UnsignedInput] = for {
     boxId <- boxIdGen
   } yield new UnsignedInput(boxId)
+
+  val inputGen: Gen[Input] = for {
+    boxId <- boxIdGen
+    proof <- serializedProverResultGen
+  } yield Input(boxId, proof)
 
   def avlTreeDataGen: Gen[AvlTreeData] = for {
     digest <- Gen.listOfN(32, arbByte.arbitrary).map(_.toArray)

--- a/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
+++ b/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
@@ -1,6 +1,6 @@
 package sigmastate.utxo
 
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTransaction, UnsignedInput}
+import org.ergoplatform._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -55,5 +55,10 @@ class SerializationRoundTripSpec extends PropSpec
   property("UnsignedInput: Serializer round trip") {
     forAll { t: UnsignedInput => roundTripTest(t)(UnsignedInput.serializer) }
     forAll { t: UnsignedInput => roundTripTestWithPos(t)(UnsignedInput.serializer) }
+  }
+
+  property("Input: Serializer round trip") {
+    forAll { t: Input => roundTripTest(t)(Input.serializer) }
+    forAll { t: Input => roundTripTestWithPos(t)(Input.serializer) }
   }
 }

--- a/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
+++ b/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Assertion, Matchers, PropSpec}
-import sigmastate.interpreter.ContextExtension
+import sigmastate.interpreter.{ContextExtension, SerializedProverResult}
 import sigmastate.serialization.Serializer
 import sigmastate.serialization.generators.ValueGenerators
 
@@ -45,5 +45,10 @@ class SerializationRoundTripSpec extends PropSpec
   property("ContextExtension: Serializer round trip") {
     forAll { t: ContextExtension => roundTripTest(t)(ContextExtension.serializer) }
     forAll { t: ContextExtension => roundTripTestWithPos(t)(ContextExtension.serializer) }
+  }
+
+  property("SerializedProverResult: Serializer round trip") {
+    forAll { t: SerializedProverResult => roundTripTest(t)(SerializedProverResult.serializer) }
+    forAll { t: SerializedProverResult => roundTripTestWithPos(t)(SerializedProverResult.serializer) }
   }
 }

--- a/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
+++ b/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Assertion, Matchers, PropSpec}
+import sigmastate.interpreter.ContextExtension
 import sigmastate.serialization.Serializer
 import sigmastate.serialization.generators.ValueGenerators
 
@@ -39,5 +40,10 @@ class SerializationRoundTripSpec extends PropSpec
   property("ErgoTransaction: Serializer round trip") {
     forAll { t: ErgoTransaction => roundTripTest(t)(ErgoTransaction.serializer) }
     forAll { t: ErgoTransaction => roundTripTestWithPos(t)(ErgoTransaction.serializer) }
+  }
+
+  property("ContextExtension: Serializer round trip") {
+    forAll { t: ContextExtension => roundTripTest(t)(ContextExtension.serializer) }
+    forAll { t: ContextExtension => roundTripTestWithPos(t)(ContextExtension.serializer) }
   }
 }

--- a/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
+++ b/src/test/scala/sigmastate/utxo/SerializationRoundTripSpec.scala
@@ -1,6 +1,6 @@
 package sigmastate.utxo
 
-import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTransaction}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoTransaction, UnsignedInput}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -50,5 +50,10 @@ class SerializationRoundTripSpec extends PropSpec
   property("SerializedProverResult: Serializer round trip") {
     forAll { t: SerializedProverResult => roundTripTest(t)(SerializedProverResult.serializer) }
     forAll { t: SerializedProverResult => roundTripTestWithPos(t)(SerializedProverResult.serializer) }
+  }
+
+  property("UnsignedInput: Serializer round trip") {
+    forAll { t: UnsignedInput => roundTripTest(t)(UnsignedInput.serializer) }
+    forAll { t: UnsignedInput => roundTripTestWithPos(t)(UnsignedInput.serializer) }
   }
 }


### PR DESCRIPTION
#128 
Todo:
- [x] `ContextExtension.serializer`;
- [x] `SerializedProverResult.serializer`;
- [x] `UnsignedInput.serializer`;
- [x] `Input.serializer`;
- [x] add inputs in transaction generator;