### PR TITLE
Malicious test suite for deserializer

### DIFF
--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -2,3 +2,12 @@ package sigmastate.lang.exceptions
 
 final class InvalidTypePrefix(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
+
+final class InputSizeLimitExceeded(message: String, source: Option[SourceContext] = None)
+  extends SerializerException(message, source)
+
+final class TypeDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
+  extends SerializerException(message, source)
+
+final class ValueDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
+  extends SerializerException(message, source)

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -11,3 +11,6 @@ final class TypeDeserializeCallDepthExceeded(message: String, source: Option[Sou
 
 final class ValueDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
+
+final class InvalidOpCode(message: String, source: Option[SourceContext] = None)
+  extends SerializerException(message, source)

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -1,0 +1,4 @@
+package sigmastate.lang.exceptions
+
+final class InvalidTypePrefix(message: String, source: Option[SourceContext] = None)
+  extends SerializerException(message, source)

--- a/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
@@ -22,6 +22,9 @@ object Serializer {
   type Position = Int
   type Consumed = Int
 
+  val MaxInputSize: Int = 1024 * 1024 * 1
+  val MaxTreeDepth: Int = 100
+
     /** Helper function to be use in serializers.
     * Starting position is marked and then used to compute number of consumed bytes.
     * val r = Serializer.startReader(bytes, pos)

--- a/src/main/scala/sigmastate/serialization/TypeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TypeSerializer.scala
@@ -1,7 +1,7 @@
 package sigmastate.serialization
 
 import sigmastate._
-import sigmastate.lang.exceptions.InvalidTypePrefix
+import sigmastate.lang.exceptions.{InvalidTypePrefix, TypeDeserializeCallDepthExceeded}
 import sigmastate.utils.{ByteReader, ByteWriter}
 
 /** Serialization of types according to specification in TypeSerialization.md. */
@@ -102,8 +102,8 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
   override def deserialize(r: ByteReader): SType = deserialize(r, 0)
 
   private def deserialize(r: ByteReader, depth: Int): SType = {
-    assert(depth < Serializer.MaxTreeDepth,
-      s"deserialize call depth exceeds ${Serializer.MaxTreeDepth}")
+    if (depth > Serializer.MaxTreeDepth)
+      throw new TypeDeserializeCallDepthExceeded(s"deserialize call depth exceeds ${Serializer.MaxTreeDepth}")
     val c = r.getUByte()
     if (c <= 0)
       throw new InvalidTypePrefix(s"Cannot deserialize type prefix $c. Unexpected buffer $r with bytes ${r.getBytes(r.remaining)}")

--- a/src/main/scala/sigmastate/serialization/TypeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TypeSerializer.scala
@@ -1,7 +1,8 @@
 package sigmastate.serialization
 
 import sigmastate._
-import sigmastate.utils.{ByteWriter, ByteReader}
+import sigmastate.lang.exceptions.InvalidTypePrefix
+import sigmastate.utils.{ByteReader, ByteWriter}
 
 /** Serialization of types according to specification in TypeSerialization.md. */
 object TypeSerializer extends ByteBufferSerializer[SType] {
@@ -101,7 +102,7 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
   override def deserialize(r: ByteReader): SType = {
     val c = r.getUByte()
     if (c <= 0)
-      sys.error(s"Cannot deserialize type prefix $c. Unexpected buffer $r with bytes ${r.getBytes(r.remaining)}")
+      throw new InvalidTypePrefix(s"Cannot deserialize type prefix $c. Unexpected buffer $r with bytes ${r.getBytes(r.remaining)}")
     val tpe: SType = if (c < STuple.TupleTypeCode) {
       val constrId = c / SPrimType.PrimRange
       val primId   = c % SPrimType.PrimRange

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -11,7 +11,7 @@ import sigmastate.serialization.trees.{QuadrupleSerializer, Relation2Serializer,
 import sigmastate.utils.Extensions._
 import org.ergoplatform._
 import sigmastate.lang.DeserializationSigmaBuilder
-import sigmastate.lang.exceptions.ValueDeserializeCallDepthExceeded
+import sigmastate.lang.exceptions.{InvalidOpCode, ValueDeserializeCallDepthExceeded}
 import sigmastate.utils.{ByteReader, ByteWriter, SparseArrayContainer}
 
 import scala.collection.concurrent.TrieMap
@@ -100,7 +100,8 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
 
   override def getSerializer(opCode: Tag): ValueSerializer[_ <: Value[SType]] = {
     val serializer = serializers.get(opCode)
-    if (serializer == null) sys.error(s"Cannot find serializer for Value with opCode=$opCode")
+    if (serializer == null)
+      throw new InvalidOpCode(s"Cannot find serializer for Value with opCode=$opCode")
     serializer
   }
 

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -5,16 +5,12 @@ import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.DeserializationSigmaBuilder
+import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, ValueDeserializeCallDepthExceeded}
 import sigmastate.serialization.OpCodes._
 import sigmastate.serialization.transformers._
 import sigmastate.serialization.trees.{QuadrupleSerializer, Relation2Serializer, Relation3Serializer}
 import sigmastate.utils.Extensions._
-import org.ergoplatform._
-import sigmastate.lang.DeserializationSigmaBuilder
-import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, ValueDeserializeCallDepthExceeded}
 import sigmastate.utils.{ByteReader, ByteWriter, SparseArrayContainer}
-
-import scala.collection.concurrent.TrieMap
 
 
 trait ValueSerializer[V <: Value[SType]] extends SigmaSerializer[Value[SType], V] {

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -11,6 +11,8 @@ import sigmastate.serialization.trees.{QuadrupleSerializer, Relation2Serializer,
 import sigmastate.utils.Extensions._
 import sigmastate.utils.{ByteReader, ByteWriter, SparseArrayContainer}
 
+import scala.collection.concurrent.TrieMap
+
 
 trait ValueSerializer[V <: Value[SType]] extends SigmaSerializer[Value[SType], V] {
 
@@ -109,9 +111,16 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
       getSerializer(opCode).asInstanceOf[ValueSerializer[v.type]].serializeBody(v, w)
   }
 
+  private val nestedValuesDepthPerReader = TrieMap[Int, Int]()
+
   override def deserialize(r: ByteReader): Value[SType] = {
+    val depthKey = r.hashCode()
+    val depth = nestedValuesDepthPerReader.getOrElseUpdate(depthKey, 0)
+    assert(depth <= Serializer.MaxTreeDepth,
+      s"nested value deserialization call depth($depth) exceeds allowed maximum ${Serializer.MaxTreeDepth}")
+    nestedValuesDepthPerReader.update(depthKey, depth + 1)
     val firstByte = r.peekByte()
-    if (firstByte.toUByte <= LastConstantCode) {
+    val v = if (firstByte.toUByte <= LastConstantCode) {
       // look ahead byte tell us this is going to be a Constant
       ConstantSerializer(builder).deserialize(r)
     }
@@ -119,6 +128,11 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
       val opCode = r.getByte()
       getSerializer(opCode).parseBody(r)
     }
+    if (depth == 1)
+      nestedValuesDepthPerReader.remove(depthKey)
+    else
+      nestedValuesDepthPerReader.update(depthKey, depth - 1)
+    v
   }
 
   def serialize(v: Value[SType]): Array[Byte] = {

--- a/src/main/scala/sigmastate/utils/ByteReader.scala
+++ b/src/main/scala/sigmastate/utils/ByteReader.scala
@@ -82,8 +82,13 @@ class ByteBufferReader(buf: ByteBuffer) extends ByteReader {
     * Decode Short previously encoded with [[ByteArrayWriter.putUShort]] using VLQ.
     * @see [[https://en.wikipedia.org/wiki/Variable-length_quantity]]
     * @return Int
+    * @throws AssertionError for deserialized values not in unsigned Short range
     */
-  @inline override def getUShort(): Int = getUInt().toInt
+  @inline override def getUShort(): Int = {
+    val x = getUInt().toInt
+    assert(x >= 0 && x <= 0xFFFF, s"$x is out of unsigned short range")
+    x
+  }
 
   /**
     * Decode signed Int previously encoded with [[ByteArrayWriter.putInt]] using VLQ with ZigZag.

--- a/src/main/scala/sigmastate/utils/ByteReader.scala
+++ b/src/main/scala/sigmastate/utils/ByteReader.scala
@@ -85,7 +85,7 @@ class ByteBufferReader(buf: ByteBuffer) extends ByteReader {
     * @throws AssertionError for deserialized values not in unsigned Short range
     */
   @inline override def getUShort(): Int = {
-    val x = getUInt().toInt
+    val x = getULong().toInt
     assert(x >= 0 && x <= 0xFFFF, s"$x is out of unsigned short range")
     x
   }
@@ -107,7 +107,11 @@ class ByteBufferReader(buf: ByteBuffer) extends ByteReader {
     * @see [[https://en.wikipedia.org/wiki/Variable-length_quantity]]
     * @return Long
     */
-  @inline override def getUInt(): Long = getULong()
+  @inline override def getUInt(): Long = {
+    val x = getULong()
+    assert(x >= 0L && x <= 0xFFFFFFFFL, s"$x is out of unsigned int range")
+    x
+  }
 
   /**
     * Decode signed Long previously encoded with [[ByteArrayWriter.putLong]] using VLQ with ZigZag.

--- a/src/main/scala/sigmastate/utils/ByteReader.scala
+++ b/src/main/scala/sigmastate/utils/ByteReader.scala
@@ -2,11 +2,9 @@ package sigmastate.utils
 
 import java.nio.ByteBuffer
 import java.util._
+import java.util.concurrent.atomic.AtomicInteger
 
-import sigmastate.Values.SValue
-import sigmastate.SType
 import sigmastate.utils.Extensions._
-import sigmastate.serialization.{TypeSerializer, ValueSerializer}
 import sigmastate.utils.ByteBufferReader.decodeZigZagLong
 
 trait ByteReader {
@@ -69,8 +67,13 @@ trait ByteReader {
   def position: Int
   def position_=(p: Int)
   def remaining: Int
+  def level: Int
+  def level_=(v: Int)
 }
 
+/**
+  * Not thread safe
+  */
 class ByteBufferReader(buf: ByteBuffer) extends ByteReader {
 
   @inline override def peekByte(): Byte = buf.array()(buf.position())
@@ -172,6 +175,10 @@ class ByteBufferReader(buf: ByteBuffer) extends ByteReader {
   @inline override def position_=(p: Int): Unit = buf.position(p)
 
   @inline override def remaining: Int = buf.remaining()
+
+  private var lvl: Int = 0
+  override def level: Int = lvl
+  override def level_=(v: Int): Unit = lvl = v
 }
 
 object ByteBufferReader {

--- a/src/main/scala/sigmastate/utils/ByteWriter.scala
+++ b/src/main/scala/sigmastate/utils/ByteWriter.scala
@@ -72,6 +72,9 @@ trait ByteWriter {
   def toBytes: Array[Byte]
 }
 
+/**
+  * Not thread safe
+  */
 class ByteArrayWriter(b: ByteArrayBuilder) extends ByteWriter {
   @inline override def put(x: Byte): ByteWriter = { b.append(x); this }
   @inline override def putBoolean(x: Boolean): ByteWriter = { b.append(x); this }

--- a/src/main/scala/sigmastate/utils/Helpers.scala
+++ b/src/main/scala/sigmastate/utils/Helpers.scala
@@ -58,7 +58,12 @@ object Helpers {
     * Helper to construct a byte array from a bunch of bytes. The inputs are actually ints so that I
     * can use hex notation and not get stupid errors about precision.
   */
-  def bytesFromInts(bytesAsInts: Int*): Array[Byte] = bytesAsInts.map(_.toByte).toArray
+  def bytesFromInts(bytesAsInts: Int*): Array[Byte] =
+    bytesAsInts.map{ i =>
+      // values from unsigned byte range will be encoded as negative values which is expected here
+      assert(i >= Byte.MinValue && i <= 0xFF, s"$i is out of the signed/unsigned Byte range")
+      i.toByte
+    }.toArray
 }
 
 object Overloading {

--- a/src/main/scala/sigmastate/utils/Helpers.scala
+++ b/src/main/scala/sigmastate/utils/Helpers.scala
@@ -53,6 +53,12 @@ object Helpers {
       case (Some(a1), Some(a2)) => deepHashCode(a1) == deepHashCode(a2)
       case _ => false
     }
+
+  /**
+    * Helper to construct a byte array from a bunch of bytes. The inputs are actually ints so that I
+    * can use hex notation and not get stupid errors about precision.
+  */
+  def bytesFromInts(bytesAsInts: Int*): Array[Byte] = bytesAsInts.map(_.toByte).toArray
 }
 
 object Overloading {

--- a/src/main/scala/sigmastate/utils/Helpers.scala
+++ b/src/main/scala/sigmastate/utils/Helpers.scala
@@ -58,12 +58,16 @@ object Helpers {
     * Helper to construct a byte array from a bunch of bytes. The inputs are actually ints so that I
     * can use hex notation and not get stupid errors about precision.
   */
-  def bytesFromInts(bytesAsInts: Int*): Array[Byte] =
-    bytesAsInts.map{ i =>
+  def bytesFromInts(bytesAsInts: Int*): Array[Byte] = {
+    val a = new Array[Byte](bytesAsInts.length)
+    for (i <- a.indices) {
+      val v = bytesAsInts(i)
       // values from unsigned byte range will be encoded as negative values which is expected here
-      assert(i >= Byte.MinValue && i <= 0xFF, s"$i is out of the signed/unsigned Byte range")
-      i.toByte
-    }.toArray
+      assert(v >= Byte.MinValue && v <= 0xFF, s"$v is out of the signed/unsigned Byte range")
+      a(i) = v.toByte
+    }
+    a
+  }
 }
 
 object Overloading {

--- a/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
@@ -49,4 +49,9 @@ class ConcreteCollectionSerializerSpecification extends TableSerializationSpecif
   tableRoundTripTest("Specific objects serializer round trip")
   tablePredefinedBytesTest("Specific objects deserialize from predefined bytes")
 
+  property("ConcreteCollection: deserialize collection of a crazy size") {
+    val bytes = Array[Byte](ConcreteCollectionSerializer.opCode) ++
+      Serializer.startWriter().putUInt(Int.MaxValue).toBytes
+    an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes)
+  }
 }

--- a/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ConcreteCollectionSerializerSpecification.scala
@@ -50,7 +50,7 @@ class ConcreteCollectionSerializerSpecification extends TableSerializationSpecif
   tablePredefinedBytesTest("Specific objects deserialize from predefined bytes")
 
   property("ConcreteCollection: deserialize collection of a crazy size") {
-    val bytes = Array[Byte](ConcreteCollectionSerializer.opCode) ++
+    val bytes = Array[Byte](OpCodes.ConcreteCollectionCode) ++
       Serializer.startWriter().putUInt(Int.MaxValue).toBytes
     an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes)
   }

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -13,8 +13,11 @@ class DeserializationResilience extends PropSpec
   }
 
   property("max size limit") {
-    val size = 1024 * 1024 * 10
-    an[SerializerException] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](size)(1))
+    val bytes = Array.fill[Byte](ValueSerializer.MaxInputSize + 1)(1)
+    an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes)
+    an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes, 0)
+    // deliberately omitted assertion (hot path)
+    ValueSerializer.deserialize(Serializer.startReader(bytes, 0))
   }
 
   property("zeroes") {

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -14,9 +14,7 @@ class DeserializationResilience extends SerializationSpecification {
   property("max size limit") {
     val bytes = Array.fill[Byte](Serializer.MaxInputSize + 1)(1)
     an[InputSizeLimitExceeded] should be thrownBy ValueSerializer.deserialize(bytes)
-    an[InputSizeLimitExceeded] should be thrownBy ValueSerializer.deserialize(bytes, 0)
-    // deliberately omitted assertion (hot path)
-    ValueSerializer.deserialize(Serializer.startReader(bytes, 0))
+    an[InputSizeLimitExceeded] should be thrownBy ValueSerializer.deserialize(Serializer.startReader(bytes, 0))
   }
 
   property("zeroes (invalid type code in constant deserialization path") {

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -1,6 +1,6 @@
 package sigmastate.serialization
 
-import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidTypePrefix, ValueDeserializeCallDepthExceeded}
+import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, InvalidTypePrefix, ValueDeserializeCallDepthExceeded}
 import sigmastate.serialization.OpCodes._
 import sigmastate.utils.Extensions._
 import sigmastate.{AND, SBoolean}
@@ -19,7 +19,7 @@ class DeserializationResilience extends SerializationSpecification {
     ValueSerializer.deserialize(Serializer.startReader(bytes, 0))
   }
 
-  property("zeroes") {
+  property("zeroes (invalid type code in constant deserialization path") {
     an[InvalidTypePrefix] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](1)(0))
     an[InvalidTypePrefix] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](2)(0))
   }
@@ -43,5 +43,10 @@ class DeserializationResilience extends SerializationSpecification {
     // test other API endpoints
     ValueSerializer.deserialize(Serializer.startReader(goodBytes, 0))
     Serializer.startReader(goodBytes, 0).getValue()
+  }
+
+  property("invalid op code") {
+    an[InvalidOpCode] should be thrownBy
+      ValueSerializer.deserialize(Array.fill[Byte](1)(255.toByte))
   }
 }

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -1,0 +1,24 @@
+package sigmastate.serialization
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import sigmastate.lang.exceptions.{InvalidTypePrefix, SerializerException}
+
+class DeserializationResilience extends PropSpec
+  with PropertyChecks
+  with Matchers {
+
+  property("empty") {
+    an[ArrayIndexOutOfBoundsException] should be thrownBy ValueSerializer.deserialize(Array[Byte]())
+  }
+
+  property("max size limit") {
+    val size = 1024 * 1024 * 10
+    an[SerializerException] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](size)(1))
+  }
+
+  property("zeroes") {
+    an[InvalidTypePrefix] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](1)(0))
+    an[InvalidTypePrefix] should be thrownBy ValueSerializer.deserialize(Array.fill[Byte](2)(0))
+  }
+}

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -13,7 +13,7 @@ class DeserializationResilience extends PropSpec
   }
 
   property("max size limit") {
-    val bytes = Array.fill[Byte](ValueSerializer.MaxInputSize + 1)(1)
+    val bytes = Array.fill[Byte](Serializer.MaxInputSize + 1)(1)
     an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes)
     an[AssertionError] should be thrownBy ValueSerializer.deserialize(bytes, 0)
     // deliberately omitted assertion (hot path)

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -2,6 +2,7 @@ package sigmastate.serialization
 
 import org.scalacheck.Arbitrary._
 import sigmastate._
+import sigmastate.lang.exceptions.{InvalidTypePrefix, SerializerException}
 import sigmastate.utils.Extensions._
 
 class TypeSerializerSpecification extends SerializationSpecification {
@@ -83,5 +84,10 @@ class TypeSerializerSpecification extends SerializationSpecification {
 
     roundtrip(STuple(SLong, SLong, SByte, SBoolean, SInt),
       Array[Byte](TupleTypeCode, 5, SLong.typeCode, SLong.typeCode, SByte.typeCode, SBoolean.typeCode, SInt.typeCode))
+  }
+
+  property("tuple of tuples crazy deep") {
+    val bytes = List.tabulate(1000)(_ => Array[Byte](TupleTypeCode, 2)).toArray.flatten
+    an[SerializerException] should be thrownBy Serializer.startReader(bytes, 0).getType()
   }
 }

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -2,6 +2,7 @@ package sigmastate.serialization
 
 import org.scalacheck.Arbitrary._
 import sigmastate._
+import sigmastate.lang.exceptions.TypeDeserializeCallDepthExceeded
 import sigmastate.utils.Extensions._
 
 class TypeSerializerSpecification extends SerializationSpecification {
@@ -88,6 +89,6 @@ class TypeSerializerSpecification extends SerializationSpecification {
   property("tuple of tuples crazy deep") {
     val bytes = List.tabulate(Serializer.MaxTreeDepth + 1)(_ => Array[Byte](TupleTypeCode, 2))
       .toArray.flatten
-    an[AssertionError] should be thrownBy Serializer.startReader(bytes, 0).getType()
+    an[TypeDeserializeCallDepthExceeded] should be thrownBy Serializer.startReader(bytes, 0).getType()
   }
 }

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -2,7 +2,6 @@ package sigmastate.serialization
 
 import org.scalacheck.Arbitrary._
 import sigmastate._
-import sigmastate.lang.exceptions.{InvalidTypePrefix, SerializerException}
 import sigmastate.utils.Extensions._
 
 class TypeSerializerSpecification extends SerializationSpecification {
@@ -87,7 +86,8 @@ class TypeSerializerSpecification extends SerializationSpecification {
   }
 
   property("tuple of tuples crazy deep") {
-    val bytes = List.tabulate(1000)(_ => Array[Byte](TupleTypeCode, 2)).toArray.flatten
-    an[SerializerException] should be thrownBy Serializer.startReader(bytes, 0).getType()
+    val bytes = List.tabulate(Serializer.MaxTreeDepth + 1)(_ => Array[Byte](TupleTypeCode, 2))
+      .toArray.flatten
+    an[AssertionError] should be thrownBy Serializer.startReader(bytes, 0).getType()
   }
 }

--- a/src/test/scala/sigmastate/utils/ByteReaderWriterImpSpecification.scala
+++ b/src/test/scala/sigmastate/utils/ByteReaderWriterImpSpecification.scala
@@ -250,4 +250,18 @@ class ByteReaderWriterImpSpecification extends PropSpec
     checkFail(Int.MaxValue)
   }
 
+  property("getUInt range check assertion") {
+    def check(in: Long): Unit =
+      byteBufReader(byteArrayWriter().putULong(in).toBytes).getUInt() shouldBe in
+
+    def checkFail(in: Long): Unit =
+      an[AssertionError] should be thrownBy
+        byteBufReader(byteArrayWriter().putULong(in).toBytes).getUInt()
+
+    check(0)
+    check(0xFFFFFFFFL)
+    checkFail(-1)
+    checkFail(0xFFFFFFFFL + 1L)
+    checkFail(Long.MaxValue)
+  }
 }


### PR DESCRIPTION
Close #198 

- [x] empty;
- [x] zeros;
- [x] collection of a crazy size;
- [x] max bytes size limit;
- [x] tuple of tuples crazy deep;
- [x] add range check assert to `getUInt`;
- [x] crazy deep nodes  (AND/OR, etc)
- [x] look into LibFuzzer Corpus;
- [x] use exceptions instead of assert;
- [x] invalid type code;
- [x] invalid op code;
- [x] glue nested call depth tracker to the reader;
