### PR TITLE
Sync scalac options with Ergo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ libraryDependencies ++= Seq(
 ) ++ testingDependencies
 
 
+scalacOptions ++= Seq("-feature", "-deprecation")
+
 //uncomment lines below if the Scala compiler hangs to see where it happens
 //scalacOptions in Compile ++= Seq("-Xprompt", "-Ydebug", "-verbose" )
 

--- a/src/main/scala/sigmastate/UnprovenTree.scala
+++ b/src/main/scala/sigmastate/UnprovenTree.scala
@@ -10,6 +10,7 @@ import scapi.sigma.{FirstDiffieHellmanTupleProverMessage, FirstProverMessage, Pr
 import sigmastate.Values.SigmaBoolean
 import sigmastate.serialization.ValueSerializer
 
+import scala.language.existentials
 
 object ConjectureType extends Enumeration {
   val AndConjecture = Value(0)

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -14,7 +14,7 @@ import scorex.crypto.authds.avltree.batch.Lookup
 import sigmastate.SCollection.SByteArray
 import scorex.crypto.authds.{ADKey, SerializedAdProof}
 import scorex.crypto.hash.Blake2b256
-import scorex.utils.ScryptoLogging
+import scorex.util.ScorexLogging
 import sigmastate.Values._
 import sigmastate.interpreter.Interpreter.VerificationResult
 import sigmastate.serialization.{OpCodes, ValueSerializer}
@@ -48,7 +48,7 @@ object CryptoFunctions {
   }
 }
 
-trait Interpreter extends ScryptoLogging {
+trait Interpreter extends ScorexLogging {
 
   import CryptoConstants._
   import Interpreter.ReductionResult

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -1,7 +1,7 @@
 package sigmastate.utxo.examples
 
 import org.ergoplatform.{ErgoLikeContext, Height, _}
-import scorex.utils.ScryptoLogging
+import scorex.util.ScorexLogging
 import sigmastate.Values.{IntConstant, LongConstant}
 import sigmastate.helpers.{ErgoLikeProvingInterpreter, SigmaTestingCommons}
 import sigmastate.interpreter.ContextExtension
@@ -15,7 +15,7 @@ import sigmastate.{SLong, _}
   * Instead of having implicit emission via coinbase transaction, we implement 1 output in a state with script,
   * that controls emission rules
   */
-class CoinEmissionSpecification extends SigmaTestingCommons with ScryptoLogging {
+class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
 
   private val reg1 = ErgoBox.nonMandatoryRegisters.head
 


### PR DESCRIPTION
Initially, I've included "-Xfatal-warnings" but I could not fix deprecated `ECFieldElement.Fp` in a reasonable time here - http://github.com/ScorexFoundation/sigmastate-interpreter/blob/95cacbc00155b9488d74bc568661a559c5a402fd/src/main/scala/scapi/sigma/BcDlogFp.scala#L143
