### PR TITLE
Fix parallel test execution in sbt

### DIFF
--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -257,7 +257,7 @@ object Values {
     }
   }
 
-  val ByteArrayTypeCode = (SCollection.CollectionTypeCode + SByte.typeCode).toByte
+  val ByteArrayTypeCode = (SCollectionType.CollectionTypeCode + SByte.typeCode).toByte
 
   object ByteArrayConstant {
     def apply(value: Array[Byte]): CollectionConstant[SByte.type] = CollectionConstant[SByte.type](value, SByte)
@@ -303,7 +303,7 @@ object Values {
     }
   }
 
-  val BoolArrayTypeCode = (SCollection.CollectionTypeCode + SBoolean.typeCode).toByte
+  val BoolArrayTypeCode = (SCollectionType.CollectionTypeCode + SBoolean.typeCode).toByte
 
   object BoolArrayConstant {
     def apply(value: Array[Boolean]): CollectionConstant[SBoolean.type] = CollectionConstant[SBoolean.type](value, SBoolean)

--- a/src/main/scala/sigmastate/serialization/TypeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TypeSerializer.scala
@@ -6,6 +6,8 @@ import sigmastate.utils.{ByteWriter, ByteReader}
 /** Serialization of types according to specification in TypeSerialization.md. */
 object TypeSerializer extends ByteBufferSerializer[SType] {
 
+  import sigmastate.SCollectionType._
+
   /** The list of embeddable types, i.e. types that can be combined with type constructor for optimized encoding.
     * For each embeddable type `T`, and type constructor `C`, the type `C[T]` can be represented by single byte. */
   val embeddableIdToType = Array[SType](null, SBoolean, SByte, SShort, SInt, SLong, SBigInt, SGroupElement)
@@ -24,18 +26,18 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
     case SAvlTree => w.put(SAvlTree.typeCode)
     case c: SCollectionType[a] => c.elemType match {
       case p: SEmbeddable =>
-        val code = p.embedIn(SCollection.CollectionTypeCode)
+        val code = p.embedIn(CollectionTypeCode)
         w.put(code)
       case cn: SCollectionType[a] => cn.elemType match {
         case p: SEmbeddable =>
-          val code = p.embedIn(SCollection.NestedCollectionTypeCode)
+          val code = p.embedIn(NestedCollectionTypeCode)
           w.put(code)
         case t =>
-          w.put(SCollection.CollectionTypeCode)
+          w.put(CollectionTypeCode)
           serialize(cn, w)
       }
       case t =>
-        w.put(SCollection.CollectionTypeCode)
+        w.put(CollectionTypeCode)
         serialize(t, w)
     }
     case o: SOption[a] => o.elemType match {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -308,7 +308,7 @@ case object SGroupElement extends SProduct with SPrimType with SEmbeddable {
   def ancestors = Nil
   val methods = Seq(
     SMethod("isIdentity", SBoolean),
-    SMethod("nonce", SByteArray)
+    SMethod("nonce", SCollectionType(SByte))
   )
 }
 
@@ -340,10 +340,10 @@ case object SBox extends SProduct with SPredefType {
   val BytesWithNoRef = "bytesWithNoRef"
   val methods = Vector(
     SMethod(Value, SLong), // see ExtractAmount
-    SMethod(PropositionBytes, SByteArray), // see ExtractScriptBytes
-    SMethod(Bytes, SByteArray), // see ExtractBytes
-    SMethod(BytesWithNoRef, SByteArray), // see ExtractBytesWithNoRef
-    SMethod(Id, SByteArray) // see ExtractId
+    SMethod(PropositionBytes, SCollectionType(SByte)), // see ExtractScriptBytes
+    SMethod(Bytes, SCollectionType(SByte)), // see ExtractBytes
+    SMethod(BytesWithNoRef, SCollectionType(SByte)), // see ExtractBytesWithNoRef
+    SMethod(Id, SCollectionType(SByte)) // see ExtractId
   ) ++ registers()
 }
 
@@ -366,7 +366,7 @@ trait SCollection[T <: SType] extends SProduct {
 }
 
 case class SCollectionType[T <: SType](elemType: T) extends SCollection[T] {
-  override val typeCode: TypeCode = SCollection.CollectionTypeCode
+  override val typeCode: TypeCode = SCollectionType.CollectionTypeCode
 
   override def mkConstant(v: Array[T#WrappedType]): Value[this.type] =
     CollectionConstant(v, elemType).asValue[this.type]
@@ -378,12 +378,14 @@ case class SCollectionType[T <: SType](elemType: T) extends SCollection[T] {
   override def toString = s"Array[$elemType]"
 }
 
-object SCollection {
+object SCollectionType {
   val CollectionTypeConstrId = 1
   val CollectionTypeCode: TypeCode = ((SPrimType.MaxPrimTypeCode + 1) * CollectionTypeConstrId).toByte
   val NestedCollectionTypeConstrId = 2
   val NestedCollectionTypeCode: TypeCode = ((SPrimType.MaxPrimTypeCode + 1) * NestedCollectionTypeConstrId).toByte
+}
 
+object SCollection {
   val tIV = STypeIdent("IV")
   val tOV = STypeIdent("OV")
   val methods = Seq(

--- a/src/test/scala/sigmastate/serialization/AndSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/AndSerializerSpecification.scala
@@ -13,7 +13,7 @@ class AndSerializerSpecification extends TableSerializationSpecification {
     (AND(boolConst(true), boolConst(false)),
       Array[Byte](AndCode, ConcreteCollectionBooleanConstantCode, 2, 1)),
     (AND(Constant[SCollection[SBoolean.type]](Array[Boolean](false, true), SCollection(SBoolean))),
-      Array[Byte](AndCode, SBoolean.embedIn(SCollection.CollectionTypeCode), 2, 2)),
+      Array[Byte](AndCode, SBoolean.embedIn(SCollectionType.CollectionTypeCode), 2, 2)),
     (AND(boolConst(true), EQ(IntConstant(1), IntConstant(1))),
       Array[Byte](AndCode, ConcreteCollectionCode, 2, SBoolean.typeCode, // collection type
         SBoolean.typeCode, 1,

--- a/src/test/scala/sigmastate/serialization/OrSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/OrSerializerSpecification.scala
@@ -13,7 +13,7 @@ class OrSerializerSpecification extends TableSerializationSpecification {
     (OR(boolConst(true), boolConst(false)),
       Array[Byte](OrCode, ConcreteCollectionBooleanConstantCode, 2, 1)),
     (OR(Constant[SCollection[SBoolean.type]](Array[Boolean](false, true), SCollection(SBoolean))),
-      Array[Byte](OrCode, SBoolean.embedIn(SCollection.CollectionTypeCode), 2, 2)),
+      Array[Byte](OrCode, SBoolean.embedIn(SCollectionType.CollectionTypeCode), 2, 2)),
     (OR(boolConst(true), EQ(IntConstant(1), IntConstant(1))),
       Array[Byte](OrCode, ConcreteCollectionCode, 2, SBoolean.typeCode, // collection type
         SBoolean.typeCode, 1,

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -25,7 +25,7 @@ class TypeSerializerSpecification extends SerializationSpecification {
       i shouldBe TypeSerializer.embeddableIdToType(i).typeCode
   }
 
-  import SCollection._; import SOption._; import STuple._
+  import SCollectionType._; import SOption._; import STuple._
 
   property("Embeddable type serialization roundtrip") {
     forAll { t: SPredefType =>


### PR DESCRIPTION
Close #210 

@ergomorphic Threads we're `Runnable` but stuck. Thread stacks were pointing to `SCollection`  object instantiation. Seems like an issue with constructor not being thread safe. 
As an alternative, we can disable parallel test execution altogether.