### PR TITLE
Eliminate implicit parameters in case classes to avoid implementing `equals()`/ `hashCode()`

### DIFF
--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -402,7 +402,7 @@ object Values {
     lazy val value = None
   }
 
-  case class ConcreteCollection[V <: SType](items: IndexedSeq[Value[V]])(implicit val elementType: V)
+  case class ConcreteCollection[V <: SType](items: IndexedSeq[Value[V]], elementType: V)
     extends EvaluatedCollection[V] with Rewritable {
     override val opCode: OpCode = ConcreteCollectionCode
 
@@ -420,13 +420,17 @@ object Values {
     def deconstruct = immutable.Seq[Any](elementType) ++ items
 
     def reconstruct(cs: immutable.Seq[Any]) = cs match {
-      case Seq(t: SType, vs@_*) => ConcreteCollection[SType](vs.asInstanceOf[Seq[Value[V]]].toIndexedSeq)(t)
+      case Seq(t: SType, vs@_*) => new ConcreteCollection[SType](vs.asInstanceOf[Seq[Value[V]]].toIndexedSeq, t)
       case _ =>
         illegalArgs("ConcreteCollection", "(IndexedSeq, SType)", cs)
     }
   }
   object ConcreteCollection {
-    def apply[V <: SType](items: Value[V]*)(implicit tV: V) = new ConcreteCollection(items.toIndexedSeq)
+    def apply[V <: SType](items: Value[V]*)(implicit tV: V) =
+      new ConcreteCollection(items.toIndexedSeq, tV)
+
+    def apply[V <: SType](items: => Seq[Value[V]])(implicit tV: V) =
+      new ConcreteCollection(items.toIndexedSeq, tV)
   }
 
   trait LazyCollection[V <: SType] extends NotReadyValue[SCollection[V]]

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -403,7 +403,7 @@ object Values {
   }
 
   case class ConcreteCollection[V <: SType](items: IndexedSeq[Value[V]], elementType: V)
-    extends EvaluatedCollection[V] with Rewritable {
+    extends EvaluatedCollection[V] {
     override val opCode: OpCode = ConcreteCollectionCode
 
     def cost[C <: Context[C]](context: C): Long = Cost.ConcreteCollection + items.map(_.cost(context)).sum
@@ -416,14 +416,6 @@ object Values {
     }
 
     def arity = 1 + items.size
-
-    def deconstruct = immutable.Seq[Any](elementType) ++ items
-
-    def reconstruct(cs: immutable.Seq[Any]) = cs match {
-      case Seq(t: SType, vs@_*) => new ConcreteCollection[SType](vs.asInstanceOf[Seq[Value[V]]].toIndexedSeq, t)
-      case _ =>
-        illegalArgs("ConcreteCollection", "(IndexedSeq, SType)", cs)
-    }
   }
   object ConcreteCollection {
     def apply[V <: SType](items: Value[V]*)(implicit tV: V) =

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -77,11 +77,11 @@ class SigmaBinder(env: Map[String, Any]) {
       Some(ByIndex(obj.asValue[SCollection[SType]], i.toInt))
 
     // Rule: allOf(Array(...)) --> AND(...)
-    case Apply(AllSym, Seq(ConcreteCollection(args: Seq[Value[SBoolean.type]]@unchecked))) =>
+    case Apply(AllSym, Seq(ConcreteCollection(args: Seq[Value[SBoolean.type]]@unchecked, _))) =>
       Some(AND(args))
 
     // Rule: anyOf(Array(...)) --> OR(...)
-    case Apply(AnySym, Seq(ConcreteCollection(args: Seq[Value[SBoolean.type]]@unchecked))) =>
+    case Apply(AnySym, Seq(ConcreteCollection(args: Seq[Value[SBoolean.type]]@unchecked, _))) =>
       Some(OR(args))
 
     // Rule: allOf(arr) --> AND(arr)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -54,7 +54,7 @@ class SigmaTyper {
 
     case Tuple(items) => Tuple(items.map(assignType(env, _)))
 
-    case c @ ConcreteCollection(items) =>
+    case c @ ConcreteCollection(items, _) =>
       val newItems = items.map(assignType(env, _))
       val types = newItems.map(_.tpe).distinct
       val tItem = if (items.isEmpty) {

--- a/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/src/main/scala/sigmastate/utxo/transformers.scala
@@ -77,7 +77,7 @@ case class Append[IV <: SType](input: Value[SCollection[IV]], col2: Value[SColle
   override def transformationReady: Boolean = input.isEvaluated && col2.isEvaluated
 
   override def function(cl: EvaluatedValue[SCollection[IV]]): Value[SCollection[IV]] = (cl, col2) match {
-    case (ConcreteCollection(items), ConcreteCollection(items2)) =>
+    case (ConcreteCollection(items, _), ConcreteCollection(items2, _)) =>
       ConcreteCollection(items ++ items2)(tpe.elemType)
 
     case (CollectionConstant(arr, t1), CollectionConstant(arr2, t2)) =>
@@ -86,11 +86,11 @@ case class Append[IV <: SType](input: Value[SCollection[IV]], col2: Value[SColle
       val newArr = Helpers.concatArrays(Seq(arr, arr2))(t1.classTag)
       CollectionConstant(newArr, t1)
 
-    case (CollectionConstant(arr, t1), arr2 @ ConcreteCollection(_)) =>
+    case (CollectionConstant(arr, t1), arr2 @ ConcreteCollection(_, _)) =>
       val newArr = Helpers.concatArrays(Seq(arr, arr2.value))(t1.classTag)
       CollectionConstant(newArr, t1)
 
-    case (arr @ ConcreteCollection(_), CollectionConstant(arr2, t2)) =>
+    case (arr @ ConcreteCollection(_, _), CollectionConstant(arr2, t2)) =>
       val newArr = Helpers.concatArrays(Seq(arr.value, arr2))(t2.classTag)
       CollectionConstant(newArr, t2)
 

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -309,7 +309,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  indexCollection.forall(elementRule)
          }""".stripMargin
 
-    val indexCollection = new ConcreteCollection((0 until 6).map(i => LongConstant(i)))
+    val indexCollection = ConcreteCollection((0 until 6).map(i => LongConstant(i)))
     val indexId = 21.toByte
     val index = TaggedInt(indexId)
     val boundaryIndex = If(EQ(index, 0), 5, Minus(index, 1))
@@ -333,8 +333,8 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  indexCollection.forall(elementRule)
          }""".stripMargin
 
-    val indexCollection = new ConcreteCollection((0 until 6).map(i => LongConstant(i)))
-    val string = new ConcreteCollection(Array(1, 1, 0, 0, 0, 1).map(i => LongConstant(i)))
+    val indexCollection = ConcreteCollection((0 until 6).map(i => LongConstant(i)))
+    val string = ConcreteCollection(Array(1, 1, 0, 0, 0, 1).map(i => LongConstant(i)))
     val indexId = 21.toByte
     val index = TaggedInt(indexId)
     val element = ByIndex(string, If(LE(index, 0), 5, Minus(index, 1)))


### PR DESCRIPTION
Closes #111 