### PR TITLE
getVar to return Option[T]

### DIFF
--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -81,9 +81,10 @@ Every box has the following properties:
 Besides properties, every box can have up to 10 numbered registers.
 The following syntax is supported to access registers on box objects:
 ```
-SELF.R3[Int].value     // access R3 register, cast its value to Int and return it
-SELF.R3.isDefined      // check that value of R3  is defined
-SELF.R3[Int].isDefined // check that value of R3  is defined and has type Int
+SELF.R3[Int].get            // access R3 register, cast its value to Int and return it
+SELF.R3[Int].isDefined      // check that value of R3  is defined and has type Int
+SELF.R3[Int].isEmpty        // check that value of R3  is undefined 
+SELF.R3[Int].getOrElse(def) // access R3 value if defined, otherwise return def
 ```
 Note, that Option[T] is introduced at frontend to represent the type of register value
 ```
@@ -156,7 +157,7 @@ fun byteArrayToBigInt(input: Array[Byte]): BigInt
 fun intToByteArray(input: Int): Array[Byte]
 
 /** Returns value of the given type from the environment by its tag.*/
-fun getVar[T](tag: Int): T
+fun getVar[T](tag: Int): Option[T]
 
 fun proveDHTuple(g: GroupElement, h: GroupElement, 
                  u: GroupElement, v: GroupElement): Boolean
@@ -208,7 +209,7 @@ into the blockchain yet, then R3 contains the current height of the blockchain).
 ```
 guard DemurrageCurrency(demurragePeriod: Int, demurrageCost: Int, regularScript: Sigma) {
   let c2 = allOf(Array(
-   HEIGHT >= SELF.R3[Int].value + demurragePeriod,
+   HEIGHT >= SELF.R3[Int].get + demurragePeriod,
    OUTPUTS.exists(fun (out: Box) = {
      out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes
    })

--- a/docs/wpaper/sigma.tex
+++ b/docs/wpaper/sigma.tex
@@ -270,7 +270,7 @@ A context can also contain typed variables that can be retrieved by numerical id
 
 Such context enxtensions can be useful, for example, for requiring a spending transaction to produce hash preimages (the BLAKE2b-256 and SHA-256 hash functions can invoked in \langname, using keywords \texttt{blake2b256} and \texttt{sha256}). For example,
 \begin{verbatim}
-       pkA && blake2b256(getVar[Array[Byte]](1)) ==  hashOutput
+       pkA && blake2b256(getVar[Array[Byte]](1).get) ==  hashOutput
 \end{verbatim}
 says that spending can be done only using the signature of Alice, and only if the preimage of \texttt{hashOutput} is written in the context. Specifically, the script requires that the context extension should contain a variable (with id \texttt{1}), which is an array of bytes that hashes to the value of \texttt{hashOutput} (the value of \texttt{hashOutput}, like \texttt{pkA}, is defined in the environment and is hardwired into the script at compile time).  Note that although the script requires both the secret key corresponding to \texttt{pkA} and the hash preimage corresponding to \texttt{hashOutput}, there is the stark difference between how these two values are used: the secret key is not revealed in the proof (by the zero-knowledge property of $\Sigma$-proofs), while the hash preimage is explicitly written into the context extension and can be seen by anyone once the transaction takes place.
 
@@ -282,7 +282,7 @@ Alice creates a random secret \texttt{x} of 256 bits (32 bytes), hashes it to ob
 \begin{verbatim}
         anyOf( Array(
                 HEIGHT > deadlineBob && pkA,
-                pkB && blake2b256(getVar[Array[Byte]](1)) == hx
+                pkB && blake2b256(getVar[Array[Byte]](1).get) == hx
         ))
 \end{verbatim}
 Bob can receive the value of this box only upon presentation of a hash preimage of \texttt{hx}. Alice can reclaim it after \texttt{deadlineBob}.
@@ -293,15 +293,15 @@ From this output, Bob learns \texttt{hx}. He creates a transaction in Alice's bl
                 HEIGHT > deadlineAlice && pkB,
                 allOf( Array( 
                         pkA,
-                        getVar[Array[Byte]](1).size<33,
-                        blake2b256(getVar[Array[Byte]](1)) == hx
+                        getVar[Array[Byte]](1).get.size < 33,
+                        blake2b256(getVar[Array[Byte]](1).get) == hx
                 ))
         ))
 \end{verbatim}
 
 If Alice is satisfied with the amount Bob is giving her, she claims the value of this box by revealing \texttt{x}. Alice is protected as long as the hash function is one-way and she keeps her \texttt{x} secret until she claims the value of this box. (She should be careful to submit her transaction in enough time before \texttt{deadlineAlice} to make sure it gets processed before Bob can reclaim this money, because once she submits the transaction, \texttt{x} is public and thus, if the \texttt{deadlineAlice} passes before the transaction is processed, Bob can both reclaim this box and claim the box Alice left in his blockchain.)
 
-Bob is protected, because in order for Alice to claim the value of this box, she must present a hash preimage of \texttt{hx} as a context extension in the transaction that uses this box as input. But once she does, Bob also learns this hash preimage, and is able to claim the value of the box that Alice placed into his blockchain. Note that Bob needs to choose \texttt{deadlineAlice} early enough to make sure that he is able to learn the preimage of \texttt{hx} from the transaction in Alice's block chain, and create a transaction in his blockchain, all before \texttt{deadlineBob} that Alice chose. Note also that \texttt{HEIGHT} in the two scripts is with respect to two different blockchains, which may be growing at a different rate. Bob also needs to make sure that he can use Alice's \texttt{x} as a context extension; to make sure Alice cannot cheat by making this \texttt{x} so long that it will not be allowed as a context extension in his blockchain, he uses the constraint \texttt{getVar[Array[Byte]](1).size<33}.
+Bob is protected, because in order for Alice to claim the value of this box, she must present a hash preimage of \texttt{hx} as a context extension in the transaction that uses this box as input. But once she does, Bob also learns this hash preimage, and is able to claim the value of the box that Alice placed into his blockchain. Note that Bob needs to choose \texttt{deadlineAlice} early enough to make sure that he is able to learn the preimage of \texttt{hx} from the transaction in Alice's block chain, and create a transaction in his blockchain, all before \texttt{deadlineBob} that Alice chose. Note also that \texttt{HEIGHT} in the two scripts is with respect to two different blockchains, which may be growing at a different rate. Bob also needs to make sure that he can use Alice's \texttt{x} as a context extension; to make sure Alice cannot cheat by making this \texttt{x} so long that it will not be allowed as a context extension in his blockchain, he uses the constraint \texttt{getVar[Array[Byte]](1).get.size < 33}.
 
 The same approach can be used to trade different assets on the same blockchain, in case of multiasset blockchains. However, for transactions on a single blockchain, an alternative approach is also possible. We describe it below.
 

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -93,7 +93,7 @@ class SigmaBinder(env: Map[String, Any], builder: SigmaBuilder) {
         throw new InvalidArguments(s"Invalid arguments for max: $args")
     }
 
-    case e @ Apply(ApplyTypes(f @ GetVarSym, targs), args) =>
+    case e @ Select(Apply(ApplyTypes(f @ GetVarSym, targs), args), "get", _) =>
       if (targs.length != 1 || args.length != 1)
         error(s"Wrong number of arguments in $e: expected one type argument and one variable id")
       val id = args.head match {

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -134,6 +134,9 @@ trait SigmaBuilder {
   def mkLambda(args: IndexedSeq[(String,SType)],
                givenResType: SType,
                body: Option[Value[SType]]): Value[SFunc]
+  def mkGenLambda(tpeParams: Seq[STypeParam], args: IndexedSeq[(String,SType)],
+               givenResType: SType,
+               body: Option[Value[SType]]): Value[SFunc]
 
   def mkConstant[T <: SType](value: T#WrappedType, tpe: T): Constant[T]
   def mkCollectionConstant[T <: SType](values: Array[T#WrappedType],
@@ -370,7 +373,13 @@ class StdSigmaBuilder extends SigmaBuilder {
   override def mkLambda(args: IndexedSeq[(String, SType)],
                         givenResType: SType,
                         body: Option[Value[SType]]): Value[SFunc] =
-    Lambda(args, givenResType, body)
+    Lambda(Nil, args, givenResType, body)
+
+  def mkGenLambda(tpeParams: Seq[STypeParam],
+                  args: IndexedSeq[(String, SType)],
+                  givenResType: SType,
+                  body: Option[Value[SType]]) =
+    Lambda(tpeParams, args, givenResType, body)
 
   override def mkConstant[T <: SType](value: T#WrappedType, tpe: T): Constant[T] =
     ConstantNode[T](value, tpe)

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -30,7 +30,7 @@ object SigmaPredef {
     "byteArrayToBigInt" -> mkLambda(Vector("input" -> SByteArray), SBigInt, None),
     "longToByteArray" -> mkLambda(Vector("input" -> SLong), SByteArray, None),
 
-    "getVar" -> mkGenLambda(Seq(STypeParam(tT)), Vector("varId" -> SByte), tT, None),
+    "getVar" -> mkGenLambda(Seq(STypeParam(tT)), Vector("varId" -> SByte), SOption(tT), None),
 
     "proveDHTuple" -> mkLambda(Vector(
       "g" -> SGroupElement, "h" -> SGroupElement, "u" -> SGroupElement, "v" -> SGroupElement), SBoolean, None),

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -1,9 +1,9 @@
 package sigmastate.lang
 
 import sigmastate.SCollection.SByteArray
-import sigmastate.Values.{SValue, Value}
+import sigmastate.Values.{Value, SValue}
 import sigmastate._
-import sigmastate.lang.Terms.Lambda
+import sigmastate.lang.Terms.{Lambda, STypeParam}
 import sigmastate.lang.TransformingSigmaBuilder._
 
 object SigmaPredef {
@@ -30,7 +30,7 @@ object SigmaPredef {
     "byteArrayToBigInt" -> mkLambda(Vector("input" -> SByteArray), SBigInt, None),
     "longToByteArray" -> mkLambda(Vector("input" -> SLong), SByteArray, None),
 
-    "getVar" -> mkLambda(Vector("varId" -> SByte), tT, None),
+    "getVar" -> mkGenLambda(Seq(STypeParam(tT)), Vector("varId" -> SByte), tT, None),
 
     "proveDHTuple" -> mkLambda(Vector(
       "g" -> SGroupElement, "h" -> SGroupElement, "u" -> SGroupElement, "v" -> SGroupElement), SBoolean, None),

--- a/src/main/scala/sigmastate/lang/SigmaPrinter.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPrinter.scala
@@ -33,7 +33,7 @@ class SigmaPrinter extends org.bitbucket.inkytonik.kiama.output.PrettyPrinter {
     t match {
       case LongConstant(d) => value(d)
       case Ident(i,_) => i
-      case Lambda(args, tLam, Some(e)) =>
+      case Lambda(_, args, tLam, Some(e)) =>
         parens('\\' <> parens(lsep(args.map { case (n, targ) => n <+> ": " <+> typedeclToDoc(targ) }.to, comma)) <>
           typedeclToDoc(tLam) <+> '.' <+>
           group(nest(toDoc(e))))

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -83,7 +83,7 @@ class SigmaTyper(val builder: SigmaBuilder) {
           error(s"Cannot get field '$n' in in the object $obj of non-product type $t")
       }
 
-    case lam @ Lambda(args, t, body) =>
+    case lam @ Lambda(tparams, args, t, body) =>
       for ((name, t) <- args)
         if (t == NoType)
           error(s"Invalid function $lam: undefined type of argument $name")
@@ -93,7 +93,7 @@ class SigmaTyper(val builder: SigmaBuilder) {
         if (newBody.isDefined && t != newBody.get.tpe)
           error(s"Invalid function $lam: resulting expression type ${newBody.get.tpe} doesn't equal declared type $t")
       }
-      val res = mkLambda(args, newBody.fold(t)(_.tpe), newBody)
+      val res = mkGenLambda(tparams, args, newBody.fold(t)(_.tpe), newBody)
       res
 
     case app @ Apply(sel @ Select(obj, n, _), args) =>
@@ -257,21 +257,22 @@ class SigmaTyper(val builder: SigmaBuilder) {
           error(s"Invalid operation $mc on type $t")
       }
 
-    case app @ ApplyTypes(sel: Select, targs) =>
-      val newSel @ Select(obj, n, _) = assignType(env, sel)
-      newSel.tpe match {
-        case genFunTpe @ SFunc(_, _, tyVars) =>
-          if (tyVars.lengthCompare(targs.length) != 0)
-            error(s"Wrong number of type arguments $app: expected $tyVars but provided $targs")
-          val subst = tyVars.zip(targs).toMap
-          val concrFunTpe = applySubst(genFunTpe, subst).asFunc
-          mkSelect(obj, n, Some(concrFunTpe.tRange))
-        case _ =>
-          error(s"Invalid application of type arguments $app: function $sel doesn't have type parameters")
+    case app @ ApplyTypes(input, targs) =>
+      def update(input: SValue, newTpe: SType) = input match {
+        case Select(obj, n, _) => mkSelect(obj, n, Some(newTpe))
       }
-
-    case app @ ApplyTypes(in, targs) =>
-      error(s"Invalid application of type arguments $app: expression doesn't have type parameters")
+      val newInput = assignType(env, input)
+      newInput.tpe match {
+        case genFunTpe @ SFunc(_, _, tpeParams) =>
+          if (tpeParams.lengthCompare(targs.length) != 0)
+            error(s"Wrong number of type arguments $app: expected $tpeParams but provided $targs. " +
+                  s"Note that partial application of type parameters is not supported.")
+          val subst = tpeParams.map(_.ident).zip(targs).toMap
+          val concrFunTpe = applySubst(genFunTpe, subst).asFunc
+          update(newInput, concrFunTpe.tRange)
+        case _ =>
+          error(s"Invalid application of type arguments $app: function $input doesn't have type parameters")
+      }
 
     case If(c, t, e) =>
       val c1 = assignType(env, c).asValue[SBoolean.type]
@@ -509,8 +510,8 @@ object SigmaTyper {
   }
 
   def applySubst(tpe: SType, subst: STypeSubst): SType = tpe match {
-    case SFunc(args, res, tvars) =>
-      val remainingVars = tvars.filterNot(subst.contains)
+    case SFunc(args, res, tparams) =>
+      val remainingVars = tparams.filterNot { p => subst.contains(p.ident) }
       SFunc(args.map(applySubst(_, subst)), applySubst(res, subst), remainingVars)
     case _ =>
       val substRule = rule[SType] {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -403,7 +403,7 @@ case object SBox extends SProduct with SPredefType {
 
   private val tT = STypeIdent("T")
   def registers(): Seq[SMethod] = {
-    (1 to 10).map(i => SMethod(s"R$i", SFunc(IndexedSeq(), SOption(tT), Seq(tT))))
+    (1 to 10).map(i => SMethod(s"R$i", SFunc(IndexedSeq(), SOption(tT), Seq(STypeParam(tT)))))
   }
   val PropositionBytes = "propositionBytes"
   val Value = "value"
@@ -462,13 +462,16 @@ object SCollection {
   val tOV = STypeIdent("OV")
   val methods = Seq(
     SMethod("size", SInt),
-    SMethod("getOrElse", SFunc(IndexedSeq(SCollection(tIV), SInt, tIV), tIV, Seq(tIV))),
-    SMethod("map", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, tOV)), SCollection(tOV), Seq(tIV, tOV))),
-    SMethod("exists", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(tIV))),
-    SMethod("fold", SFunc(IndexedSeq(SCollection(tIV), tOV, SFunc(IndexedSeq(tOV, tIV), tOV)), tOV, Seq(tIV, tOV))),
-    SMethod("forall", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(tIV))),
-    SMethod("slice", SFunc(IndexedSeq(SCollection(tIV), SInt, SInt), SCollection(tIV), Seq(tIV))),
-    SMethod("where", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SCollection(tIV), Seq(tIV)))
+    SMethod("getOrElse", SFunc(IndexedSeq(SCollection(tIV), SInt, tIV), tIV, Seq(STypeParam(tIV)))),
+    SMethod("map", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, tOV)),
+                         SCollection(tOV),
+                         Seq(STypeParam(tIV), STypeParam(tOV)))),
+    SMethod("exists", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(STypeParam(tIV)))),
+    SMethod("fold", SFunc(IndexedSeq(SCollection(tIV), tOV, SFunc(IndexedSeq(tOV, tIV), tOV)),
+                          tOV, Seq(STypeParam(tIV), STypeParam(tOV)))),
+    SMethod("forall", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SBoolean, Seq(STypeParam(tIV)))),
+    SMethod("slice", SFunc(IndexedSeq(SCollection(tIV), SInt, SInt), SCollection(tIV), Seq(STypeParam(tIV)))),
+    SMethod("where", SFunc(IndexedSeq(SCollection(tIV), SFunc(tIV, SBoolean)), SCollection(tIV), Seq(STypeParam(tIV))))
   )
   def apply[T <: SType](elemType: T): SCollection[T] = SCollectionType(elemType)
   def apply[T <: SType](implicit elemType: T, ov: Overload1): SCollection[T] = SCollectionType(elemType)
@@ -521,7 +524,7 @@ object SOption {
     Seq(
       SMethod("isDefined", SBoolean),
       SMethod("value", tArg),
-      SMethod("valueOrElse", SFunc(IndexedSeq(SOption(tArg), tArg), tArg, Seq(tT)))
+      SMethod("valueOrElse", SFunc(IndexedSeq(SOption(tArg), tArg), tArg, Seq(STypeParam(tT))))
     )
   private val tT = STypeIdent("T")
   val methods: Seq[SMethod] = createMethods(tT)
@@ -575,11 +578,11 @@ object STuple {
   val componentNames = Range(1, 31).map(i => s"_$i")
 }
 
-case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeArgs: Seq[STypeIdent] = Nil) extends SType {
+case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeParams: Seq[STypeParam] = Nil) extends SType {
   override type WrappedType = Seq[Any] => tRange.WrappedType
   override val typeCode = SFunc.FuncTypeCode
   override def toString = {
-    val args = if (tpeArgs.isEmpty) "" else tpeArgs.mkString("[", ",", "]")
+    val args = if (tpeParams.isEmpty) "" else tpeParams.mkString("[", ",", "]")
     s"$args(${tDom.mkString(",")}) => $tRange"
   }
 }

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -522,9 +522,10 @@ object SOption {
 
   private[sigmastate] def createMethods(tArg: STypeIdent): Seq[SMethod] =
     Seq(
+      SMethod("isEmpty", SBoolean),
       SMethod("isDefined", SBoolean),
-      SMethod("value", tArg),
-      SMethod("valueOrElse", SFunc(IndexedSeq(SOption(tArg), tArg), tArg, Seq(STypeParam(tT))))
+      SMethod("get", tArg),
+      SMethod("getOrElse", SFunc(IndexedSeq(SOption(tArg), tArg), tArg, Seq(STypeParam(tT))))
     )
   private val tT = STypeIdent("T")
   val methods: Seq[SMethod] = createMethods(tT)

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -127,15 +127,15 @@ class TestingInterpreterSpecification extends PropSpec
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R4[Array[Int]].value
+              |  let arr = box1.R4[Array[Int]].get
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R5[Array[Boolean]].value
+              |  let arr = box1.R5[Array[Boolean]].get
               |  anyOf(arr)
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R5[Array[Boolean]].value
+              |  let arr = box1.R5[Array[Boolean]].get
               |  allOf(arr) == false
               |}""".stripMargin)
     testEval("""{

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -41,8 +41,8 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("predefined functions") {
-    bind(env, "getVar[Byte](10)") shouldBe TaggedVariable(10, SByte)
-    bind(env, "getVar[Array[Byte]](10)") shouldBe TaggedVariable(10, SByteArray)
+    bind(env, "getVar[Byte](10).get") shouldBe TaggedVariable(10, SByte)
+    bind(env, "getVar[Array[Byte]](10).get") shouldBe TaggedVariable(10, SByteArray)
     bind(env, "min(1, 2)") shouldBe Min(IntConstant(1), IntConstant(2))
     bind(env, "max(1, 2)") shouldBe Max(IntConstant(1), IntConstant(2))
     bind(env, "min(1, 2L)") shouldBe Min(Upcast(IntConstant(1), SLong), LongConstant(2))

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -167,7 +167,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "X[(Int, Boolean)]") shouldBe ApplyTypes(Ident("X"), Seq(STuple(SInt, SBoolean)))
     bind(env, "X[Int, Boolean]") shouldBe ApplyTypes(Ident("X"), Seq(SInt, SBoolean))
     bind(env, "SELF.R1[Int]") shouldBe ApplyTypes(Select(Self, "R1"), Seq(SInt))
-    bind(env, "SELF.R1[Int].isDefined") shouldBe Select(ApplyTypes(Select(Self, "R1"), Seq(SInt)), "isDefined")
+    bind(env, "SELF.R1[Int].isEmpty") shouldBe Select(ApplyTypes(Select(Self, "R1"), Seq(SInt)), "isEmpty")
     bind(env, "f[Int](10)") shouldBe Apply(ApplyTypes(Ident("f"), Seq(SInt)), IndexedSeq(IntConstant(10)))
     bind(env, "INPUTS.map[Int]") shouldBe ApplyTypes(Select(Inputs, "map"), Seq(SInt))
     bind(env, "INPUTS.map[Int](10)") shouldBe Apply(ApplyTypes(Select(Inputs, "map"), Seq(SInt)), IndexedSeq(IntConstant(10)))

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -54,13 +54,13 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
 
   property("predefined functions") {
     comp(env, "anyOf(Array(c1, c2))") shouldBe OR(ConcreteCollection(Vector(TrueLeaf, FalseLeaf)))
-    comp(env, "blake2b256(getVar[Array[Byte]](10))") shouldBe CalcBlake2b256(TaggedVariable(10, SByteArray))
+    comp(env, "blake2b256(getVar[Array[Byte]](10).get)") shouldBe CalcBlake2b256(TaggedVariable(10, SByteArray))
     comp(env, "10.toByte") shouldBe ByteConstant(10)
     comp(env, "Array(1)(0).toByte") shouldBe
       Downcast(ByIndex(ConcreteCollection(Vector(IntConstant(1)),SInt),IntConstant(0),None), SByte)
     comp(env, "allOf(Array(c1, c2))") shouldBe AND(ConcreteCollection(Vector(TrueLeaf, FalseLeaf)))
-    comp(env, "getVar[Byte](10)") shouldBe TaggedVariable(10, SByte)
-    comp(env, "getVar[Array[Byte]](10)") shouldBe TaggedVariable(10, SByteArray)
+    comp(env, "getVar[Byte](10).get") shouldBe TaggedVariable(10, SByte)
+    comp(env, "getVar[Array[Byte]](10).get") shouldBe TaggedVariable(10, SByteArray)
   }
 
   property("negative tests") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -307,7 +307,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("f(x, y).size") shouldBe Select(Apply(Ident("f"), IndexedSeq(Ident("x"), Ident("y"))), "size")
     parse("f(x, y).get(1)") shouldBe Apply(Select(Apply(Ident("f"), IndexedSeq(Ident("x"), Ident("y"))), "get"), IndexedSeq(IntConstant(1)))
     parse("{let y = f(x); y}") shouldBe Block(Seq(Let("y", Apply(Ident("f"), IndexedSeq(Ident("x"))))), Ident("y"))
-    parse("getVar[Array[Byte]](10)") shouldBe Apply(ApplyTypes(Ident("getVar"), Seq(SByteArray)), IndexedSeq(IntConstant(10)))
+    parse("getVar[Array[Byte]](10).get") shouldBe Select(Apply(ApplyTypes(Ident("getVar"), Seq(SByteArray)), IndexedSeq(IntConstant(10))), "get")
     parse("min(x, y)") shouldBe Apply(Ident("min"), IndexedSeq(Ident("x"), Ident("y")))
     parse("min(1, 2)") shouldBe Apply(Ident("min"), IndexedSeq(IntConstant(1), IntConstant(2)))
     parse("max(x, y)") shouldBe Apply(Ident("max"), IndexedSeq(Ident("x"), Ident("y")))

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -80,13 +80,13 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   property("predefined functions") {
     typecheck(env, "allOf") shouldBe AllSym.tpe
     typecheck(env, "allOf(Array(c1, c2))") shouldBe SBoolean
-    typecheck(env, "getVar[Byte](10)") shouldBe SByte
-    typecheck(env, "getVar[Array[Byte]](10)") shouldBe SByteArray
-    typecheck(env, "getVar[SigmaProp](10)") shouldBe SSigmaProp
-    typecheck(env, "p1 && getVar[SigmaProp](10)") shouldBe SBoolean
-    typecheck(env, "getVar[SigmaProp](10) || p2") shouldBe SBoolean
-    typecheck(env, "getVar[SigmaProp](10) && getVar[SigmaProp](11)") shouldBe SBoolean
-    typecheck(env, "Array(true, getVar[SigmaProp](11))") shouldBe SCollection(SBoolean)
+    typecheck(env, "getVar[Byte](10).get") shouldBe SByte
+    typecheck(env, "getVar[Array[Byte]](10).get") shouldBe SByteArray
+    typecheck(env, "getVar[SigmaProp](10).get") shouldBe SSigmaProp
+    typecheck(env, "p1 && getVar[SigmaProp](10).get") shouldBe SBoolean
+    typecheck(env, "getVar[SigmaProp](10).get || p2") shouldBe SBoolean
+    typecheck(env, "getVar[SigmaProp](10).get && getVar[SigmaProp](11).get") shouldBe SBoolean
+    typecheck(env, "Array(true, getVar[SigmaProp](11).get)") shouldBe SCollection(SBoolean)
     typecheck(env, "min(1, 2)") shouldBe SInt
     typecheck(env, "min(1L, 2)") shouldBe SLong
     typecheck(env, "min(HEIGHT, INPUTS.size)") shouldBe SLong
@@ -239,12 +239,12 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   property("type parameters") {
     typecheck(env, "SELF.R1[Int]") shouldBe SOption(SInt)
     typecheck(env, "SELF.R1[Int].isDefined") shouldBe SBoolean
-    typecheck(env, "SELF.R1[Int].value") shouldBe SInt
+    typecheck(env, "SELF.R1[Int].get") shouldBe SInt
     typefail(env, "x[Int]", "doesn't have type parameters")
     typefail(env, "arr1[Int]", "doesn't have type parameters")
     typecheck(env, "SELF.R1[(Int,Boolean)]") shouldBe SOption(STuple(SInt, SBoolean))
-    typecheck(env, "SELF.R1[(Int,Boolean)].value") shouldBe STuple(SInt, SBoolean)
-    an[IllegalArgumentException] should be thrownBy typecheck(env, "SELF.R1[Int,Boolean].value")
+    typecheck(env, "SELF.R1[(Int,Boolean)].get") shouldBe STuple(SInt, SBoolean)
+    an[IllegalArgumentException] should be thrownBy typecheck(env, "SELF.R1[Int,Boolean].get")
     typecheck(env, "Array[Int]()") shouldBe SCollection(SInt)
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -240,11 +240,11 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "SELF.R1[Int]") shouldBe SOption(SInt)
     typecheck(env, "SELF.R1[Int].isDefined") shouldBe SBoolean
     typecheck(env, "SELF.R1[Int].value") shouldBe SInt
-    typefail(env, "X[Int]", "expression doesn't have type parameters")
-    typefail(env, "arr1[Int]", "expression doesn't have type parameters")
+    typefail(env, "x[Int]", "doesn't have type parameters")
+    typefail(env, "arr1[Int]", "doesn't have type parameters")
     typecheck(env, "SELF.R1[(Int,Boolean)]") shouldBe SOption(STuple(SInt, SBoolean))
     typecheck(env, "SELF.R1[(Int,Boolean)].value") shouldBe STuple(SInt, SBoolean)
-    typefail(env, "SELF.R1[Int,Boolean].value", "Wrong number of type arguments")
+    an[IllegalArgumentException] should be thrownBy typecheck(env, "SELF.R1[Int,Boolean].value")
     typecheck(env, "Array[Int]()") shouldBe SCollection(SInt)
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -239,6 +239,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   property("type parameters") {
     typecheck(env, "SELF.R1[Int]") shouldBe SOption(SInt)
     typecheck(env, "SELF.R1[Int].isDefined") shouldBe SBoolean
+    typecheck(env, "SELF.R1[Int].isEmpty") shouldBe SBoolean
     typecheck(env, "SELF.R1[Int].get") shouldBe SInt
     typefail(env, "x[Int]", "doesn't have type parameters")
     typefail(env, "arr1[Int]", "doesn't have type parameters")

--- a/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
@@ -35,7 +35,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val treeData = new AvlTreeData(digest, 32, None)
 
     val env = Map("key" -> key, "proof" -> proof)
-    val prop = compile(env, """isMember(SELF.R4[AvlTree].value, key, proof)""").asBoolValue
+    val prop = compile(env, """isMember(SELF.R4[AvlTree].get, key, proof)""").asBoolValue
 
     val propTree = IsMember(ExtractRegisterAs(Self, reg1),
       ByteArrayConstant(key),
@@ -77,9 +77,9 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val env = Map("proofId" -> proofId.toLong, "elementId" -> elementId.toLong)
     val propCompiled = compile(env,
       """{
-        |  let tree = SELF.R3[AvlTree].value
-        |  let proof = getVar[Array[Byte]](proofId)
-        |  let element = getVar[Long](elementId)
+        |  let tree = SELF.R3[AvlTree].get
+        |  let proof = getVar[Array[Byte]](proofId).get
+        |  let element = getVar[Long](elementId).get
         |  let elementKey = blake2b256(longToByteArray(element))
         |  element >= 120 && isMember(tree, elementKey, proof)
         |}""".stripMargin).asBoolValue
@@ -136,9 +136,9 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val env = Map("proofId" -> proofId.toLong)
     val prop = compile(env,
       """{
-        |  let tree = SELF.R4[AvlTree].value
-        |  let key = SELF.R5[Array[Byte]].value
-        |  let proof = getVar[Array[Byte]](proofId)
+        |  let tree = SELF.R4[AvlTree].get
+        |  let key = SELF.R5[Array[Byte]].get
+        |  let proof = getVar[Array[Byte]](proofId).get
         |  isMember(tree, key, proof)
         |}""".stripMargin).asBoolValue
 

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -68,92 +68,92 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
   property("Relation operations") {
     test(env, ext,
-      "{ allOf(Array(getVar[Boolean](trueVar), true, true)) }",
+      "{ allOf(Array(getVar[Boolean](trueVar).get, true, true)) }",
       AND(TaggedBoolean(booleanVar), TrueLeaf, TrueLeaf)
     )
     test(env, ext,
-      "{ anyOf(Array(getVar[Boolean](trueVar), true, false)) }",
+      "{ anyOf(Array(getVar[Boolean](trueVar).get, true, false)) }",
       OR(TaggedBoolean(booleanVar), TrueLeaf, FalseLeaf)
     )
     test(env, ext,
-      "{ getVar[Int](intVar2) > getVar[Int](intVar1) && getVar[Int](intVar1) < getVar[Int](intVar2) }",
+      "{ getVar[Int](intVar2).get > getVar[Int](intVar1).get && getVar[Int](intVar1).get < getVar[Int](intVar2).get }",
       AND(GT(TaggedInt(intVar2), TaggedInt(intVar1)), LT(TaggedInt(intVar1), TaggedInt(intVar2)))
     )
     test(env, ext,
-      "{ getVar[Int](intVar2) >= getVar[Int](intVar1) && getVar[Int](intVar1) <= getVar[Int](intVar2) }",
+      "{ getVar[Int](intVar2).get >= getVar[Int](intVar1).get && getVar[Int](intVar1).get <= getVar[Int](intVar2).get }",
       AND(GE(TaggedInt(intVar2), TaggedInt(intVar1)), LE(TaggedInt(intVar1), TaggedInt(intVar2)))
     )
     test(env, ext,
-      "{ getVar[Byte](byteVar2) > getVar[Byte](byteVar1) && getVar[Byte](byteVar1) < getVar[Byte](byteVar2) }",
+      "{ getVar[Byte](byteVar2).get > getVar[Byte](byteVar1).get && getVar[Byte](byteVar1).get < getVar[Byte](byteVar2).get }",
       AND(GT(TaggedByte(byteVar2), TaggedByte(byteVar1)), LT(TaggedByte(byteVar1), TaggedByte(byteVar2)))
     )
     test(env, ext,
-      "{ getVar[Byte](byteVar2) >= getVar[Byte](byteVar1) && getVar[Byte](byteVar1) <= getVar[Byte](byteVar2) }",
+      "{ getVar[Byte](byteVar2).get >= getVar[Byte](byteVar1).get && getVar[Byte](byteVar1).get <= getVar[Byte](byteVar2).get }",
       AND(GE(TaggedByte(byteVar2), TaggedByte(byteVar1)), LE(TaggedByte(byteVar1), TaggedByte(byteVar2)))
     )
     test(env, ext,
-      "{ getVar[BigInt](bigIntVar2) > getVar[BigInt](bigIntVar1) && getVar[BigInt](bigIntVar1) < getVar[BigInt](bigIntVar2) }",
+      "{ getVar[BigInt](bigIntVar2).get > getVar[BigInt](bigIntVar1).get && getVar[BigInt](bigIntVar1).get < getVar[BigInt](bigIntVar2).get }",
       AND(GT(TaggedBigInt(bigIntVar2), TaggedBigInt(bigIntVar1)), LT(TaggedBigInt(bigIntVar1), TaggedBigInt(bigIntVar2)))
     )
     test(env, ext,
-      "{ getVar[BigInt](bigIntVar2) >= getVar[BigInt](bigIntVar1) && getVar[BigInt](bigIntVar1) <= getVar[BigInt](bigIntVar2) }",
+      "{ getVar[BigInt](bigIntVar2).get >= getVar[BigInt](bigIntVar1).get && getVar[BigInt](bigIntVar1).get <= getVar[BigInt](bigIntVar2).get }",
       AND(GE(TaggedBigInt(bigIntVar2), TaggedBigInt(bigIntVar1)), LE(TaggedBigInt(bigIntVar1), TaggedBigInt(bigIntVar2)))
     )
   }
 
   property("SigmaProp operations") {
     test(env, ext,
-      "{ getVar[SigmaProp](proofVar1).isValid }",
+      "{ getVar[SigmaProp](proofVar1).get.isValid }",
       TaggedSigmaProp(propVar1).isValid
     )
     test(env, ext,
-      "{ getVar[SigmaProp](proofVar1) || getVar[SigmaProp](proofVar2) }",
+      "{ getVar[SigmaProp](proofVar1).get || getVar[SigmaProp](proofVar2).get }",
       OR(TaggedSigmaProp(propVar1).isValid, TaggedSigmaProp(propVar2).isValid)
     )
     test(env, ext,
-      "{ getVar[SigmaProp](proofVar1) && getVar[SigmaProp](proofVar2) }",
+      "{ getVar[SigmaProp](proofVar1).get && getVar[SigmaProp](proofVar2).get }",
       AND(TaggedSigmaProp(propVar1).isValid, TaggedSigmaProp(propVar2).isValid)
     )
     test(env, ext,
-      "{ getVar[SigmaProp](proofVar1).isValid && getVar[SigmaProp](proofVar2) }",
+      "{ getVar[SigmaProp](proofVar1).get.isValid && getVar[SigmaProp](proofVar2).get }",
       AND(TaggedSigmaProp(propVar1).isValid, TaggedSigmaProp(propVar2).isValid)
     )
     test(env, ext,
-      "{ getVar[SigmaProp](proofVar1) && getVar[Int](intVar1) == 1 }",
+      "{ getVar[SigmaProp](proofVar1).get && getVar[Int](intVar1).get == 1 }",
       AND(TaggedSigmaProp(propVar1).isValid, EQ(TaggedInt(intVar1), 1))
     )
     test(env, ext,
-      "{ getVar[Int](intVar1) == 1 || getVar[SigmaProp](proofVar1) }",
+      "{ getVar[Int](intVar1).get == 1 || getVar[SigmaProp](proofVar1).get }",
       OR(EQ(TaggedInt(intVar1), 1), TaggedSigmaProp(propVar1).isValid)
     )
     test(env, ext,
-      "{ SELF.R4[SigmaProp].value.isValid }",
+      "{ SELF.R4[SigmaProp].get.isValid }",
       ExtractRegisterAs[SSigmaProp.type](Self, reg1).isValid,
       true
     )
     test(env, ext,
-      "{ SELF.R4[SigmaProp].value && getVar[SigmaProp](proofVar1)}",
+      "{ SELF.R4[SigmaProp].get && getVar[SigmaProp](proofVar1).get}",
       AND(ExtractRegisterAs[SSigmaProp.type](Self, reg1).isValid, TaggedSigmaProp(propVar1).isValid),
       true
     )
     test(env, ext,
-      "{ allOf(Array(SELF.R4[SigmaProp].value, getVar[SigmaProp](proofVar1)))}",
+      "{ allOf(Array(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get))}",
       AND(ExtractRegisterAs[SSigmaProp.type](Self, reg1).isValid, TaggedSigmaProp(propVar1).isValid),
       true
     )
     test(env, ext,
-      "{ anyOf(Array(SELF.R4[SigmaProp].value, getVar[SigmaProp](proofVar1)))}",
+      "{ anyOf(Array(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get))}",
       OR(ExtractRegisterAs[SSigmaProp.type](Self, reg1).isValid, TaggedSigmaProp(propVar1).isValid),
       true
     )
     test(env, ext,
-      "{ Array(SELF.R4[SigmaProp].value, getVar[SigmaProp](proofVar1)).forall(fun (p: SigmaProp) = p.isValid) }",
+      "{ Array(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get).forall(fun (p: SigmaProp) = p.isValid) }",
       ForAll(ConcreteCollection(ExtractRegisterAs[SSigmaProp.type](Self, reg1), TaggedSigmaProp(propVar1)),
         21, SigmaPropIsValid(TaggedSigmaProp(21))),
       true
     )
     test(env, ext,
-      "{ SELF.R4[SigmaProp].value.propBytes != getVar[SigmaProp](proofVar1).propBytes }",
+      "{ SELF.R4[SigmaProp].get.propBytes != getVar[SigmaProp](proofVar1).get.propBytes }",
       NEQ(ExtractRegisterAs[SSigmaProp.type](Self, reg1).propBytes, TaggedSigmaProp(propVar1).propBytes),
       true
     )
@@ -161,38 +161,38 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
   property("Arith operations") {
     test(env, ext,
-      "{ getVar[Int](intVar2) * 2 + getVar[Int](intVar1) == 5 }",
+      "{ getVar[Int](intVar2).get * 2 + getVar[Int](intVar1).get == 5 }",
       EQ(Plus(Multiply(TaggedInt(intVar2), IntConstant(2)), TaggedInt(intVar1)), IntConstant(5))
     )
     test(env, ext :+ (bigIntVar3 -> BigIntConstant(50)),
-      "{ getVar[BigInt](bigIntVar2) * 2 + getVar[BigInt](bigIntVar1) == getVar[BigInt](bigIntVar3) }",
+      "{ getVar[BigInt](bigIntVar2).get * 2 + getVar[BigInt](bigIntVar1).get == getVar[BigInt](bigIntVar3).get }",
       EQ(Plus(Multiply(TaggedBigInt(bigIntVar2), BigIntConstant(2)), TaggedBigInt(bigIntVar1)), TaggedBigInt(bigIntVar3))
     )
     test(env, ext :+ (byteVar3 -> ByteConstant(5)),
-      "{ getVar[Byte](byteVar2) * 2.toByte + getVar[Byte](byteVar1) == 5.toByte }",
+      "{ getVar[Byte](byteVar2).get * 2.toByte + getVar[Byte](byteVar1).get == 5.toByte }",
       EQ(Plus(Multiply(TaggedByte(byteVar2), ByteConstant(2)), TaggedByte(byteVar1)), ByteConstant(5))
     )
     test(env, ext,
-      "{ getVar[Int](intVar2) / 2 + getVar[Int](intVar1) == 2 }",
+      "{ getVar[Int](intVar2).get / 2 + getVar[Int](intVar1).get == 2 }",
       EQ(Plus(Divide(TaggedInt(intVar2), IntConstant(2)), TaggedInt(intVar1)), IntConstant(2))
     )
     test(env, ext,
-      "{ getVar[Int](intVar2) % 2 + getVar[Int](intVar1) == 1 }",
+      "{ getVar[Int](intVar2).get % 2 + getVar[Int](intVar1).get == 1 }",
       EQ(Plus(Modulo(TaggedInt(intVar2), IntConstant(2)), TaggedInt(intVar1)), IntConstant(1))
     )
   }
 
   property("Tuple operations") {
     test(env, ext,
-      "{ (getVar[Int](intVar1), getVar[Int](intVar2))._1 == 1 }",
+      "{ (getVar[Int](intVar1).get, getVar[Int](intVar2).get)._1 == 1 }",
       EQ(SelectField(Tuple(TaggedInt(intVar1), TaggedInt(intVar2)), 1), IntConstant(1))
     )
     test(env, ext,
-      "{ (getVar[Int](intVar1), getVar[Int](intVar2))._2 == 2 }",
+      "{ (getVar[Int](intVar1).get, getVar[Int](intVar2).get)._2 == 2 }",
       EQ(SelectField(Tuple(TaggedInt(intVar1), TaggedInt(intVar2)), 2), IntConstant(2))
     )
     test(env, ext,
-      """{ let p = (getVar[Int](intVar1), getVar[Int](intVar2))
+      """{ let p = (getVar[Int](intVar1).get, getVar[Int](intVar2).get)
         |  let res = p._1 + p._2
         |  res == 3 }""".stripMargin,
       {
@@ -205,14 +205,14 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
   property("Tuple as Collection operations") {
     test(env, ext,
-    """{ let p = (getVar[Int](intVar1), getVar[Byte](byteVar2))
+    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
      |  p.size == 2 }""".stripMargin,
     {
       val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))
       EQ(SizeOf(p), IntConstant(2))
     })
     test(env, ext,
-    """{ let p = (getVar[Int](intVar1), getVar[Byte](byteVar2))
+    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
      |  p(0) == 1 }""".stripMargin,
     {
       val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))
@@ -226,7 +226,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     val ext1 = ext :+ (dataVar, Constant[SCollection[STuple]](data, dataType))
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar)
+        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.size == 1
         |}""".stripMargin,
       {
@@ -236,7 +236,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar)
+        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.exists(fun (p: (Array[Byte], Long)) = p._2 == 10L)
         |}""".stripMargin,
       {
@@ -246,7 +246,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar)
+        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.forall(fun (p: (Array[Byte], Long)) = p._1.size > 0)
         |}""".stripMargin,
       {
@@ -257,7 +257,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar)
+        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.map(fun (p: (Array[Byte], Long)) = (p._2, p._1)).size == 1
         |}""".stripMargin,
       {
@@ -270,7 +270,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
 // TODO uncomment after operations over Any are implemented
 //    test(env, ext,
-//    """{ let p = (getVar[Int](intVar1), getVar[Byte](byteVar2))
+//    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
 //     |  p.getOrElse(2, 3).isInstanceOf[Int] }""".stripMargin,
 //    {
 //      val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -141,7 +141,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val prop = compile(Map(),
       """OUTPUTS.exists(fun (box: Box) = {
-        |  box.R4[Long].value == SELF.R4[Long].value + 1
+        |  box.R4[Long].get == SELF.R4[Long].get + 1
          })""".stripMargin).asBoolValue
 
     val propTree = Exists(Outputs, 21, EQ(ExtractRegisterAs(TaggedBox(21), reg1)(SLong),
@@ -175,7 +175,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val prop = compile(Map(),
       """OUTPUTS.exists(fun (box: Box) = {
-        |  box.R4[Long].valueOrElse(0L) == SELF.R4[Long].value + 1
+        |  box.R4[Long].getOrElse(0L) == SELF.R4[Long].get + 1
          })""".stripMargin).asBoolValue
 
     val propTree = Exists(Outputs, 21,

--- a/src/test/scala/sigmastate/utxo/ContextEnrichingSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ContextEnrichingSpecification.scala
@@ -17,7 +17,7 @@ class ContextEnrichingSpecification extends SigmaTestingCommons {
     val env = Map("blake" -> Blake2b256(preimage), "pubkey" -> pubkey)
     val compiledScript = compile(env,
       """{
-        |  pubkey && blake2b256(getVar[Array[Byte]](1)) == blake
+        |  pubkey && blake2b256(getVar[Array[Byte]](1).get) == blake
         |}
       """.stripMargin)
     val prop = AND(
@@ -45,7 +45,7 @@ class ContextEnrichingSpecification extends SigmaTestingCommons {
     val env = Map("blake" -> Blake2b256(preimage1 ++ preimage2), "pubkey" -> pubkey)
     val compiledScript = compile(env,
       """{
-        |  pubkey && blake2b256(getVar[Array[Byte]](1) ++ getVar[Array[Byte]](2)) == blake
+        |  pubkey && blake2b256(getVar[Array[Byte]](1).get ++ getVar[Array[Byte]](2).get) == blake
         |}
       """.stripMargin)
 
@@ -84,7 +84,7 @@ class ContextEnrichingSpecification extends SigmaTestingCommons {
     val env = Map("k1" -> k1.toInt, "k2" -> k2.toInt, "r" -> r)
     val compiledScript = compile(env,
       """{
-        |  (getVar[Array[Byte]](k1) | getVar[Array[Byte]](k2)) == r
+        |  (getVar[Array[Byte]](k1).get | getVar[Array[Byte]](k2).get) == r
         |}
       """.stripMargin)
 
@@ -111,7 +111,7 @@ class ContextEnrichingSpecification extends SigmaTestingCommons {
     val env = Map("blake" -> Blake2b256(preimage))
     val compiledScript = compile(env,
       """{
-        |  blake2b256(getVar[Array[Byte]](1)) == blake
+        |  blake2b256(getVar[Array[Byte]](1).get) == blake
         |}
       """.stripMargin)
 
@@ -136,7 +136,7 @@ class ContextEnrichingSpecification extends SigmaTestingCommons {
     val env = Map("blake" -> Blake2b256(preimage2 ++ preimage1))
     val compiledScript = compile(env,
       """{
-        |  blake2b256(getVar[Array[Byte]](2) ++ getVar[Array[Byte]](1)) == blake
+        |  blake2b256(getVar[Array[Byte]](2).get ++ getVar[Array[Byte]](1).get) == blake
         |}
       """.stripMargin)
 

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -310,8 +310,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val prop = compile(Map(),
       """{
-        |  let pubkey1 = SELF.R4[GroupElement].value
-        |  let pubkey2 = SELF.R5[GroupElement].value
+        |  let pubkey1 = SELF.R4[GroupElement].get
+        |  let pubkey2 = SELF.R5[GroupElement].get
         |  proveDlog(pubkey1) && proveDlog(pubkey2)
         |}""".stripMargin).asBoolValue
 
@@ -554,9 +554,9 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       """{
         |  let cond = INPUTS(0).value > 10
         |  let preimage = if (cond)
-        |    INPUTS(2).R4[Array[Byte]].value
+        |    INPUTS(2).R4[Array[Byte]].get
         |  else
-        |    INPUTS(1).R4[Array[Byte]].value
+        |    INPUTS(1).R4[Array[Byte]].get
         |  helloHash == blake2b256(preimage)
          }""".stripMargin).asBoolValue
 

--- a/src/test/scala/sigmastate/utxo/SigmaCompilerSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SigmaCompilerSpecification.scala
@@ -16,7 +16,7 @@ class SigmaCompilerSpecification extends SigmaTestingCommons {
     val propTree = GE(TaggedInt(elementId), IntConstant(120))
     val propComp = compile(env,
       """{
-        |  getVar[Int](elementId) >= 120
+        |  getVar[Int](elementId).get >= 120
         |}""".stripMargin).asBoolValue
     propComp shouldBe propTree
   }

--- a/src/test/scala/sigmastate/utxo/examples/AssetsAtomicExchangeSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/AssetsAtomicExchangeSpecification.scala
@@ -76,7 +76,7 @@ class AssetsAtomicExchangeSpecification extends SigmaTestingCommons {
     val buyerEnv = Map("pkA" -> tokenBuyerKey, "deadline" -> deadline, "token1" -> tokenId)
     val altBuyerProp = compile(buyerEnv,
       """(HEIGHT > deadline && pkA) || {
-        |  let tokenData = OUTPUTS(0).R2[Array[(Array[Byte], Long)]].value(0)
+        |  let tokenData = OUTPUTS(0).R2[Array[(Array[Byte], Long)]].get(0)
         |  allOf(Array(
         |      tokenData._1 == token1,
         |      tokenData._2 >= 60L,

--- a/src/test/scala/sigmastate/utxo/examples/AtomicSwapExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/AtomicSwapExampleSpecification.scala
@@ -44,7 +44,7 @@ class AtomicSwapExampleSpecification extends SigmaTestingCommons {
       """{
         |  anyOf(Array(
         |    HEIGHT > height1 + deadlineA && pubkeyA,
-        |    pubkeyB && blake2b256(getVar[Array[Byte]](1)) == hx
+        |    pubkeyB && blake2b256(getVar[Array[Byte]](1).get) == hx
         |  ))
         |}""".stripMargin).asBoolValue
 
@@ -61,8 +61,8 @@ class AtomicSwapExampleSpecification extends SigmaTestingCommons {
         |    HEIGHT > height2 + deadlineB && pubkeyB,
         |    allOf(Array(
         |        pubkeyA,
-        |        getVar[Array[Byte]](1).size<33,
-        |        blake2b256(getVar[Array[Byte]](1)) == hx
+        |        getVar[Array[Byte]](1).get.size<33,
+        |        blake2b256(getVar[Array[Byte]](1).get) == hx
         |    ))
         |  ))
         |}

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -81,8 +81,8 @@ class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
         |    let coinsToIssue = if(HEIGHT < fixedRatePeriod) fixedRate else fixedRate - (oneEpochReduction * epoch)
         |    let correctCoinsConsumed = coinsToIssue == (SELF.value - out.value)
         |    let sameScriptRule = SELF.propositionBytes == out.propositionBytes
-        |    let heightIncreased = HEIGHT > SELF.R4[Long].value
-        |    let heightCorrect = out.R4[Long].value == HEIGHT
+        |    let heightIncreased = HEIGHT > SELF.R4[Long].get
+        |    let heightCorrect = out.R4[Long].get == HEIGHT
         |    let lastCoins = SELF.value <= oneEpochReduction
         |    allOf(Array(correctCoinsConsumed, heightCorrect, heightIncreased, sameScriptRule)) || (heightIncreased && lastCoins)
         |}""".stripMargin).asBoolValue

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -45,7 +45,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     val prop = compile(env,
       """{
         | let c2 = allOf(Array(
-        |   HEIGHT >= SELF.R4[Long].value + demurragePeriod,
+        |   HEIGHT >= SELF.R4[Long].get + demurragePeriod,
         |   OUTPUTS.exists(fun (out: Box) = {
         |     out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes
         |   })

--- a/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
@@ -42,14 +42,14 @@ class Rule110Specification extends SigmaTestingCommons {
     val prop = compile(Map(),
       """{
         |  let indices: Array[Int] = Array(0, 1, 2, 3, 4, 5)
-        |  let inLayer: Array[Byte] = SELF.R4[Array[Byte]].value
+        |  let inLayer: Array[Byte] = SELF.R4[Array[Byte]].get
         |  fun procCell(i: Int): Byte = {
         |    let l = inLayer((if (i == 0) 5 else (i - 1)))
         |    let c = inLayer(i)
         |    let r = inLayer((i + 1) % 6)
         |    ((l * c * r + c * r + c + r) % 2).toByte
         |  }
-        |  (OUTPUTS(0).R4[Array[Byte]].value == indices.map(procCell)) &&
+        |  (OUTPUTS(0).R4[Array[Byte]].get == indices.map(procCell)) &&
         |   (OUTPUTS(0).propositionBytes == SELF.propositionBytes)
          }""".stripMargin).asBoolValue
 


### PR DESCRIPTION
fixes #235 
Changes:
- Global function `getVar[T](id: Byte): T` now returns `Option[T]`
- `Option.value` renamed `Option.get`
- `Option.valueOrElse` renamed `Option.getOrElse`
- all examples and wpaper updated 
