### PR TITLE
Add String type and string literal syntax

### DIFF
--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -179,6 +179,15 @@ object Values {
       case _ => None
     }
   }
+  object StringConstant {
+    def apply(value: String): Constant[SString.type]  = Constant[SString.type](value, SString)
+    def unapply(v: SValue): Option[String] = v match {
+      case Constant(value: String, SString) => Some(value)
+      case _ => None
+    }
+
+    def Empty = StringConstant("")
+  }
 
   object BoxConstant {
     def apply(value: ErgoBox): Constant[SBox.type]  = Constant[SBox.type](value, SBox)

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -134,6 +134,7 @@ object Values {
   type ShortConstant = Constant[SShort.type]
   type IntConstant = Constant[SInt.type]
   type LongConstant = Constant[SLong.type]
+  type StringConstant = Constant[SString.type]
   type BigIntConstant = Constant[SBigInt.type]
   type BoxConstant = Constant[SBox.type]
   type GroupElementConstant = Constant[SGroupElement.type]

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -263,6 +263,9 @@ trait Interpreter {
     case LE(BigIntConstant(l), BigIntConstant(r)) =>
       BooleanConstant.fromBoolean(l.compareTo(r) <= 0)
 
+    case StringConcat(StringConstant(l), StringConstant(r)) =>
+      StringConstant(l + r)
+
     case IsMember(tree: EvaluatedValue[AvlTreeData]@unchecked, key: EvaluatedValue[SByteArray], proof: EvaluatedValue[SByteArray]) =>
       def invalidArg = Interpreter.error(s"Collection expected but found $key")
       val keyBytes = key.matchCase(cc => cc.value, c => c.value, _ => invalidArg)

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -137,6 +137,7 @@ trait SigmaBuilder {
   def mkConstant[T <: SType](value: T#WrappedType, tpe: T): Constant[T]
   def mkCollectionConstant[T <: SType](values: Array[T#WrappedType],
                                        elementType: T): Constant[SCollection[T]]
+  def mkStringConcat(left: Value[SString.type], right: Value[SString.type]): Value[SString.type]
 }
 
 class StdSigmaBuilder extends SigmaBuilder {
@@ -371,6 +372,8 @@ class StdSigmaBuilder extends SigmaBuilder {
                                                 elementType: T): Constant[SCollection[T]] =
     ConstantNode[SCollection[T]](values, SCollection(elementType))
 
+  override def mkStringConcat(left: Value[SString.type], right: Value[SString.type]): Value[SString.type] =
+    StringConcat(left, right)
 }
 
 trait TypeConstraintCheck {

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -55,18 +55,15 @@ object SigmaParser extends Exprs with Types with Core {
     case _ => error(s"Unknown prefix operation $opName")
   }
 
-  val parseAsMethods = Set("*", "++", "||", "&&")
+  val parseAsMethods = Set("*", "++", "||", "&&", "+")
 
   def mkBinaryOp(l: Value[SType], opName: String, r: Value[SType]): Value[SType] = opName match {
-//    case "||" => OR(l.asValue[SBoolean.type], r.asValue[SBoolean.type])
-//    case "&&" => AND(l.asValue[SBoolean.type], r.asValue[SBoolean.type])
     case "==" => EQ(l, r)
     case "!=" => NEQ(l, r)
     case ">=" => GE(l, r)
     case ">"  => GT(l, r)
     case "<=" => LE(l, r)
     case "<"  => LT(l, r)
-    case "+"  => builder.mkPlus(l.asValue[SLong.type], r.asValue[SLong.type])
     case "-"  => builder.mkMinus(l.asValue[SLong.type], r.asValue[SLong.type])
     case "|"  => builder.mkXor(l.asValue[SByteArray], r.asValue[SByteArray])
     case "^"  => builder.mkExponentiate(l.asValue[SGroupElement.type], r.asValue[SBigInt.type])

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -131,6 +131,7 @@ object Terms {
   implicit class ValueOps(v: Value[SType]) {
     def asValue[T <: SType]: Value[T] = v.asInstanceOf[Value[T]]
     def asNumValue: Value[SNumericType] = v.asInstanceOf[Value[SNumericType]]
+    def asStringValue: Value[SString.type] = v.asInstanceOf[Value[SString.type]]
     def asBoolValue: Value[SBoolean.type] = v.asInstanceOf[Value[SBoolean.type]]
     def asIntValue: Value[SInt.type] = v.asInstanceOf[Value[SInt.type]]
     def asLongValue: Value[SLong.type] = v.asInstanceOf[Value[SLong.type]]

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaTyperExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaTyperExceptions.scala
@@ -5,3 +5,6 @@ final class InvalidBinaryOperationParameters(message: String, source: Option[Sou
 
 final class MethodNotFound(message: String, source: Option[SourceContext] = None)
   extends TyperException(message, source)
+
+final class NonApplicableMethod(message: String, source: Option[SourceContext] = None)
+  extends TyperException(message, source)

--- a/src/main/scala/sigmastate/lang/syntax/Literals.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Literals.scala
@@ -95,7 +95,9 @@ trait Literals { l =>
                 builder.mkConstant[SInt.type](sign * parseInt(digits, radix), SInt)
           }
         | Bool
-        /*| String | "'" ~/ (Char | Symbol) | Null*/ )
+        | (String | "'" ~/ (Char | Symbol) | Null).!.map {
+          lit: String => builder.mkConstant[SString.type](lit, SString)
+        })
 
       val Interp: Parser[Unit] = interp match{
         case None => P ( Fail )

--- a/src/main/scala/sigmastate/lang/syntax/Literals.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Literals.scala
@@ -95,8 +95,10 @@ trait Literals { l =>
                 builder.mkConstant[SInt.type](sign * parseInt(digits, radix), SInt)
           }
         | Bool
-        | (String | "'" ~/ (Char | Symbol) | Null).!.map {
-          lit: String => builder.mkConstant[SString.type](lit, SString)
+        | (String | "'" ~/ (Char | Symbol) | Null).!.map { lit: String =>
+          // strip single or triple quotes
+          def strip(s: String): String = if (!s.startsWith("\"")) s else strip(s.stripPrefix("\"").stripSuffix("\""))
+          builder.mkConstant[SString.type](strip(lit), SString)
         })
 
       val Interp: Parser[Unit] = interp match{

--- a/src/main/scala/sigmastate/serialization/DataSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/DataSerializer.scala
@@ -1,12 +1,15 @@
 package sigmastate.serialization
 
 import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+
 import org.ergoplatform.ErgoBox
 import sigmastate.Values.SigmaBoolean
-import sigmastate.utils.{ByteWriter, ByteReader}
+import sigmastate.utils.{ByteReader, ByteWriter}
 import sigmastate.utils.Extensions._
 import sigmastate._
 import sigmastate.interpreter.CryptoConstants.EcPointType
+
 import scala.collection.mutable
 
 /** This works in tandem with ConstantSerializer, if you change one make sure to check the other.*/
@@ -19,6 +22,10 @@ object DataSerializer {
     case SShort => w.putShort(v.asInstanceOf[Short])
     case SInt => w.putInt(v.asInstanceOf[Int])
     case SLong => w.putLong(v.asInstanceOf[Long])
+    case SString =>
+      val bytes = v.asInstanceOf[String].getBytes(StandardCharsets.UTF_8)
+      w.putUInt(bytes.length)
+      w.putBytes(bytes)
     case SBigInt =>
       val data = v.asInstanceOf[BigInteger].toByteArray
       w.putUShort(data.length)
@@ -66,6 +73,10 @@ object DataSerializer {
     case SShort => r.getShort()
     case SInt => r.getInt()
     case SLong => r.getLong()
+    case SString =>
+      val size = r.getUInt().toInt
+      val bytes = r.getBytes(size)
+      new String(bytes, StandardCharsets.UTF_8)
     case SBigInt =>
       val size: Short = r.getUShort().toShort
       val valueBytes = r.getBytes(size)

--- a/src/main/scala/sigmastate/serialization/OpCodes.scala
+++ b/src/main/scala/sigmastate/serialization/OpCodes.scala
@@ -102,7 +102,8 @@ object OpCodes extends ValueCodes {
   val AppendCode       : OpCode = (LastConstantCode + 67).toByte
   val SliceCode        : OpCode = (LastConstantCode + 68).toByte
   val WhereCode        : OpCode = (LastConstantCode + 69).toByte
-  val IsMemberCode     : OpCode = (LastConstantCode + 70).toByte  // reserved 71 - 80
+  val IsMemberCode     : OpCode = (LastConstantCode + 70).toByte
+  val StringConcatCode : OpCode = (LastConstantCode + 71).toByte  // reserved 72 - 80
 
   // Type casts codes
   val ExtractAmountCode        : OpCode = (LastConstantCode + 81).toByte

--- a/src/main/scala/sigmastate/serialization/TypeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TypeSerializer.scala
@@ -21,6 +21,7 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
 
   override def serialize(tpe: SType, w: ByteWriter) = tpe match {
     case p: SEmbeddable => w.put(p.typeCode)
+    case SString => w.put(SString.typeCode)
     case SAny => w.put(SAny.typeCode)
     case SUnit => w.put(SUnit.typeCode)
     case SBox => w.put(SBox.typeCode)
@@ -164,6 +165,7 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
           val items = (0 until len).map(_ => deserialize(r, depth + 1))
           STuple(items)
         }
+        case SString.typeCode => SString
         case SAny.typeCode => SAny
         case SUnit.typeCode => SUnit
         case SBox.typeCode => SBox

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -50,6 +50,7 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     TwoArgumentsSerializer(PlusCode, mkPlus[SNumericType]),
     TwoArgumentsSerializer(MinCode, mkMin[SNumericType]),
     TwoArgumentsSerializer(MaxCode, mkMax[SNumericType]),
+    TwoArgumentsSerializer(StringConcatCode, mkStringConcat),
     ProveDiffieHellmanTupleSerializer(mkProveDiffieHellmanTuple),
     ProveDlogSerializer(mkProveDlog),
     CaseObjectSerialization(TrueCode, TrueLeaf),

--- a/src/main/scala/sigmastate/trees.scala
+++ b/src/main/scala/sigmastate/trees.scala
@@ -304,6 +304,12 @@ case class MultiplyGroup(override val left: Value[SGroupElement.type],
   override def cost[C <: Context[C]](context: C) = Cost.MultiplyGroup + left.cost(context) + right.cost(context)
 }
 
+case class StringConcat(left: Value[SString.type], right: Value[SString.type])
+  extends TwoArgumentsOperation[SString.type, SString.type, SString.type] with NotReadyValue[SString.type] {
+  override def tpe: SString.type = left.tpe
+  override val opCode: OpCode = StringConcatCode
+}
+
 // Relation
 
 sealed trait Relation[LIV <: SType, RIV <: SType] extends Triple[LIV, RIV, SBoolean.type]

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -354,6 +354,8 @@ case object SString extends SProduct {
   override def methods: Seq[SMethod] = Seq()
   override type WrappedType = String
   override val typeCode: TypeCode = 101: Byte
+  override def mkConstant(v: String): Value[SString.type] = StringConstant(v)
+  override def dataCost(v: SType#WrappedType): Long = Cost.StringConstantDeclaration
 }
 
   case object SGroupElement extends SProduct with SPrimType with SEmbeddable {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -349,7 +349,14 @@ case object SBigInt extends SPrimType with SEmbeddable with SNumericType {
   }
 }
 
-case object SGroupElement extends SProduct with SPrimType with SEmbeddable {
+case object SString extends SProduct {
+  override def ancestors: Seq[SType] = Nil
+  override def methods: Seq[SMethod] = Seq()
+  override type WrappedType = String
+  override val typeCode: TypeCode = 101: Byte
+}
+
+  case object SGroupElement extends SProduct with SPrimType with SEmbeddable {
   override type WrappedType = EcPointType
   override val typeCode: TypeCode = 7: Byte
   override def mkConstant(v: EcPointType): Value[SGroupElement.type] = GroupElementConstant(v)

--- a/src/main/scala/sigmastate/utxo/CostTable.scala
+++ b/src/main/scala/sigmastate/utxo/CostTable.scala
@@ -34,6 +34,7 @@ object CostTable {
     val IntConstantDeclaration = 1
     val LongConstantDeclaration = 1
     val BigIntConstantDeclaration = 1
+    val StringConstantDeclaration = 1
     val GroupElementConstantDeclaration = 10
     val SigmaPropConstantDeclaration = 10
     val BoxConstantDeclaration = 10

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -186,6 +186,11 @@ class TestingInterpreterSpecification extends PropSpec
     an[ArithmeticException] should be thrownBy testEval(s"Array(${Long.MaxValue}L)(0).toInt > 0")
   }
 
+  property("string concat") {
+    testEval(""" "a" + "b" == "ab" """)
+    testEval(""" "a" + "b" != "cb" """)
+  }
+
   property("Array indexing (out of bounds with const default value)") {
     testEval("Array(1, 2).getOrElse(3, 0) == 0")
   }

--- a/src/test/scala/sigmastate/lang/LangTests.scala
+++ b/src/test/scala/sigmastate/lang/LangTests.scala
@@ -1,7 +1,7 @@
 package sigmastate.lang
 
-import sigmastate.lang.Terms.Ident
-import sigmastate.Values.{ConcreteCollection, Value, LongConstant, SigmaBoolean}
+import sigmastate.lang.Terms.{Ident, MethodCall}
+import sigmastate.Values.{ConcreteCollection, LongConstant, SValue, SigmaBoolean, Value}
 import sigmastate._
 import java.math.BigInteger
 
@@ -19,6 +19,8 @@ trait LangTests {
   def SigmaPropIdent(name: String): Value[SSigmaProp.type] = Ident(name).asValue[SSigmaProp.type]
   def BigIntIdent(name: String): Value[SBigInt.type] = Ident(name).asValue[SBigInt.type]
 
+  def plus(l: SValue, r: SValue, tpe: SType = NoType): MethodCall =
+    MethodCall(l, "+", IndexedSeq(r), tpe)
 
   val EV: Map[String, Any] = Map()
 

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -23,10 +23,10 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   property("simple expressions") {
     bind(env, "x") shouldBe IntConstant(10)
     bind(env, "b1") shouldBe ByteConstant(1)
-    bind(env, "x+y") shouldBe Plus(10, 11)
+    bind(env, "x-y") shouldBe Minus(10, 11)
     bind(env, "c1 && c2") shouldBe MethodCall(TrueLeaf, "&&", IndexedSeq(FalseLeaf))
     bind(env, "arr1") shouldBe ByteArrayConstant(Array(1, 2))
-    bind(env, "HEIGHT + 1") shouldBe mkPlus(Height, 1)
+    bind(env, "HEIGHT - 1") shouldBe mkMinus(Height, 1)
     bind(env, "INPUTS.size > 1") shouldBe GT(Select(Inputs, "size").asIntValue, 1)
     bind(env, "arr1 | arr2") shouldBe Xor(Array[Byte](1, 2), Array[Byte](10, 20))
     bind(env, "arr1 ++ arr2") shouldBe MethodCall(Array[Byte](1, 2), "++", IndexedSeq(Array[Byte](10, 20))) // AppendBytes(Array[Byte](1, 2), Array[Byte](10,20))
@@ -53,8 +53,8 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
       Block(Let("X", SInt, IntConstant(10)), GT(IntIdent("X"), 2))
     bind(env, "{let X = 10; X >= X}") shouldBe
       Block(Let("X", SInt, IntConstant(10)), GE(IntIdent("X"), IntIdent("X")))
-    bind(env, "{let X = 10 + 1; X >= X}") shouldBe
-      Block(Let("X", SInt, Plus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
+    bind(env, "{let X = 10 - 1; X >= X}") shouldBe
+      Block(Let("X", SInt, Minus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
     bind(env,
       """{let X = 10
         |let Y = 11
@@ -84,9 +84,9 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "()") shouldBe UnitConstant
     bind(env, "(1)") shouldBe IntConstant(1)
     bind(env, "(1, 2)") shouldBe Tuple(IntConstant(1), IntConstant(2))
-    bind(env, "(1, x + 1)") shouldBe Tuple(IntConstant(1), Plus(10, 1))
+    bind(env, "(1, x - 1)") shouldBe Tuple(IntConstant(1), Minus(10, 1))
     bind(env, "(1, 2, 3)") shouldBe Tuple(IntConstant(1), IntConstant(2), IntConstant(3))
-    bind(env, "(1, 2 + 3, 4)") shouldBe Tuple(IntConstant(1), Plus(2, 3), IntConstant(4))
+    bind(env, "(1, 2 - 3, 4)") shouldBe Tuple(IntConstant(1), Minus(2, 3), IntConstant(4))
   }
 
   property("types") {
@@ -118,30 +118,30 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "Some(None)") shouldBe SomeValue(NoneValue(NoType))
     bind(env, "Some(10)") shouldBe SomeValue(IntConstant(10))
     bind(env, "Some(X)") shouldBe SomeValue(Ident("X"))
-    bind(env, "Some(Some(X + 1))") shouldBe
-      SomeValue(SomeValue(mkPlus(Ident("X").asValue[SInt.type], IntConstant(1))))
+    bind(env, "Some(Some(X - 1))") shouldBe
+      SomeValue(SomeValue(mkMinus(Ident("X").asValue[SInt.type], IntConstant(1))))
   }
 
   property("lambdas") {
-    bind(env, "fun (a: Int) = a + 1") shouldBe
-      Lambda(IndexedSeq("a" -> SInt), NoType, mkPlus(IntIdent("a"), 1))
-    bind(env, "fun (a: Int, box: Box): Long = a + box.value") shouldBe
+    bind(env, "fun (a: Int) = a - 1") shouldBe
+      Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))
+    bind(env, "fun (a: Int, box: Box): Long = a - box.value") shouldBe
       Lambda(IndexedSeq("a" -> SInt, "box" -> SBox), SLong,
-        mkPlus(IntIdent("a"), Select(Ident("box"), "value").asValue[SLong.type]))
-    bind(env, "fun (a) = a + 1") shouldBe
-      Lambda(IndexedSeq("a" -> NoType), NoType, mkPlus(IntIdent("a"), IntConstant(1)))
-    bind(env, "fun (a) = a + x") shouldBe
-      Lambda(IndexedSeq("a" -> NoType), NoType, mkPlus(IntIdent("a"), 10))
-    bind(env, "fun (a: Int) = { let Y = a + 1; Y + x }") shouldBe
+        mkMinus(IntIdent("a"), Select(Ident("box"), "value").asValue[SLong.type]))
+    bind(env, "fun (a) = a - 1") shouldBe
+      Lambda(IndexedSeq("a" -> NoType), NoType, mkMinus(IntIdent("a"), IntConstant(1)))
+    bind(env, "fun (a) = a - x") shouldBe
+      Lambda(IndexedSeq("a" -> NoType), NoType, mkMinus(IntIdent("a"), 10))
+    bind(env, "fun (a: Int) = { let Y = a - 1; Y - x }") shouldBe
       Lambda(IndexedSeq("a" -> SInt), NoType,
-        Block(Let("Y", NoType, mkPlus(IntIdent("a"), 1)), mkPlus(IntIdent("Y"), 10)))
+        Block(Let("Y", NoType, mkMinus(IntIdent("a"), 1)), mkMinus(IntIdent("Y"), 10)))
   }
 
   property("function definitions") {
-    bind(env, "{let f = fun (a: Int) = a + 1; f}") shouldBe
-      Block(Let("f", SFunc(IndexedSeq(SInt), NoType), Lambda(IndexedSeq("a" -> SInt), NoType, mkPlus(IntIdent("a"), 1))), Ident("f"))
-    bind(env, "{fun f(a: Int) = a + x; f}") shouldBe
-      Block(Let("f", SFunc(IndexedSeq(SInt), NoType), Lambda(IndexedSeq("a" -> SInt), NoType, mkPlus(IntIdent("a"), 10))), Ident("f"))
+    bind(env, "{let f = fun (a: Int) = a - 1; f}") shouldBe
+      Block(Let("f", SFunc(IndexedSeq(SInt), NoType), Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))), Ident("f"))
+    bind(env, "{fun f(a: Int) = a - x; f}") shouldBe
+      Block(Let("f", SFunc(IndexedSeq(SInt), NoType), Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 10))), Ident("f"))
   }
 
   property("predefined primitives") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -389,9 +389,9 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   property("string literals") {
     parse("\"hello\"") shouldBe StringConstant("hello")
     // triple double quotes
-    parse("\"\"\"hello\"\"\"") shouldBe StringConstant("\"\"\"hello\"\"\"")
+    parse("\"\"\"hello\"\"\"") shouldBe StringConstant("hello")
     // triple double quotes with newline and a backslash
-    parse("\"\"\"h\\el\nlo\"\"\"") shouldBe StringConstant("\"\"\"h\\el\nlo\"\"\"")
+    parse("\"\"\"h\\el\nlo\"\"\"") shouldBe StringConstant("h\\el\nlo")
     // in expression
     parse(""" "hello" == "hello" """) shouldBe EQ(StringConstant("hello"), StringConstant("hello"))
   }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -385,4 +385,14 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("1.toLong") shouldBe Select(IntConstant(1), "toLong")
     parse("1.toBigInt") shouldBe Select(IntConstant(1), "toBigInt")
   }
+
+  property("string literals") {
+    parse("\"hello\"") shouldBe StringConstant("hello")
+    // triple double quotes
+    parse("\"\"\"hello\"\"\"") shouldBe StringConstant("\"\"\"hello\"\"\"")
+    // triple double quotes with newline and a backslash
+    parse("\"\"\"h\\el\nlo\"\"\"") shouldBe StringConstant("\"\"\"h\\el\nlo\"\"\"")
+    // in expression
+    parse(""" "hello" == "hello" """) shouldBe EQ(StringConstant("hello"), StringConstant("hello"))
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -45,11 +45,11 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("0x10") shouldBe IntConstant(0x10)
     parse("0x10L") shouldBe LongConstant(0x10)
     parse("0x10l") shouldBe LongConstant(0x10)
-    parse("10L+11L") shouldBe Plus(10L, 11L)
-    parse("(10+11)") shouldBe Plus(10, 11)
-    parse("(10+11) + 12") shouldBe Plus(Plus(10, 11), 12)
-    parse("10   + 11 + 12") shouldBe Plus(Plus(10, 11), 12)
-    parse("1+2+3+4+5") shouldBe Plus(Plus(Plus(Plus(1, 2), 3), 4), 5)
+    parse("10L-11L") shouldBe Minus(10L, 11L)
+    parse("(10-11)") shouldBe Minus(10, 11)
+    parse("(10-11) - 12") shouldBe Minus(Minus(10, 11), 12)
+    parse("10   - 11 - 12") shouldBe Minus(Minus(10, 11), 12)
+    parse("1-2-3-4-5") shouldBe Minus(Minus(Minus(Minus(1, 2), 3), 4), 5)
     parse("10 - 11") shouldBe Minus(10, 11)
     parse("1 / 2") shouldBe Divide(1, 2)
     parse("5 % 2") shouldBe Modulo(5, 2)
@@ -64,35 +64,36 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("col1 ++ col2") shouldBe MethodCall(Ident("col1"), "++", IndexedSeq(Ident("col2")))
     parse("ge ^ n") shouldBe Exponentiate(GEIdent("ge"), BigIntIdent("n"))
     parse("g1 * g2") shouldBe MethodCall(Ident("g1"), "*", IndexedSeq(Ident("g2")))
+    parse("g1 + g2") shouldBe MethodCall(Ident("g1"), "+", IndexedSeq(Ident("g2")))
   }
 
   property("precedence of binary operations") {
-    parse("1 + 2 + 3") shouldBe Plus(Plus(1, 2), 3)
-    parse("1 + 2 + 3 + 4") shouldBe Plus(Plus(Plus(1, 2), 3), 4)
+    parse("1 - 2 - 3") shouldBe Minus(Minus(1, 2), 3)
+    parse("1 - 2 - 3 - 4") shouldBe Minus(Minus(Minus(1, 2), 3), 4)
     parse("1 == 0 || 3 == 2") shouldBe or(EQ(1, 0), EQ(3, 2))
-    parse("3 + 2 > 2 + 1") shouldBe GT(Plus(3, 2), Plus(2, 1))
-    parse("1 + 2 + 3 > 4 + 5 + 6") shouldBe GT(Plus(Plus(1, 2), 3), Plus(Plus(4, 5), 6))
+    parse("3 - 2 > 2 - 1") shouldBe GT(Minus(3, 2), Minus(2, 1))
+    parse("1 - 2 - 3 > 4 - 5 - 6") shouldBe GT(Minus(Minus(1, 2), 3), Minus(Minus(4, 5), 6))
     parse("1 >= 0 || 3 > 2") shouldBe or(GE(1, 0), GT(3, 2))
-    parse("2 >= 0 + 1 || 3 - 1 >= 2") shouldBe or(GE(2, Plus(0, 1)), GE(Minus(3, 1), 2))
-    parse("x1 || x2 > x3 + x4 - x5 || x6") shouldBe
+    parse("2 >= 0 - 1 || 3 - 1 >= 2") shouldBe or(GE(2, Minus(0, 1)), GE(Minus(3, 1), 2))
+    parse("x1 || x2 > x3 - x4 - x5 || x6") shouldBe
       or(
         or(BoolIdent("x1"),
            GT(IntIdent("x2"),
-              Minus(Plus(IntIdent("x3"), IntIdent("x4")), IntIdent("x5")))),
+              Minus(Minus(IntIdent("x3"), IntIdent("x4")), IntIdent("x5")))),
         BoolIdent("x6"))
-    parse("x1 || x2 > x3 + x4") shouldBe
+    parse("x1 || x2 > x3 - x4") shouldBe
       or(BoolIdent("x1"),
         GT(IntIdent("x2"),
-          Plus(IntIdent("x3"), IntIdent("x4"))))
+          Minus(IntIdent("x3"), IntIdent("x4"))))
   }
 
   property("tuple operations") {
     parse("()") shouldBe UnitConstant
     parse("(1)") shouldBe IntConstant(1)
     parse("(1, 2)") shouldBe Tuple(IntConstant(1), IntConstant(2))
-    parse("(1, X + 1)") shouldBe Tuple(IntConstant(1), mkPlus(IntIdent("X"), 1))
+    parse("(1, X - 1)") shouldBe Tuple(IntConstant(1), mkMinus(IntIdent("X"), 1))
     parse("(1, 2, 3)") shouldBe Tuple(IntConstant(1), IntConstant(2), IntConstant(3))
-    parse("(1, 2 + 3, 4)") shouldBe Tuple(IntConstant(1), Plus(2, 3), IntConstant(4))
+    parse("(1, 2 - 3, 4)") shouldBe Tuple(IntConstant(1), Minus(2, 3), IntConstant(4))
 
     parse("(1, 2L)._1") shouldBe Select(Tuple(IntConstant(1), LongConstant(2)), "_1")
     parse("(1, 2L)._2") shouldBe Select(Tuple(IntConstant(1), LongConstant(2)), "_2")
@@ -111,7 +112,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
       """.stripMargin) shouldBe Block(Let("X", IntConstant(10)), GT(3, 2))
 
     parse("{let X = 10; 3 > 2}") shouldBe Block(Let("X", IntConstant(10)), GT(3, 2))
-    parse("{let X = 3 + 2; 3 > 2}") shouldBe Block(Let("X", Plus(3, 2)), GT(3, 2))
+    parse("{let X = 3 - 2; 3 > 2}") shouldBe Block(Let("X", Minus(3, 2)), GT(3, 2))
     parse("{let X = if (true) true else false; false}") shouldBe Block(Let("X", If(TrueLeaf, TrueLeaf, FalseLeaf)), FalseLeaf)
 
     val expr = parse(
@@ -163,10 +164,10 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
        |let X = 12
        |/* comment // nested line comment
        |*/
-       |3 + // end line comment
+       |3 - // end line comment
        |  2
        |}
-      """.stripMargin) shouldBe Block(Seq(Let("X", IntConstant(12))), Plus(3, 2))
+      """.stripMargin) shouldBe Block(Seq(Let("X", IntConstant(12))), Minus(3, 2))
   }
 
   property("if") {
@@ -204,15 +205,15 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
     parse("Array(1)") shouldBe Apply(Ident("Array"), IndexedSeq(IntConstant(1)))
     parse("Array(1, X)") shouldBe Apply(Ident("Array"), IndexedSeq(IntConstant(1), Ident("X")))
-    parse("Array(1, X + 1, Array())") shouldBe
+    parse("Array(1, X - 1, Array())") shouldBe
     Apply(Ident("Array"),
       IndexedSeq(
         IntConstant(1),
-        mkPlus(Ident("X").asValue[SLong.type], IntConstant(1)),
+        mkMinus(Ident("X").asValue[SLong.type], IntConstant(1)),
         Apply(Ident("Array"), IndexedSeq.empty)))
-    parse("Array(Array(X + 1))") shouldBe Apply(Ident("Array"),
+    parse("Array(Array(X - 1))") shouldBe Apply(Ident("Array"),
       IndexedSeq(Apply(Ident("Array"), IndexedSeq(
-                  mkPlus(Ident("X").asValue[SLong.type], IntConstant(1))))))
+                  mkMinus(Ident("X").asValue[SLong.type], IntConstant(1))))))
   }
 
   property("Option constructors") {
@@ -220,9 +221,9 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("Some(None)") shouldBe Apply(Ident("Some"), IndexedSeq(Ident("None")))
     parse("Some(10)") shouldBe Apply(Ident("Some"), IndexedSeq(IntConstant(10)))
     parse("Some(X)") shouldBe Apply(Ident("Some"), IndexedSeq(Ident("X")))
-    parse("Some(Some(X + 1))") shouldBe Apply(Ident("Some"),
+    parse("Some(Some(X - 1))") shouldBe Apply(Ident("Some"),
       IndexedSeq(Apply(Ident("Some"), IndexedSeq(
-                  mkPlus(Ident("X").asValue[SLong.type], IntConstant(1))))))
+                  mkMinus(Ident("X").asValue[SLong.type], IntConstant(1))))))
   }
 
   property("array indexed access") {
@@ -250,10 +251,10 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("OUTPUTS.forall(fun (out: Box) = out.value > 0)") shouldBe
       Apply(Select(Ident("OUTPUTS"), "forall"),
             Vector(Lambda(Vector(("out",SBox)), GT(Select(Ident("out"),"value").asIntValue, 0))))
-    parse("Array(1,2).fold(0, fun (n1: Int, n2: Int) = n1 + n2)") shouldBe
+    parse("Array(1,2).fold(0, fun (n1: Int, n2: Int) = n1 - n2)") shouldBe
       Apply(
         Select(Apply(Ident("Array"), Vector(IntConstant(1), IntConstant(2))), "fold"),
-        Vector(IntConstant(0), Lambda(Vector(("n1",SInt), ("n2",SInt)), Plus(IntIdent("n1"), IntIdent("n2"))))
+        Vector(IntConstant(0), Lambda(Vector(("n1",SInt), ("n2",SInt)), Minus(IntIdent("n1"), IntIdent("n2"))))
       )
     parse("OUTPUTS.slice(0, 10)") shouldBe
         Apply(Select(Ident("OUTPUTS"), "slice"), Vector(IntConstant(0), IntConstant(10)))
@@ -277,13 +278,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("lambdas") {
-    parse("fun (x: Int) = x + 1") shouldBe
-      Lambda(IndexedSeq("x" -> SInt), mkPlus(Ident("x").asValue[SInt.type], IntConstant(1)))
-    parse("fun (x: Int): Int = x + 1") shouldBe
-      Lambda(IndexedSeq("x" -> SInt), SInt, mkPlus(Ident("x").asValue[SInt.type], IntConstant(1)))
-    parse("fun (x: Int, box: Box): Long = x + box.value") shouldBe
+    parse("fun (x: Int) = x - 1") shouldBe
+      Lambda(IndexedSeq("x" -> SInt), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
+    parse("fun (x: Int): Int = x - 1") shouldBe
+      Lambda(IndexedSeq("x" -> SInt), SInt, mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
+    parse("fun (x: Int, box: Box): Long = x - box.value") shouldBe
         Lambda(IndexedSeq("x" -> SInt, "box" -> SBox), SLong,
-               Plus(Ident("x").asValue[SInt.type], Select(Ident("box"), "value").asValue[SLong.type]))
+               Minus(Ident("x").asValue[SInt.type], Select(Ident("box"), "value").asValue[SLong.type]))
     parse("fun (p: (Int, GroupElement), box: Box): Boolean = p._1 > box.value && p._2.isIdentity") shouldBe
         Lambda(IndexedSeq("p" -> STuple(SInt, SGroupElement), "box" -> SBox), SBoolean,
           and(
@@ -299,13 +300,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
             )
         )
 
-    parse("fun (x) = x + 1") shouldBe
-        Lambda(IndexedSeq("x" -> NoType), mkPlus(Ident("x").asValue[SInt.type], IntConstant(1)))
-    parse("fun (x: Int) = { x + 1 }") shouldBe
-        Lambda(IndexedSeq("x" -> SInt), Block(Seq(), mkPlus(Ident("x").asValue[SInt.type], IntConstant(1))))
-    parse("fun (x: Int) = { let y = x + 1; y }") shouldBe
+    parse("fun (x) = x - 1") shouldBe
+        Lambda(IndexedSeq("x" -> NoType), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
+    parse("fun (x: Int) = { x - 1 }") shouldBe
+        Lambda(IndexedSeq("x" -> SInt), Block(Seq(), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1))))
+    parse("fun (x: Int) = { let y = x - 1; y }") shouldBe
         Lambda(IndexedSeq("x" -> SInt),
-          Block(Let("y", mkPlus(IntIdent("x"), 1)), Ident("y")))
+          Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
   }
 
   property("predefined Exists with lambda argument") {
@@ -319,15 +320,15 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   property("function definitions") {
     parse(
-      """{let f = fun (x: Int) = x + 1
+      """{let f = fun (x: Int) = x - 1
        |f}
       """.stripMargin) shouldBe
-        Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkPlus(IntIdent("x"), 1))), Ident("f"))
+        Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
     parse(
-      """{fun f(x: Int) = x + 1
+      """{fun f(x: Int) = x - 1
        |f}
       """.stripMargin) shouldBe
-        Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkPlus(IntIdent("x"), 1))), Ident("f"))
+        Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
   }
 
   property("get field of ref") {
@@ -376,6 +377,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     fail("(X", 2)
     fail("{ X", 3)
     fail("{ let X", 7)
+    fail("\"str", 4)
   }
 
   property("numeric casts") {
@@ -394,5 +396,10 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("\"\"\"h\\el\nlo\"\"\"") shouldBe StringConstant("h\\el\nlo")
     // in expression
     parse(""" "hello" == "hello" """) shouldBe EQ(StringConstant("hello"), StringConstant("hello"))
+  }
+
+  property("string concat") {
+    parse(""" "hello" + "hello" """) shouldBe
+      MethodCall(StringConstant("hello"), "+", IndexedSeq(StringConstant("hello")))
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -6,7 +6,7 @@ import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.SigmaPredef._
-import sigmastate.lang.exceptions.{InvalidBinaryOperationParameters, MethodNotFound, TyperException}
+import sigmastate.lang.exceptions.{InvalidBinaryOperationParameters, MethodNotFound, NonApplicableMethod, TyperException}
 import sigmastate.serialization.generators.ValueGenerators
 
 class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with LangTests with ValueGenerators {
@@ -418,7 +418,13 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 % false")
     an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "min(1, false)")
     an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "max(1, false)")
-    an[TyperException] should be thrownBy typecheck(env, "1 * false")
+    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 * false")
+    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 + \"a\"")
+    an[NonApplicableMethod] should be thrownBy typecheck(env, "1 || 1")
+    an[NonApplicableMethod] should be thrownBy typecheck(env, "col1 || col2")
+    an[NonApplicableMethod] should be thrownBy typecheck(env, "g1 || g2")
+    an[NonApplicableMethod] should be thrownBy typecheck(env, "true ++ false")
+    an[NonApplicableMethod] should be thrownBy typecheck(env, "\"a\" ++ \"a\"")
   }
 
   property("upcast for binary operations with numeric types") {
@@ -446,5 +452,9 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("invalid cast method for numeric types") {
     an[MethodNotFound] should be thrownBy typecheck(env, "1.toSuperBigInteger")
+  }
+
+  property("string concat") {
+    typecheck(env, """ "a" + "b" """) shouldBe SString
   }
 }

--- a/src/test/scala/sigmastate/serialization/ConstantSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ConstantSerializerSpecification.scala
@@ -43,6 +43,7 @@ class ConstantSerializerSpecification extends TableSerializationSpecification {
     forAll { x: Byte => roundTripTest(Constant[SByte.type](x, SByte)) }
     forAll { x: Boolean => roundTripTest(BooleanConstant.fromBoolean(x)) }
     forAll { x: Long => roundTripTest(Constant[SLong.type](x, SLong)) }
+    forAll { x: String => roundTripTest(Constant[SString.type](x, SString)) }
     forAll { x: BigInteger => roundTripTest(Constant[SBigInt.type](x, SBigInt)) }
     forAll { x: EcPointType => roundTripTest(Constant[SGroupElement.type](x, SGroupElement)) }
     forAll { x: SigmaBoolean => roundTripTest(Constant[SSigmaProp.type](x, SSigmaProp)) }

--- a/src/test/scala/sigmastate/serialization/DataSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/DataSerializerSpecification.scala
@@ -6,9 +6,8 @@ import org.ergoplatform.ErgoBox
 import org.scalacheck.Arbitrary._
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values.SigmaBoolean
-import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate._
-import sigmastate.utils.ByteArrayBuilder
+import sigmastate.interpreter.CryptoConstants.EcPointType
 
 class DataSerializerSpecification extends SerializationSpecification {
 
@@ -56,6 +55,7 @@ class DataSerializerSpecification extends SerializationSpecification {
     forAll { x: Byte => roundtrip[SByte.type](x, SByte) }
     forAll { x: Boolean => roundtrip[SBoolean.type](x, SBoolean) }
     forAll { x: Long => roundtrip[SLong.type](x, SLong) }
+    forAll { x: String => roundtrip[SString.type](x, SString) }
     forAll { x: BigInteger => roundtrip[SBigInt.type](x, SBigInt) }
     forAll { x: EcPointType => roundtrip[SGroupElement.type](x, SGroupElement) }
     forAll { x: SigmaBoolean => roundtrip[SSigmaProp.type](x, SSigmaProp) }

--- a/src/test/scala/sigmastate/serialization/TwoArgumentSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TwoArgumentSerializerSpecification.scala
@@ -49,4 +49,10 @@ class TwoArgumentSerializerSpecification extends TableSerializationSpecification
       roundTripTest(Exponentiate(x1, x2))
     }
   }
+
+  property("StringConcat: Serializer round trip") {
+    forAll(stringConstGen, stringConstGen) { (x1: StringConstant, x2: StringConstant) =>
+      roundTripTest(StringConcat(x1, x2))
+    }
+  }
 }

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -61,6 +61,8 @@ trait ValueGenerators extends TypeGenerators {
     arbInt.arbitrary.map { v => mkConstant[SInt.type](v, SInt) }
   val longConstGen: Gen[LongConstant] =
     arbLong.arbitrary.map { v => mkConstant[SLong.type](v, SLong) }
+  val stringConstGen: Gen[StringConstant] =
+    arbString.arbitrary.map { v => mkConstant[SString.type](v, SString) }
   val bigIntConstGen: Gen[BigIntConstant] =
     arbBigInt.arbitrary.map { v => mkConstant[SBigInt.type](v.bigInteger, SBigInt) }
   val byteArrayConstGen: Gen[CollectionConstant[SByte.type]] = for {


### PR DESCRIPTION
Ref #230 

Todo:
- [x] add `SString` type and `StringConstant`;
- [x] enable string literals parsing in the parser;
- [x] strip parsed literal of single/triple quotes;
- [x] (de)serialization of SString constant;
- [x] Add string concatenation + (parse, interpret, (de)serialize);
