### PR TITLE
Add optional default value to `ByIndex` (new)

### DIFF
--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -88,7 +88,7 @@ class SigmaSpecializer {
         case (box, SBox.Id) => Some(ExtractId(box))
         case (box, SBox.Bytes) => Some(ExtractBytes(box))
         case (box, SBox.BytesWithNoRef) => Some(ExtractBytesWithNoRef(box))
-        case (box, _) if box.tpe.hasField(field) =>
+        case (box, _) if box.tpe.hasMethod(field) =>
           None  // leave it as it is and handle on a level of parent node
         case _ => error(s"Invalid access to Box property in $sel: field $field is not found")
       }

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -131,6 +131,11 @@ class SigmaSpecializer {
       val body1 = eval(env ++ Seq(zeroArg -> taggedZero, opArg -> taggedOp), body)
       Some(Fold(col.asValue[SCollection[SType]], taggedZero.varId, zero, taggedOp.varId, body1))
 
+    case Apply(Select(col,"getOrElse", _), Seq(index, defaultValue)) =>
+      val index1 = eval(env, index).asValue[SInt.type]
+      val defaultValue1 = eval(env, defaultValue).asValue[SType]
+      Some(ByIndex(col.asValue[SCollection[SType]], index1, Some(defaultValue1)))
+
     case opt: OptionValue[_] =>
       error(s"Option values are not supported: $opt")
 

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -150,30 +150,13 @@ class SigmaTyper {
           args match {
             case Seq(Constant(index, _: SNumericType)) =>
               ByIndex[SType](new_f.asCollection, SInt.upcast(index.asInstanceOf[AnyVal]), None)
-            case Seq(Constant(index, _: SNumericType), dvConst@Constant(_, dvtpe)) =>
-              if (dvtpe == elemType)
-                ByIndex[SType](new_f.asCollection, SInt.upcast(index.asInstanceOf[AnyVal]), Some(dvConst))
-              else
-                error(s"Invalid default value(const) type in array application $app: expected collection element type; actual: $dvtpe")
             case Seq(index) =>
               val typedIndex = assignType(env, index)
               typedIndex.tpe match {
                 case _: SNumericType =>
                   ByIndex[SType](new_f.asCollection, typedIndex.upcastTo(SInt), None)
                 case _ =>
-                  error(s"Invalid argument type of array application(w/o default value) $app: expected numeric type; actual: ${typedIndex.tpe}")
-              }
-            case Seq(index, defVal) =>
-              val typedIndex = assignType(env, index)
-              val typedDefVal = assignType(env, defVal)
-              (typedIndex.tpe, typedDefVal.tpe) match {
-                case (_: SNumericType, dvtpe) =>
-                  if (dvtpe == elemType)
-                    ByIndex[SType](new_f.asCollection, typedIndex.upcastTo(SInt), Some(typedDefVal))
-                  else
-                    error(s"Invalid default value(expr) type in array application $app: expected array element type; actual: ${typedDefVal.tpe}")
-                case _ =>
-                  error(s"Invalid argument type of array application(with default value) $app: expected numeric type; actual: ${typedIndex.tpe}")
+                  error(s"Invalid argument type of array application $app: expected numeric type; actual: ${typedIndex.tpe}")
               }
             case _ =>
               error(s"Invalid argument of array application $app: expected integer value; actual: $args")

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -264,11 +264,15 @@ class SigmaTyper {
         error(s"Invalid binary operation Exponentiate: expected argument types ($SGroupElement, $SBigInt); actual: (${l.tpe}, ${r.tpe})")
       Exponentiate(l1, r1)
 
-    case ByIndex(col, i, default) =>
+    case ByIndex(col, i, defaultValue) =>
       val c1 = assignType(env, col).asCollection[SType]
       if (!c1.tpe.isCollection)
         error(s"Invalid operation ByIndex: expected argument types ($SCollection); actual: (${col.tpe})")
-      ByIndex(c1, i, default)
+      defaultValue match {
+        case Some(v) if v.tpe.typeCode != c1.tpe.elemType.typeCode =>
+            error(s"Invalid operation ByIndex: expected default value type (${c1.tpe.elemType}); actual: (${v.tpe})")
+        case ref @ _ => ByIndex(c1, i, ref)
+      }
 
     case SizeOf(col) =>
       val c1 = assignType(env, col).asCollection[SType]

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -264,11 +264,11 @@ class SigmaTyper {
         error(s"Invalid binary operation Exponentiate: expected argument types ($SGroupElement, $SBigInt); actual: (${l.tpe}, ${r.tpe})")
       Exponentiate(l1, r1)
 
-    case ByIndex(col, i) =>
+    case ByIndex(col, i, default) =>
       val c1 = assignType(env, col).asCollection[SType]
       if (!c1.tpe.isCollection)
         error(s"Invalid operation ByIndex: expected argument types ($SCollection); actual: (${col.tpe})")
-      ByIndex(c1, i)
+      ByIndex(c1, i, default)
 
     case SizeOf(col) =>
       val c1 = assignType(env, col).asCollection[SType]

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -87,11 +87,11 @@ class SigmaTyper {
       val newObj = assignType(env, obj)
       newObj.tpe match {
         case s: SProduct =>
-          val iField = s.fieldIndex(n)
+          val iField = s.methodIndex(n)
           val tRes = if (iField != -1) {
-            s.fields(iField)._2
+            s.methods(iField).stype
           } else
-            error(s"Cannot find field '$n' in in the object $obj of Product type with fields ${s.fields}")
+            error(s"Cannot find method '$n' in in the object $obj of Product type with methods ${s.methods}")
           Select(newObj, n, Some(tRes))
         case t =>
           error(s"Cannot get field '$n' in in the object $obj of non-product type $t")
@@ -398,8 +398,8 @@ object SigmaTyper {
       unifyTypeLists(args1, args2)
     case (SPrimType(e1), SPrimType(e2)) if e1 == e2 =>
       Some(Map())
-    case (e1: SProduct, e2: SProduct) if e1.sameFields(e2) =>
-      unifyTypeLists(e1.fields.map(_._2), e2.fields.map(_._2))
+    case (e1: SProduct, e2: SProduct) if e1.sameMethods(e2) =>
+      unifyTypeLists(e1.methods.map(_.stype), e2.methods.map(_.stype))
     case _ => None
   }
 

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -42,9 +42,9 @@ object Terms {
     override def evaluated: Boolean = ???
     val tpe: SType = resType.getOrElse(obj.tpe match {
       case p: SProduct =>
-        val i = p.fieldIndex(field)
+        val i = p.methodIndex(field)
         if (i == -1) NoType
-        else p.fields(i)._2
+        else p.methods(i).stype
       case _ => NoType
     })
   }

--- a/src/main/scala/sigmastate/serialization/transformers/ByIndexSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/transformers/ByIndexSerializer.scala
@@ -2,23 +2,29 @@ package sigmastate.serialization.transformers
 
 import sigmastate.Values.Value
 import sigmastate.serialization.OpCodes.OpCode
-import sigmastate.serialization.Serializer.{Position, Consumed}
-import sigmastate.serialization.{ValueSerializer, OpCodes}
+import sigmastate.serialization.Serializer.{Consumed, Position}
+import sigmastate.serialization.{OpCodes, Serializer, ValueSerializer}
 import sigmastate.utxo.ByIndex
-import sigmastate.{SCollection, SType, SInt}
+import sigmastate.{SCollection, SInt, SType}
 
 object ByIndexSerializer extends ValueSerializer[ByIndex[SType]] {
 
   override val opCode: OpCode = OpCodes.ByIndexCode
 
   override def parseBody(bytes: Array[Byte], pos: Position): (ByIndex[SType], Consumed) = {
-    val (input, c1) = ValueSerializer.deserialize(bytes, pos)
-    val (index, c2) = ValueSerializer.deserialize(bytes, pos + c1)
-    ByIndex(input.asInstanceOf[Value[SCollection[SType]]],
-      index.asInstanceOf[Value[SInt.type]]) -> (c1 + c2)
+    val r = Serializer.startReader(bytes, pos)
+    val input = r.getValue().asInstanceOf[Value[SCollection[SType]]]
+    val index = r.getValue().asInstanceOf[Value[SInt.type ]]
+    val default = r.getOption(r.getValue())
+    val res = ByIndex(input, index, default)
+    res -> r.consumed
   }
 
-  override def serializeBody(obj: ByIndex[SType]): Array[Byte] = {
-    ValueSerializer.serialize(obj.input) ++ ValueSerializer.serialize(obj.index)
-  }
+  override def serializeBody(obj: ByIndex[SType]): Array[Byte] =
+    Serializer.startWriter()
+      .putValue(obj.input)
+      .putValue(obj.index)
+      .putOption(obj.default)(_.putValue(_))
+      .toBytes
+
 }

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -367,6 +367,7 @@ object SCollection {
   private val tOV = STypeIdent("OV")
   val fields = Seq(
     "size" -> SInt,
+    "getOrElse" -> SFunc(IndexedSeq(SCollection(tIV), SInt, tIV), tIV, Seq(tIV)),
     "map" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, tOV)), SCollection(tOV), Seq(tIV, tOV)),
     "exists" -> SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(tIV)),
     "fold" -> SFunc(IndexedSeq(SCollection(tIV), tIV, SFunc(IndexedSeq(tIV, tIV), tIV)), tIV, Seq(tIV)),

--- a/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/src/main/scala/sigmastate/utxo/transformers.scala
@@ -221,7 +221,9 @@ object Fold {
   }
 }
 
-case class ByIndex[V <: SType](input: Value[SCollection[V]], index: Value[SInt.type])
+case class ByIndex[V <: SType](input: Value[SCollection[V]],
+                               index: Value[SInt.type],
+                               default: Option[Value[V]] = None)
   extends Transformer[SCollection[V], V] with NotReadyValue[V] {
   override val opCode: OpCode = OpCodes.ByIndexCode
   override val tpe = input.tpe.elemType

--- a/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/src/main/scala/sigmastate/utxo/transformers.scala
@@ -225,8 +225,12 @@ case class ByIndex[V <: SType](input: Value[SCollection[V]], index: Value[SInt.t
   extends Transformer[SCollection[V], V] with NotReadyValue[V] {
   override val opCode: OpCode = OpCodes.ByIndexCode
   override val tpe = input.tpe.elemType
+  // todo account for default value
   override def transformationReady: Boolean = input.isEvaluated && index.evaluated
 
+  // todo restore default value application
+  // input.items.lift(index.asInstanceOf[EvaluatedValue[SInt.type]].value.toInt)
+  //      .orElse(default).get
   override def function(intr: Interpreter, ctx: Context[_], input: EvaluatedValue[SCollection[V]]): Value[V] = {
     val i = index.asInstanceOf[EvaluatedValue[SInt.type]].value
     input.matchCase(

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -160,11 +160,11 @@ class TestingInterpreterSpecification extends PropSpec
   }
 
   property("Array indexing (out of bounds with const default value)") {
-    testeval("Array(1, 2)(3, 0) == 0")
+    testeval("Array(1, 2).getOrElse(3, 0) == 0")
   }
 
   property("Array indexing (out of bounds with evaluated default value)") {
-    testeval("Array(1, 1)(3, 1 + 1) == 2")
+    testeval("Array(1, 1).getOrElse(3, 1 + 1) == 2")
   }
 
   property("Evaluation example #1") {

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -159,6 +159,9 @@ class TestingInterpreterSpecification extends PropSpec
     testeval("5 % 2 == 1")
   }
 
+  property("Array indexing (out of bounds with default value)") {
+    testeval("Array(1, 2)(3, 0) == 0")
+  }
   property("Evaluation example #1") {
     val dk1 = ProveDlog(secrets(0).publicImage.h)
     val dk2 = ProveDlog(secrets(1).publicImage.h)

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -159,9 +159,14 @@ class TestingInterpreterSpecification extends PropSpec
     testeval("5 % 2 == 1")
   }
 
-  property("Array indexing (out of bounds with default value)") {
+  property("Array indexing (out of bounds with const default value)") {
     testeval("Array(1, 2)(3, 0) == 0")
   }
+
+  property("Array indexing (out of bounds with evaluated default value)") {
+    testeval("Array(1, 1)(3, 1 + 1) == 2")
+  }
+
   property("Evaluation example #1") {
     val dk1 = ProveDlog(secrets(0).publicImage.h)
     val dk2 = ProveDlog(secrets(1).publicImage.h)

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -114,20 +114,6 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
       SomeValue(SomeValue(Plus(Ident("X").asValue[SInt.type], IntConstant(1))))
   }
 
-  // todo move after the indexed access
-  property("array indexed access with default value") {
-    bind(env, "Array(1)(0, 1)") shouldBe
-      ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0, Some(IntConstant(1)))
-
-    bind(env, "Array(Array(1))(0, Array(2))(0)") shouldBe
-      ByIndex(
-        ByIndex(
-          ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)),
-          0,
-          Some(ConcreteCollection(Vector(IntConstant(2))))),
-        0)
-  }
-
   property("lambdas") {
     bind(env, "fun (a: Int) = a + 1") shouldBe
       Lambda(IndexedSeq("a" -> SInt), NoType, Plus(IntIdent("a"), 1))

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -114,6 +114,20 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
       SomeValue(SomeValue(Plus(Ident("X").asValue[SInt.type], IntConstant(1))))
   }
 
+  // todo move after the indexed access
+  property("array indexed access with default value") {
+    bind(env, "Array(1)(0, 1)") shouldBe
+      ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0, Some(IntConstant(1)))
+
+    bind(env, "Array(Array(1))(0, Array(2))(0)") shouldBe
+      ByIndex(
+        ByIndex(
+          ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)),
+          0,
+          Some(ConcreteCollection(Vector(IntConstant(2))))),
+        0)
+  }
+
   property("lambdas") {
     bind(env, "fun (a: Int) = a + 1") shouldBe
       Lambda(IndexedSeq("a" -> SInt), NoType, Plus(IntIdent("a"), 1))

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -36,6 +36,19 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
         ByIndex(ByIndex(ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)), 0), 0)
   }
 
+  property("array indexed access with default value") {
+    comp(env, "Array(1)(0, 1)") shouldBe
+      ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0, Some(IntConstant(1)))
+
+    comp(env, "Array(Array(1))(0, Array(2))(0)") shouldBe
+      ByIndex(
+        ByIndex(
+          ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)),
+          0,
+          Some(ConcreteCollection(Vector(IntConstant(2))))),
+        0)
+  }
+
   property("predefined functions") {
     comp(env, "anyOf(Array(c1, c2))") shouldBe OR(ConcreteCollection(Vector(TrueLeaf, FalseLeaf)))
     comp(env, "blake2b256(getVar[Array[Byte]](10))") shouldBe CalcBlake2b256(TaggedVariable(10, SByteArray))

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -31,15 +31,16 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
   }
 
   property("array indexed access") {
-    comp(env, "Array(1)(0)") shouldBe ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0)
+    comp(env, "Array(1)(0)") shouldBe
+      ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0)
     comp(env, "Array(Array(1))(0)(0)") shouldBe
         ByIndex(ByIndex(ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)), 0), 0)
+    comp(env, "arr1(0)") shouldBe ByIndex(ByteArrayConstant(Array(1, 2)), 0)
   }
 
   property("array indexed access with default value") {
     comp(env, "Array(1)(0, 1)") shouldBe
       ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0, Some(IntConstant(1)))
-
     comp(env, "Array(Array(1))(0, Array(2))(0)") shouldBe
       ByIndex(
         ByIndex(
@@ -47,6 +48,8 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
           0,
           Some(ConcreteCollection(Vector(IntConstant(2))))),
         0)
+    comp(env, "arr1(999, intToByte(0))") shouldBe
+      ByIndex(ByteArrayConstant(Array(1, 2)), IntConstant(999), Some(IntToByte(IntConstant(0))))
   }
 
   property("predefined functions") {

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -39,16 +39,16 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
   }
 
   property("array indexed access with default value") {
-    comp(env, "Array(1)(0, 1)") shouldBe
+    comp(env, "Array(1).getOrElse(0, 1)") shouldBe
       ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0, Some(IntConstant(1)))
-    comp(env, "Array(Array(1))(0, Array(2))(0)") shouldBe
+    comp(env, "Array(Array(1)).getOrElse(0, Array(2))(0)") shouldBe
       ByIndex(
         ByIndex(
           ConcreteCollection(IndexedSeq(ConcreteCollection(IndexedSeq(IntConstant(1)))))(SCollection(SInt)),
           0,
           Some(ConcreteCollection(Vector(IntConstant(2))))),
         0)
-    comp(env, "arr1(999, intToByte(0))") shouldBe
+    comp(env, "arr1.getOrElse(999, intToByte(0))") shouldBe
       ByIndex(ByteArrayConstant(Array(1, 2)), IntConstant(999), Some(IntToByte(IntConstant(0))))
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -223,6 +223,15 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("Array()(0)(0)") shouldBe Apply(Apply(Apply(Ident("Array"), IndexedSeq.empty), IndexedSeq(IntConstant(0))), IndexedSeq(IntConstant(0)))
   }
 
+  property("array indexed access with default values") {
+    parse("Array()(0, 1)") shouldBe
+      Apply(Apply(Ident("Array"), IndexedSeq.empty), IndexedSeq(IntConstant(0), IntConstant(1)))
+    parse("Array()(0, 1)(0)") shouldBe
+      Apply(Apply(Apply(Ident("Array"), IndexedSeq.empty),
+        IndexedSeq(IntConstant(0), IntConstant(1))),
+        IndexedSeq(IntConstant(0)))
+  }
+
   property("generic methods of arrays") {
     parse("OUTPUTS.map(fun (out: Box) = out.value)") shouldBe
       Apply(Select(Ident("OUTPUTS"), "map"),

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -159,13 +159,15 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   property("array indexed access with evaluation") {
     typecheck(env, "Array(0)(1 - 1)") shouldBe SInt
     typecheck(env, "Array(0)((1 - 1) + 0)") shouldBe SInt
-    typefail(env, "Array(0)(0 == 0)", "Invalid argument type")
+    typefail(env, "Array(0)(0 == 0)", "Invalid argument type of array application(w/o default value) ")
     typefail(env, "Array(0)(1,1,1)", "Invalid argument of array application")
   }
 
   property("array indexed access with default value") {
     typecheck(env, "Array(0)(0, 1)") shouldBe SInt
-    typefail(env, "Array(0)(0, Array(1))", "expected default value type")
+    typefail(env, "Array(0)(true, 1)", "Invalid argument type of array application(with default value)")
+    typefail(env, "Array(true)(0, 1)", "Invalid default value(const) type")
+    typefail(env, "Array(0)(0, Array(1))", "Invalid default value(expr) type")
   }
 
   property("array indexed access with default value with evaluation") {

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -168,6 +168,10 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typefail(env, "Array(0)(0, Array(1))", "expected default value type")
   }
 
+  property("array indexed access with default value with evaluation") {
+    typecheck(env, "Array(0)(0, (2 - 1) + 0)") shouldBe SInt
+  }
+
   property("lambdas") {
     typecheck(env, "fun (a: Int) = a + 1") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "fun (a: Int): Int = a + 1") shouldBe SFunc(IndexedSeq(SInt), SInt)

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -163,6 +163,11 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typefail(env, "Array(0)(1,1,1)", "Invalid argument of array application")
   }
 
+  property("array indexed access with default value") {
+    typecheck(env, "Array(0)(0, 1)") shouldBe SInt
+    typefail(env, "Array(0)(0, Array(1))", "expected default value type")
+  }
+
   property("lambdas") {
     typecheck(env, "fun (a: Int) = a + 1") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "fun (a: Int): Int = a + 1") shouldBe SFunc(IndexedSeq(SInt), SInt)

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -159,19 +159,19 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   property("array indexed access with evaluation") {
     typecheck(env, "Array(0)(1 - 1)") shouldBe SInt
     typecheck(env, "Array(0)((1 - 1) + 0)") shouldBe SInt
-    typefail(env, "Array(0)(0 == 0)", "Invalid argument type of array application(w/o default value) ")
+    typefail(env, "Array(0)(0 == 0)", "Invalid argument type of array application")
     typefail(env, "Array(0)(1,1,1)", "Invalid argument of array application")
   }
 
   property("array indexed access with default value") {
-    typecheck(env, "Array(0)(0, 1)") shouldBe SInt
-    typefail(env, "Array(0)(true, 1)", "Invalid argument type of array application(with default value)")
-    typefail(env, "Array(true)(0, 1)", "Invalid default value(const) type")
-    typefail(env, "Array(0)(0, Array(1))", "Invalid default value(expr) type")
+    typecheck(env, "Array(0).getOrElse(0, 1)") shouldBe SInt
+    typefail(env, "Array(0).getOrElse(true, 1)", "Invalid argument type of application")
+    typefail(env, "Array(true).getOrElse(0, 1)", "Invalid argument type of application")
+    typefail(env, "Array(0).getOrElse(0, Array(1))", "Invalid argument type of application")
   }
 
   property("array indexed access with default value with evaluation") {
-    typecheck(env, "Array(0)(0, (2 - 1) + 0)") shouldBe SInt
+    typecheck(env, "Array(0).getOrElse(0, (2 - 1) + 0)") shouldBe SInt
   }
 
   property("lambdas") {

--- a/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
@@ -102,9 +102,10 @@ trait TransformerGenerators {
   val calcSha256Gen: Gen[CalcSha256] = arbByteArrayConstant.arbitrary.map { v => CalcSha256(v) }
 
   val byIndexGen: Gen[ByIndex[SInt.type]] = for {
-    input <- arbCCOfIntConstant.arbitrary
+    input <- Gen.oneOf(intConstCollectionGen, intArrayConstGen)
     index <- arbInt.arbitrary
-  } yield ByIndex(input, index)
+    defaultValue <- arbOption(arbIntConstants).arbitrary
+  } yield ByIndex(input, index, defaultValue)
 
   val booleanExprGen: Gen[Value[SBoolean.type]] =
     Gen.oneOf(

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -57,6 +57,10 @@ trait ValueGenerators extends TypeGenerators {
     length <- Gen.chooseNum(1, 100)
     bytes <- Gen.listOfN(length, arbByte.arbitrary)
   } yield ByteArrayConstant(bytes.toArray)
+  val intArrayConstGen: Gen[CollectionConstant[SInt.type]] = for {
+    length <- Gen.chooseNum(1, 100)
+    ints <- Gen.listOfN(length, arbInt.arbitrary)
+  } yield IntArrayConstant(ints.toArray)
   val groupElementConstGen: Gen[GroupElementConstant] = for {
     _ <- Gen.const(1)
     el = CryptoConstants.dlogGroup.createRandomGenerator()

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -284,7 +284,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map(fun (box: Box): Long = box.value)(3, 0L)== 0""".stripMargin
+        |.map(fun (box: Box): Long = box.value).getOrElse(3, 0L)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
         MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),
@@ -296,7 +296,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
   property("by index with evaluated default value") {
     val outputBoxValues = IndexedSeq(20L, 0L)
-    val code = "OUTPUTS(3, OUTPUTS(0)).value == 20"
+    val code = "OUTPUTS.getOrElse(3, OUTPUTS(0)).value == 20"
     val expectedPropTree = EQ(
       ExtractAmount(
         ByIndex(Outputs,

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -280,6 +280,20 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     assertProof(code, expectedPropTree, outputBoxValues)
   }
 
+  property("by index with default value") {
+    val outputBoxValues = IndexedSeq(10L, 10L)
+    val code =
+      """OUTPUTS
+        |.map(fun (box: Box) = box.value)(3, 0)== 0""".stripMargin
+    val expectedPropTree = EQ(
+      ByIndex(
+        MapCollection(Outputs,21,ExtractAmount(TaggedBox(21)))(SInt),
+        IntConstant(3),
+        Some(IntConstant(0))),
+      IntConstant(0))
+    assertProof(code, expectedPropTree, outputBoxValues)
+  }
+
   property("map fold") {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -287,7 +287,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |.map(fun (box: Box) = box.value)(3, 0)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
-        MapCollection(Outputs,21,ExtractAmount(TaggedBox(21)))(SInt),
+        MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),
         IntConstant(3),
         Some(IntConstant(0))),
       IntConstant(0))

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -284,13 +284,25 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map(fun (box: Box) = box.value)(3, 0)== 0""".stripMargin
+        |.map(fun (box: Box): Long = box.value)(3, 0L)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
         MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),
         IntConstant(3),
-        Some(IntConstant(0))),
-      IntConstant(0))
+        Some(LongConstant(0))),
+      LongConstant(0))
+    assertProof(code, expectedPropTree, outputBoxValues)
+  }
+
+  property("by index with evaluated default value") {
+    val outputBoxValues = IndexedSeq(20L, 0L)
+    val code = "OUTPUTS(3, OUTPUTS(0)).value == 20"
+    val expectedPropTree = EQ(
+      ExtractAmount(
+        ByIndex(Outputs,
+          IntConstant(3),
+          Some(ByIndex(Outputs, IntConstant(0))))),
+      LongConstant(20))
     assertProof(code, expectedPropTree, outputBoxValues)
   }
 


### PR DESCRIPTION
Continue from the #127 
Closes #99
Todo:
- [x] fixes after rebase;
- [x] cover all code paths (const/value) in typer;
- [x] update `ByIndex.function/cost/transformationReady`  to use an optional default value;
- [x] update (de)serialization;
- [x] revert changes to `SigmaTyper`;
- [x] implement new syntax;
- [x] rename `SProduct.fields` to `methods` and switch from tuple to a case class;