### PR TITLE
Scala like lambda syntax

### DIFF
--- a/docs/LANG.md
+++ b/docs/LANG.md
@@ -48,6 +48,6 @@ The following transformations are performed by `Specializer`:
 (e.g. arr(0) --> ByIndex(arr, 0), etc) 
 
 As result of specialization the following AST nodes should be eliminated:
- Block, Let, Ident, Select, Lambda, Apply 
+ Block, Val, Ident, Select, Lambda, Apply 
 
 In case of any error it throws `SpecializerException`

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -122,10 +122,10 @@ The following properties and methods can be used with arrays
 Function  | Description
 --------- | ------------
 `Array[T].size` |  number of items in the array
-`fun Array[T].exists(p: T => Boolean): Boolean ` | Returns true if there exists an item `x` in the array for which `p(x) == true`  
-`fun Array[T].forall(f: T => Boolean): Boolean ` | Returns true if for all items `x` in the array `p(x) == true`   
-`fun Array[T].map[R](f: T => R): Array[R] ` | Applies function `f` for each element of array collecting results in a new array of type `R`. 
-`fun Array[T].reduce(f: (T, T) => T): T ` | For an array `Array(a0, ..., aN)` computes `f(f( ...f(f(a0, a1), a2) ...), aN)`. 
+`def Array[T].exists(p: T => Boolean): Boolean ` | Returns true if there exists an item `x` in the array for which `p(x) == true`  
+`def Array[T].forall(f: T => Boolean): Boolean ` | Returns true if for all items `x` in the array `p(x) == true`   
+`def Array[T].map[R](f: T => R): Array[R] ` | Applies function `f` for each element of array collecting results in a new array of type `R`. 
+`def Array[T].reduce(f: (T, T) => T): T ` | For an array `Array(a0, ..., aN)` computes `f(f( ...f(f(a0, a1), a2) ...), aN)`. 
 
 #### AvlTree
 TBD
@@ -139,32 +139,32 @@ The following function declarations are automatically imported into any script:
 
 ```
 /** Returns true if all the conditions are true */
-fun allOf(conditions: Array[Boolean]): Boolean
+def allOf(conditions: Array[Boolean]): Boolean
 
 /** Returns true if any of the conditions is true */
-fun anyOf(conditions: Array[Boolean]): Boolean
+def anyOf(conditions: Array[Boolean]): Boolean
 
 /** Cryptographic hash function Blake2b */
-fun blake2b256(input: Array[Byte]): Array[Byte]
+def blake2b256(input: Array[Byte]): Array[Byte]
 
 /** Cryptographic hash function Sha256 */
-fun sha256(input: Array[Byte]): Array[Byte]
+def sha256(input: Array[Byte]): Array[Byte]
 
 /** Create BigInt from byte array representation. */
-fun byteArrayToBigInt(input: Array[Byte]): BigInt
+def byteArrayToBigInt(input: Array[Byte]): BigInt
 
 /** Returns bytes representation of integer value. */
-fun intToByteArray(input: Int): Array[Byte]
+def intToByteArray(input: Int): Array[Byte]
 
 /** Returns value of the given type from the environment by its tag.*/
-fun getVar[T](tag: Int): Option[T]
+def getVar[T](tag: Int): Option[T]
 
-fun proveDHTuple(g: GroupElement, h: GroupElement, 
+def proveDHTuple(g: GroupElement, h: GroupElement, 
                  u: GroupElement, v: GroupElement): Boolean
-fun proveDlog(value: GroupElement): Boolean
+def proveDlog(value: GroupElement): Boolean
 
 /** Predicate which checks whether a key is in a tree, by using a membership proof. */
-fun isMember(tree: AvlTree, key: Array[Byte], proof: Array[Byte]): Boolean
+def isMember(tree: AvlTree, key: Array[Byte], proof: Array[Byte]): Boolean
 ```
 
 ## Examples

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -17,13 +17,13 @@
 
 - Binary operations: `>, <, >=, <=, +, -, &&, ||, ==, !=, |, *, ^, ++`
 - predefined primitives: `blake2b256`, `byteArrayToBigInt`, `proveDlog` etc. 
-- let declarations: `let h = blake2b256(pubkey)`
+- val declarations: `val h = blake2b256(pubkey)`
 - if-then-else clause: `if (x > 0) 1 else 0`
 - array literals: `Array(1, 2, 3, 4)`
 - generic high-order array operations: `map`, `fold`, `exists`, `forall`, etc.
 - accessing fields of any predefined structured objects: `box.value`
 - function invocations (predefined and user defined): `proveDlog(pubkey)` 
-- user defined functions: `let isValid(pk: GroupElement) = proveDlog(pk)`
+- user defined functions: `val isValid(pk: GroupElement) = proveDlog(pk)`
 - lambdas and high-order methods: `OUTPUTS.exists(fun (out: Box) = out.value >= minToRaise)`
 
 #### Data types 
@@ -48,10 +48,10 @@
 There is a syntax for literals, which can be used to introduce values 
 of some types directly in program text like the following examples:
 ```
- let unit: Unit = ()       // unit constant
- let long: Int = 10       // interger value literal
- let bool: Boolean = true  // logical literal
- let arr = Array(1, 2, 3)  // constructs array with given items
+ val unit: Unit = ()       // unit constant
+ val long: Int = 10       // interger value literal
+ val bool: Boolean = true  // logical literal
+ val arr = Array(1, 2, 3)  // constructs array with given items
 ```
 Note that many types don't have literal syntax and their values are introduced 
 by applying operations.
@@ -100,21 +100,21 @@ As in many languages Array is a collection of items of the same type.
 
 Each item can be accessed by constant index, for example:
 ```
-let myOutput = OUTPUTS(0)
-let myInput = INPUTS(0)
+val myOutput = OUTPUTS(0)
+val myInput = INPUTS(0)
 ```
 
 Array have `size` property which returns number of elements in an array. 
 
 ```
-let size = OUTPUTS.size
+val size = OUTPUTS.size
 ```
 
 Even though ErgoScript is not object-oriented language, Array operations use the syntax of method invocations. 
 For example the following script check an existence of some element in the array satisfying some predicate (condition)
 
 ```
-let ok = OUTPUTS.exists(fun (box: Box) = box.value > 1000)
+val ok = OUTPUTS.exists(fun (box: Box) = box.value > 1000)
 ``` 
 
 The following properties and methods can be used with arrays
@@ -180,8 +180,8 @@ After the timeout output could be spent by backer only.
 ```
 guard CrowdFunding(timeout: Int, minToRaise: Int, 
                    backerPubKey: Sigma, projectPubKey: Sigma) {
-  let c1 = HEIGHT >= timeout && backerPubKey
-  let c2 = allOf(Array(
+  val c1 = HEIGHT >= timeout && backerPubKey
+  val c2 = allOf(Array(
     HEIGHT < timeout,
     projectPubKey,
     OUTPUTS.exists(fun (out: Box) = {

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -23,7 +23,7 @@
 - generic high-order array operations: `map`, `fold`, `exists`, `forall`, etc.
 - accessing fields of any predefined structured objects: `box.value`
 - function invocations (predefined and user defined): `proveDlog(pubkey)` 
-- user defined functions: `val isValid(pk: GroupElement) = proveDlog(pk)`
+- user defined functions: `def isValid(pk: GroupElement) = proveDlog(pk)`
 - lambdas and high-order methods: `OUTPUTS.exists({ (out: Box) => out.value >= minToRaise })`
 
 #### Data types 

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -24,7 +24,7 @@
 - accessing fields of any predefined structured objects: `box.value`
 - function invocations (predefined and user defined): `proveDlog(pubkey)` 
 - user defined functions: `val isValid(pk: GroupElement) = proveDlog(pk)`
-- lambdas and high-order methods: `OUTPUTS.exists(fun (out: Box) = out.value >= minToRaise)`
+- lambdas and high-order methods: `OUTPUTS.exists({ (out: Box) => out.value >= minToRaise })`
 
 #### Data types 
 
@@ -114,7 +114,7 @@ Even though ErgoScript is not object-oriented language, Array operations use the
 For example the following script check an existence of some element in the array satisfying some predicate (condition)
 
 ```
-val ok = OUTPUTS.exists(fun (box: Box) = box.value > 1000)
+val ok = OUTPUTS.exists({ (box: Box) => box.value > 1000 })
 ``` 
 
 The following properties and methods can be used with arrays
@@ -184,7 +184,7 @@ guard CrowdFunding(timeout: Int, minToRaise: Int,
   val c2 = allOf(Array(
     HEIGHT < timeout,
     projectPubKey,
-    OUTPUTS.exists(fun (out: Box) = {
+    OUTPUTS.exists({ (out: Box) => 
       out.value >= minToRaise && out.propositionBytes == projectPubKey.propBytes
     })
   ))
@@ -208,9 +208,9 @@ into the blockchain yet, then R3 contains the current height of the blockchain).
     
 ```
 guard DemurrageCurrency(demurragePeriod: Int, demurrageCost: Int, regularScript: Sigma) {
-  let c2 = allOf(Array(
+  val c2 = allOf(Array(
    HEIGHT >= SELF.R3[Int].get + demurragePeriod,
-   OUTPUTS.exists(fun (out: Box) = {
+   OUTPUTS.exists({ (out: Box) => 
      out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes
    })
  ))

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -24,7 +24,7 @@
 - accessing fields of any predefined structured objects: `box.value`
 - function invocations (predefined and user defined): `proveDlog(pubkey)` 
 - user defined functions: `def isValid(pk: GroupElement) = proveDlog(pk)`
-- lambdas and high-order methods: `OUTPUTS.exists({ (out: Box) => out.value >= minToRaise })`
+- lambdas and high-order methods: `OUTPUTS.exists { (out: Box) => out.value >= minToRaise }`
 
 #### Data types 
 
@@ -114,7 +114,7 @@ Even though ErgoScript is not object-oriented language, Array operations use the
 For example the following script check an existence of some element in the array satisfying some predicate (condition)
 
 ```
-val ok = OUTPUTS.exists({ (box: Box) => box.value > 1000 })
+val ok = OUTPUTS.exists { (box: Box) => box.value > 1000 }
 ``` 
 
 The following properties and methods can be used with arrays
@@ -184,9 +184,9 @@ guard CrowdFunding(timeout: Int, minToRaise: Int,
   val c2 = allOf(Array(
     HEIGHT < timeout,
     projectPubKey,
-    OUTPUTS.exists({ (out: Box) => 
+    OUTPUTS.exists { (out: Box) => 
       out.value >= minToRaise && out.propositionBytes == projectPubKey.propBytes
-    })
+    }
   ))
   c1 || c2
 }
@@ -210,9 +210,9 @@ into the blockchain yet, then R3 contains the current height of the blockchain).
 guard DemurrageCurrency(demurragePeriod: Int, demurrageCost: Int, regularScript: Sigma) {
   val c2 = allOf(Array(
    HEIGHT >= SELF.R3[Int].get + demurragePeriod,
-   OUTPUTS.exists({ (out: Box) => 
+   OUTPUTS.exists { (out: Box) => 
      out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes
-   })
+   }
  ))
  regularScript || c2
 }

--- a/docs/wpaper/sigma.tex
+++ b/docs/wpaper/sigma.tex
@@ -226,7 +226,7 @@ Access to this information allows us, for example, to create an output box that 
 
 Note that the script does not prevent the \texttt{friend} box from being spent on its own, in which case the output box protected by the script above will become not spendable.
 
-We can be more permissive and allow for other inputs in addition to the friend box. To do so, we will examine the input array using the \texttt{exists} operator, which applies a boolean function to each array element until it finds one that satisfies the function or finds that none exists. To define a function, we use \texttt{fun} keyword; the argument type (in this case \texttt{Box}) is specified with a colon after the argument name \texttt{inputBox}. We name the function using the \texttt{let} keyword.
+We can be more permissive and allow for other inputs in addition to the friend box. To do so, we will examine the input array using the \texttt{exists} operator, which applies a boolean function to each array element until it finds one that satisfies the function or finds that none exists. To define a function, we use lambda syntax; the argument type (in this case \texttt{Box}) is specified with a colon after the argument name \texttt{inputBox}. We name the function using the \texttt{val} keyword.
 \begin{verbatim}
         {
                 val isFriend = { (inputBox: Box) => inputBox.id == friend.id }
@@ -249,7 +249,7 @@ To give money to the project, the backer will create an output box protected by 
 \begin{verbatim}
         {
                 val fundraisingFailure = HEIGHT >= deadline && backerPubKey
-                val enoughRaised = fun(outBox: Box) = {
+                val enoughRaised = {(outBox: Box) =>
                         outBox.value >= minToRaise && 
                         outBox.propositionBytes == projectPubKey.propBytes
                 }

--- a/docs/wpaper/sigma.tex
+++ b/docs/wpaper/sigma.tex
@@ -229,7 +229,7 @@ Note that the script does not prevent the \texttt{friend} box from being spent o
 We can be more permissive and allow for other inputs in addition to the friend box. To do so, we will examine the input array using the \texttt{exists} operator, which applies a boolean function to each array element until it finds one that satisfies the function or finds that none exists. To define a function, we use \texttt{fun} keyword; the argument type (in this case \texttt{Box}) is specified with a colon after the argument name \texttt{inputBox}. We name the function using the \texttt{let} keyword.
 \begin{verbatim}
         {
-                val isFriend = fun (inputBox: Box) = {inputBox.id == friend.id}
+                val isFriend = { (inputBox: Box) => inputBox.id == friend.id }
                 INPUTS.exists (isFriend)
         }
 \end{verbatim}
@@ -237,7 +237,7 @@ We can be more permissive and allow for other inputs in addition to the friend b
 This is our first example of a script with more than one statement; note that such scripts require braces, and their output is determined by the last statement.
 It can also be written in one statement, as follows:
 \begin{verbatim}
-        INPUTS.exists (fun (inputBox: Box) = {inputBox.id == friend.id})
+        INPUTS.exists ({ (inputBox: Box) => inputBox.id == friend.id })
 \end{verbatim}
 
 

--- a/docs/wpaper/sigma.tex
+++ b/docs/wpaper/sigma.tex
@@ -229,7 +229,7 @@ Note that the script does not prevent the \texttt{friend} box from being spent o
 We can be more permissive and allow for other inputs in addition to the friend box. To do so, we will examine the input array using the \texttt{exists} operator, which applies a boolean function to each array element until it finds one that satisfies the function or finds that none exists. To define a function, we use \texttt{fun} keyword; the argument type (in this case \texttt{Box}) is specified with a colon after the argument name \texttt{inputBox}. We name the function using the \texttt{let} keyword.
 \begin{verbatim}
         {
-                let isFriend = fun (inputBox: Box) = {inputBox.id == friend.id}
+                val isFriend = fun (inputBox: Box) = {inputBox.id == friend.id}
                 INPUTS.exists (isFriend)
         }
 \end{verbatim}
@@ -248,12 +248,12 @@ To give money to the project, the backer will create an output box protected by 
 
 \begin{verbatim}
         {
-                let fundraisingFailure = HEIGHT >= deadline && backerPubKey
-                let enoughRaised = fun(outBox: Box) = {
+                val fundraisingFailure = HEIGHT >= deadline && backerPubKey
+                val enoughRaised = fun(outBox: Box) = {
                         outBox.value >= minToRaise && 
                         outBox.propositionBytes == projectPubKey.propBytes
                 }
-                let fundraisingSuccess = HEIGHT < deadline &&
+                val fundraisingSuccess = HEIGHT < deadline &&
                          projectPubKey &&  
                          OUTPUTS.exists(enoughRaised)
                  
@@ -537,7 +537,7 @@ $Constant$ tree nodes.
     D, t_1 \otimes t_2 & \to & genCF(D, t_1) + Cost_\otimes + genCF(D, t_2) \\
     arr.map(f) & \to & 
         \begin{tabular}[t]{l}
-            let $f_{cost}$ = $genCF(D, f)$ \\
+            val $f_{cost}$ = $genCF(D, f)$ \\
             $sum(arr.map(\lambda x \to f_{cost}(x)))$ \\
         \end{tabular} \\
      & \to & $\mnote{arg}$ \\

--- a/docs/wpaper/sigma.tex
+++ b/docs/wpaper/sigma.tex
@@ -237,7 +237,7 @@ We can be more permissive and allow for other inputs in addition to the friend b
 This is our first example of a script with more than one statement; note that such scripts require braces, and their output is determined by the last statement.
 It can also be written in one statement, as follows:
 \begin{verbatim}
-        INPUTS.exists ({ (inputBox: Box) => inputBox.id == friend.id })
+        INPUTS.exists { (inputBox: Box) => inputBox.id == friend.id }
 \end{verbatim}
 
 

--- a/src/main/java/gf2t/GF2_192.java
+++ b/src/main/java/gf2t/GF2_192.java
@@ -509,7 +509,7 @@ public class GF2_192 {
             // so that's what we compute.
             // Note that we have no precomputed table for k=7 (i.e., 2^128), because we don't expect
             // this to be needed -- only up to k=6 is used in inversion.
-            // Here's the proof: let m = 64. 2^{2^k} mod (2^{192}-1) = 2^{mn} mod (2^{3m}-1) for n = 2^{k-6}.
+            // Here's the proof: val m = 64. 2^{2^k} mod (2^{192}-1) = 2^{mn} mod (2^{3m}-1) for n = 2^{k-6}.
             // Let d = n div 3 and r = n mod 3.
             // Then 2^{mn} = (2^{3m}-1) (2^{m(n-3}}+2^{m(n-6)}+...+2^{m-nd})+2^{nr}
             // So the remainder is 2^{nr}. r is 2 when k is odd and 1 when k is even.

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -114,10 +114,10 @@ class SigmaBinder(env: Map[String, Any], builder: SigmaBuilder) {
     case Block(Seq(), body) => Some(body)
 
     case block @ Block(binds, t) =>
-      val newBinds = for (Let(n, t, b) <- binds) yield {
+      val newBinds = for (Val(n, t, b) <- binds) yield {
         if (env.contains(n)) error(s"Variable $n already defined ($n = ${env(n)}")
         val b1 = eval(b, env)
-        mkLet(n, if (t != NoType) t else b1.tpe, b1)
+        mkVal(n, if (t != NoType) t else b1.tpe, b1)
       }
       val t1 = eval(t, env)
       val newBlock = mkBlock(newBinds, t1)

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -103,7 +103,7 @@ class SigmaBinder(env: Map[String, Any], builder: SigmaBuilder) {
       }
       Some(mkTaggedVariable(id, targs.head))
 
-    // Rule: fun (...) = ... --> fun (...): T = ...
+    // Rule: lambda (...) = ... --> lambda (...): T = ...
     case lam @ Lambda(params, args, t, Some(body)) =>
       require(params.isEmpty)
       val b1 = eval(body, env)

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -121,8 +121,8 @@ trait SigmaBuilder {
   def mkSomeValue[T <: SType](x: Value[T]): Value[SOption[T]]
   def mkNoneValue[T <: SType](elemType: T): Value[SOption[T]]
 
-  def mkBlock(bindings: Seq[Let], result: Value[SType]): Value[SType]
-  def mkLet(name: String, givenType: SType, body: Value[SType]): Let
+  def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType]
+  def mkVal(name: String, givenType: SType, body: Value[SType]): Val
   def mkSelect(obj: Value[SType], field: String, resType: Option[SType] = None): Value[SType]
   def mkIdent(name: String, tpe: SType): Value[SType]
   def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType]
@@ -347,11 +347,11 @@ class StdSigmaBuilder extends SigmaBuilder {
   override def mkSomeValue[T <: SType](x: Value[T]): Value[SOption[T]] = SomeValue(x)
   override def mkNoneValue[T <: SType](elemType: T): Value[SOption[T]] = NoneValue(elemType)
 
-  override def mkBlock(bindings: Seq[Let], result: Value[SType]): Value[SType] =
+  override def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType] =
     Block(bindings, result)
 
-  override def mkLet(name: String, givenType: SType, body: Value[SType]): Let =
-    LetNode(name, givenType, body)
+  override def mkVal(name: String, givenType: SType, body: Value[SType]): Val =
+    ValNode(name, givenType, body)
 
   override def mkSelect(obj: Value[SType],
                         field: String,

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -21,16 +21,16 @@ object SigmaParser extends Exprs with Types with Core {
     P( "{" ~/ BlockLambda.? ~ Semis.? ~ TmplStat.repX(sep = Semis) ~ Semis.? ~ `}` )
   }
 
-  val FunDef = {
-    P( (Id | `this`).! ~ LambdaDef ).map { case (name, lam) => builder.mkLet(name, NoType, lam) }
-  }
+//  val FunDef = {
+//    P( (Id | `this`).! ~ LambdaDef ).map { case (name, lam) => builder.mkLet(name, NoType, lam) }
+//  }
 
   val ValVarDef = P( BindPattern/*.rep(1, ",".~/)*/ ~ (`:` ~/ Type).? ~ (`=` ~/ FreeCtx.Expr) ).map {
     case (Ident(n,_), t, body) => builder.mkLet(n, t.getOrElse(NoType), body)
     case (pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 
-  val BlockDef = P( Dcl )
+  val BlockDef = P( Dcl ).log()
 
   val Constr = P( AnnotType ~~ (NotNewline ~ ParenArgList ).repX )
   val Constrs = P( (WL ~ Constr).rep(1, `with`.~/) )

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -30,7 +30,7 @@ object SigmaParser extends Exprs with Types with Core {
     case (pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 
-  val BlockDef = P( Dcl ).log()
+  val BlockDef = P( Dcl )
 
   val Constr = P( AnnotType ~~ (NotNewline ~ ParenArgList ).repX )
   val Constrs = P( (WL ~ Constr).rep(1, `with`.~/) )

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -22,11 +22,11 @@ object SigmaParser extends Exprs with Types with Core {
   }
 
 //  val FunDef = {
-//    P( (Id | `this`).! ~ LambdaDef ).map { case (name, lam) => builder.mkLet(name, NoType, lam) }
+//    P( (Id | `this`).! ~ LambdaDef ).map { case (name, lam) => builder.mkVal(name, NoType, lam) }
 //  }
 
   val ValVarDef = P( BindPattern/*.rep(1, ",".~/)*/ ~ (`:` ~/ Type).? ~ (`=` ~/ FreeCtx.Expr) ).map {
-    case (Ident(n,_), t, body) => builder.mkLet(n, t.getOrElse(NoType), body)
+    case (Ident(n,_), t, body) => builder.mkVal(n, t.getOrElse(NoType), body)
     case (pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 

--- a/src/main/scala/sigmastate/lang/SigmaPrinter.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPrinter.scala
@@ -42,11 +42,11 @@ class SigmaPrinter extends org.bitbucket.inkytonik.kiama.output.PrettyPrinter {
 //      case Opn(l, AddOp(), r) => binToDoc(l, "+", r)
 //      case Opn(l, SubOp(), r) => binToDoc(l, "-", r)
 
-//      case Let(i, t, e1, e2) =>
+//      case Val(i, t, e1, e2) =>
 //        parens("let" <+> i <> typedeclToDoc(t) <+> '=' <>
 //            nest(line <> toDoc(e1)) <+> "in" <>
 //            nest(line <> toDoc(e2)))
-//      case Letp(bs, e) =>
+//      case Valp(bs, e) =>
 //        parens("letp" <>
 //            nest(line <> vsep(bs.map(b => b.i <+> '=' <+> toDoc(b.e)))) <+>
 //            "in" <>

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -7,7 +7,7 @@ import sigmastate.Values.Value.Typed
 import sigmastate._
 import sigmastate.Values._
 import sigmastate.lang.SigmaPredef._
-import sigmastate.lang.Terms.{Apply, Block, Ident, Lambda, Let, Select, ValueOps}
+import sigmastate.lang.Terms.{Apply, Block, Ident, Lambda, Val, Select, ValueOps}
 import sigmastate.lang.exceptions.{MethodNotFound, SpecializerException}
 import sigmastate.utxo._
 
@@ -28,7 +28,7 @@ class SigmaSpecializer(val builder: SigmaBuilder) {
 
     case _ @ Block(binds, res) =>
       var curEnv = env
-      for (Let(n, _, b) <- binds) {
+      for (Val(n, _, b) <- binds) {
         if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
         val b1 = eval(curEnv, b)
         curEnv = curEnv + (n -> b1)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -36,12 +36,12 @@ class SigmaTyper(val builder: SigmaBuilder) {
                  expected: Option[SType] = None): SValue = bound match {
     case Block(bs, res) =>
       var curEnv = env
-      val bs1 = ArrayBuffer[Let]()
-      for (Let(n, _, b) <- bs) {
+      val bs1 = ArrayBuffer[Val]()
+      for (Val(n, _, b) <- bs) {
         if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
         val b1 = assignType(curEnv, b)
         curEnv = curEnv + (n -> b1.tpe)
-        bs1 += mkLet(n, b1.tpe, b1)
+        bs1 += mkVal(n, b1.tpe, b1)
       }
       val res1 = assignType(curEnv, res)
       mkBlock(bs1, res1)

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -12,7 +12,7 @@ import sigmastate.utxo.CostTable.Cost
 
 object Terms {
 
-  case class Block(bindings: Seq[Let], result: SValue) extends Value[SType] {
+  case class Block(bindings: Seq[Val], result: SValue) extends Value[SType] {
     override val opCode: OpCode = OpCodes.Undefined
 
     override def cost[C <: Context[C]](context: C): Long = ???
@@ -21,17 +21,17 @@ object Terms {
     def tpe: SType = result.tpe
   }
   object Block {
-    def apply(let: Let, result: SValue)(implicit o1: Overload1): Block =
+    def apply(let: Val, result: SValue)(implicit o1: Overload1): Block =
       Block(Seq(let), result)
   }
 
-  trait Let extends Value[SType] {
+  trait Val extends Value[SType] {
     val name: String
     val givenType: SType
     val body: SValue
   }
 
-  case class LetNode(name: String, givenType: SType, body: SValue) extends Let {
+  case class ValNode(name: String, givenType: SType, body: SValue) extends Val {
     override val opCode: OpCode = OpCodes.Undefined
 
     override def cost[C <: Context[C]](context: C): Long = ???
@@ -39,11 +39,11 @@ object Terms {
     override def evaluated: Boolean = ???
     def tpe: SType = givenType ?: body.tpe
   }
-  object Let {
-    def apply(name: String, body: SValue): Let = LetNode(name, NoType, body)
-    def apply(name: String, givenType: SType, body: SValue): Let = LetNode(name, givenType, body)
+  object Val {
+    def apply(name: String, body: SValue): Val = ValNode(name, NoType, body)
+    def apply(name: String, givenType: SType, body: SValue): Val = ValNode(name, givenType, body)
     def unapply(v: SValue): Option[(String, SType, SValue)] = v match {
-      case LetNode(name, givenType, body) => Some((name, givenType, body))
+      case ValNode(name, givenType, body) => Some((name, givenType, body))
       case _ => None
     }
   }

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -31,7 +31,7 @@ trait Types extends Core {
     case (t, None) => t
     case (d, Some(r)) => SFunc(IndexedSeq(d), r)
   }
-  val Type: P[SType] = P( `=>`.? ~~ PostfixType ~ TypeBounds ~ `*`.? ).log()
+  val Type: P[SType] = P( `=>`.? ~~ PostfixType ~ TypeBounds ~ `*`.? )
 
 
   // Can't cut after `Id` because it may be a `*`, in which case
@@ -60,7 +60,7 @@ trait Types extends Core {
       }
     }
     P( CompoundType ~~ (NotNewline ~ Id.! ~~ OneNLMax ~ CompoundType).repX ).map { case (t, h) => buildInfix(t,h) }
-  }.log()
+  }
 
   val CompoundType = {
 //    val Refinement = P( OneNLMax ~ `{` ~/ Dcl.repX(sep=Semis) ~ `}` )
@@ -105,17 +105,17 @@ trait Types extends Core {
 //      case (n, Some(t)) => (n, t)
 //      case (n, None) => (n, NoType)
 //    }
-//    val Args = P( FunArg.repTC(1) ).log()
-//    val FunArgs = P( OneNLMax ~ "(" ~/ Args.? ~ ")" ).log().map(_.toSeq.flatten)
-//    val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).repTC(1) ~ "]" ).log()
+//    val Args = P( FunArg.repTC(1) )
+//    val FunArgs = P( OneNLMax ~ "(" ~/ Args.? ~ ")" ).map(_.toSeq.flatten)
+//    val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).repTC(1) ~ "]" )
 //    P( FunTypeArgs.? ~~ FunArgs.rep )
-//  }.log()
+//  }
 
   val TypeBounds: P0 = P( (`>:` ~/ Type).? ~ (`<:` ~/ Type).? ).ignore
   val TypeArg: P0 = {
     val CtxBounds = P((`:` ~/ Type).rep)
     P((Id | `_`) ~ TypeArgList.? ~ TypeBounds ~ CtxBounds).ignore
-  }.log()
+  }
 
   val Annot: P0 = P( `@` ~/ SimpleType ~  ("(" ~/ (Exprs ~ (`:` ~/ `_*`).?).? ~ TrailingComma ~ ")").rep ).ignore
 

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -13,10 +13,10 @@ trait Types extends Core {
   import WhitespaceApi._
   def TypeExpr: P[Value[SType]]
   def ValVarDef: P[Value[SType]]
-  def FunDef: P[Value[SType]]
+//  def FunDef: P[Value[SType]]
 
   val Dcl = {
-    P( `let` ~/ ValVarDef | `fun` ~/ FunDef )
+    P( `let` ~/ ValVarDef /*| /* `fun` ~/ */ FunDef */ )
   }
 
   /** This map should be in sync with SType.allPredefTypes*/
@@ -60,7 +60,7 @@ trait Types extends Core {
       }
     }
     P( CompoundType ~~ (NotNewline ~ Id.! ~~ OneNLMax ~ CompoundType).repX ).map { case (t, h) => buildInfix(t,h) }
-  }
+  }.log()
 
   val CompoundType = {
 //    val Refinement = P( OneNLMax ~ `{` ~/ Dcl.repX(sep=Semis) ~ `}` )
@@ -109,7 +109,7 @@ trait Types extends Core {
     val FunArgs = P( OneNLMax ~ "(" ~/ Args.? ~ ")" ).map(_.toSeq.flatten)
     val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).repTC(1) ~ "]" )
     P( FunTypeArgs.? ~~ FunArgs.rep )
-  }
+  }.log()
 
   val TypeBounds: P0 = P( (`>:` ~/ Type).? ~ (`<:` ~/ Type).? ).ignore
   val TypeArg: P0 = {

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -31,7 +31,7 @@ trait Types extends Core {
     case (t, None) => t
     case (d, Some(r)) => SFunc(IndexedSeq(d), r)
   }
-  val Type: P[SType] = P( `=>`.? ~~ PostfixType ~ TypeBounds ~ `*`.? )
+  val Type: P[SType] = P( `=>`.? ~~ PostfixType ~ TypeBounds ~ `*`.? ).log()
 
 
   // Can't cut after `Id` because it may be a `*`, in which case
@@ -100,22 +100,22 @@ trait Types extends Core {
     }
   }
 
-  val FunSig = {
-    val FunArg = P( Annot.rep ~ Id.! ~ (`:` ~/ Type).? ).map {
-      case (n, Some(t)) => (n, t)
-      case (n, None) => (n, NoType)
-    }
-    val Args = P( FunArg.repTC(1) )
-    val FunArgs = P( OneNLMax ~ "(" ~/ Args.? ~ ")" ).map(_.toSeq.flatten)
-    val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).repTC(1) ~ "]" )
-    P( FunTypeArgs.? ~~ FunArgs.rep )
-  }.log()
+//  val FunSig = {
+//    val FunArg = P( Annot.rep ~ Id.! ~ (`:` ~/ Type).? ).map {
+//      case (n, Some(t)) => (n, t)
+//      case (n, None) => (n, NoType)
+//    }
+//    val Args = P( FunArg.repTC(1) ).log()
+//    val FunArgs = P( OneNLMax ~ "(" ~/ Args.? ~ ")" ).log().map(_.toSeq.flatten)
+//    val FunTypeArgs = P( "[" ~/ (Annot.rep ~ TypeArg).repTC(1) ~ "]" ).log()
+//    P( FunTypeArgs.? ~~ FunArgs.rep )
+//  }.log()
 
   val TypeBounds: P0 = P( (`>:` ~/ Type).? ~ (`<:` ~/ Type).? ).ignore
   val TypeArg: P0 = {
     val CtxBounds = P((`:` ~/ Type).rep)
     P((Id | `_`) ~ TypeArgList.? ~ TypeBounds ~ CtxBounds).ignore
-  }
+  }.log()
 
   val Annot: P0 = P( `@` ~/ SimpleType ~  ("(" ~/ (Exprs ~ (`:` ~/ `_*`).?).? ~ TrailingComma ~ ")").rep ).ignore
 

--- a/src/main/scala/sigmastate/lang/Types.scala
+++ b/src/main/scala/sigmastate/lang/Types.scala
@@ -16,7 +16,7 @@ trait Types extends Core {
 //  def FunDef: P[Value[SType]]
 
   val Dcl = {
-    P( `let` ~/ ValVarDef /*| /* `fun` ~/ */ FunDef */ )
+    P( `val` ~/ ValVarDef /*| /* `fun` ~/ */ FunDef */ )
   }
 
   /** This map should be in sync with SType.allPredefTypes*/

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -33,10 +33,10 @@ trait Core extends syntax.Literals {
   // Keywords that match themselves and nothing else
   val `=>` = O("=>") | O("⇒")
 //  val `<-` = O("<-") | O("←")
-  val `:` = O(":")
+  val `:` = O(":").log()
   val `=` = O("=")
   val `@` = O("@")
-  val `_` = W("_")
+  val `_` = W("_").log()
   val `type` = W("type")
   val `let` = W("let")
   val `fun` = W("fun")
@@ -92,7 +92,7 @@ trait Core extends syntax.Literals {
   val Id = P( WL ~ Identifiers.Id ).log()
   val VarId = P( WL ~ Identifiers.VarId )
   val BacktickId = P( WL ~ Identifiers.BacktickId )
-  val ExprLiteral = P( WL ~ Literals.Expr.Literal )
+  val ExprLiteral = P( WL ~ Literals.Expr.Literal ).log()
   val PatLiteral = P( WL ~ Literals.Pat.Literal )
 
   val QualId = P( WL ~ Id.rep(1, sep = ".") )
@@ -111,5 +111,5 @@ trait Core extends syntax.Literals {
       case (h, t) => t.foldLeft[SValue](Ident(h))(builder.mkSelect(_, _))
     }
     P( /*ThisPath |*/ IdPath )
-  }
+  }.log()
 }

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -38,7 +38,7 @@ trait Core extends syntax.Literals {
   val `@` = O("@")
   val `_` = W("_").log()
   val `type` = W("type")
-  val `let` = W("let")
+  val `val` = W("val")
   val `fun` = W("fun")
   val `case` = W("case")
   val `then` = W("then")

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -33,10 +33,10 @@ trait Core extends syntax.Literals {
   // Keywords that match themselves and nothing else
   val `=>` = O("=>") | O("⇒")
 //  val `<-` = O("<-") | O("←")
-  val `:` = O(":").log()
+  val `:` = O(":")
   val `=` = O("=")
   val `@` = O("@")
-  val `_` = W("_").log()
+  val `_` = W("_")
   val `type` = W("type")
   val `val` = W("val")
   val `fun` = W("fun")
@@ -89,10 +89,10 @@ trait Core extends syntax.Literals {
   val `}` = P( Semis.? ~ "}" )
   val `{` = P( "{" ~ Semis.? )
 
-  val Id = P( WL ~ Identifiers.Id ).log()
+  val Id = P( WL ~ Identifiers.Id )
   val VarId = P( WL ~ Identifiers.VarId )
   val BacktickId = P( WL ~ Identifiers.BacktickId )
-  val ExprLiteral = P( WL ~ Literals.Expr.Literal ).log()
+  val ExprLiteral = P( WL ~ Literals.Expr.Literal )
   val PatLiteral = P( WL ~ Literals.Pat.Literal )
 
   val QualId = P( WL ~ Id.rep(1, sep = ".") )
@@ -111,5 +111,5 @@ trait Core extends syntax.Literals {
       case (h, t) => t.foldLeft[SValue](Ident(h))(builder.mkSelect(_, _))
     }
     P( /*ThisPath |*/ IdPath )
-  }.log()
+  }
 }

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -89,7 +89,7 @@ trait Core extends syntax.Literals {
   val `}` = P( Semis.? ~ "}" )
   val `{` = P( "{" ~ Semis.? )
 
-  val Id = P( WL ~ Identifiers.Id )
+  val Id = P( WL ~ Identifiers.Id ).log()
   val VarId = P( WL ~ Identifiers.VarId )
   val BacktickId = P( WL ~ Identifiers.BacktickId )
   val ExprLiteral = P( WL ~ Literals.Expr.Literal )

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -251,7 +251,10 @@ trait Exprs extends Core with Types {
           case (Seq(), exprs) => exprs
         })
         builder.mkLambda(args.toIndexedSeq, NoType, Some(block))
-      case (None, Seq((Seq(), b))) => mkBlock(b)
+      case (None, bodyItems) =>
+        mkBlock(bodyItems.flatMap {
+          case (Seq(), exprs) => exprs
+        })
     }
   }
   val Block = BaseBlock("}").log()

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -42,7 +42,7 @@ trait Exprs extends Core with Types {
           case (c, t, e) => builder.mkIf(c.asValue[SBoolean.type], t, e)
         }
       }
-//      val Fun = P( /* `fun` ~/ */ LambdaDef)
+//      val Fun = P( /* `fun` ~/ */ FunDef)
 
       val LambdaRhs = if (semiInference) P( BlockChunk.map {
         case (_ , b)  => mkBlock(b)
@@ -195,7 +195,7 @@ trait Exprs extends Core with Types {
     rhs
   }
 
-//  val LambdaDef = {
+//  val FunDef = {
 //    val Body = P( WL ~ `=>` ~ StatCtx.Expr )
 //    P( FunSig ~ (`:` ~/ Type).? ~~ Body ).map {
 //      case (_ @ Seq(args), resType, body) => builder.mkLambda(args.toIndexedSeq, resType.getOrElse(NoType), Some(body))

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -246,8 +246,11 @@ trait Exprs extends Core with Types {
       // todo error on multiple argument lists
       case (Some((Seq(args), _)), Seq((Seq(), Seq(b)))) =>
         builder.mkLambda(args.toIndexedSeq, NoType, Some(b))
-      case (Some((Seq(args), _)), Seq((Seq(), bodyVals))) =>
-        builder.mkLambda(args.toIndexedSeq, NoType, Some(mkBlock(bodyVals)))
+      case (Some((Seq(args), _)), bodyItems) =>
+        val block = mkBlock(bodyItems.flatMap {
+          case (Seq(), exprs) => exprs
+        })
+        builder.mkLambda(args.toIndexedSeq, NoType, Some(block))
       case (None, Seq((Seq(), b))) => mkBlock(b)
     }
   }

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -3,7 +3,7 @@ package sigmastate.lang.syntax
 import fastparse.noApi._
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.lang.Terms.{Apply, ApplyTypes, Ident, Lambda, Let, MethodCall, Select, ValueOps}
+import sigmastate.lang.Terms.{Apply, ApplyTypes, Ident, Lambda, Val, MethodCall, Select, ValueOps}
 import sigmastate.lang._
 import sigmastate.lang.syntax.Basic._
 
@@ -229,11 +229,11 @@ trait Exprs extends Core with Types {
     P( BlockLambda.rep ~ BlockStat.rep(sep = Semis) )
   }.log()
 
-  def extractBlockStats(stats: Seq[SValue]): (Seq[Let], SValue) = {
+  def extractBlockStats(stats: Seq[SValue]): (Seq[Val], SValue) = {
     if (stats.nonEmpty) {
       val lets = stats.iterator.take(stats.size - 1).map {
-        case l: Let => l
-        case _ => error(s"Block should contain a list of Let bindings and one expression: but was $stats")
+        case l: Val => l
+        case _ => error(s"Block should contain a list of Val bindings and one expression: but was $stats")
       }
       (lets.toList, stats.last)
     }

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -216,10 +216,9 @@ trait Exprs extends Core with Types {
     val Arg = P( Annot.rep ~ Id.! ~ (`:` ~/ Type).? ).map {
       case (n, Some(t)) => (n, t)
       case (n, None) => (n, NoType)
-    }
+    }.log()
     val Args = P( Arg.repTC(1) ).log()
-    val LambdaArgs = P( OneNLMax ~ "(" ~ Args.? ~ ")" ).log().map(_.toSeq.flatten)
-    P( LambdaArgs.rep )
+    P( OneNLMax ~ "(" ~ Args.? ~ ")" ).log().map(_.toSeq.flatten)
   }.log()
 
   val BlockLambda = P( BlockLambdaHead ~ `=>` ).log()
@@ -251,14 +250,13 @@ trait Exprs extends Core with Types {
     val BlockEnd = P( Semis.? ~ &(end) ).log()
     val Body = P( BlockChunk.repX(sep = Semis) ).log()
     P( Semis.? ~ BlockLambda.? ~ Body ~/ BlockEnd ).map {
-      // todo error on multiple argument lists
       case (Some(args), Seq((Seq(), Seq(b)))) =>
-        builder.mkLambda(args.flatten.toIndexedSeq, NoType, Some(b))
+        builder.mkLambda(args.toIndexedSeq, NoType, Some(b))
       case (Some(args), bodyItems) =>
         val block = mkBlock(bodyItems.flatMap {
           case (Seq(), exprs) => exprs
         })
-        builder.mkLambda(args.flatten.toIndexedSeq, NoType, Some(block))
+        builder.mkLambda(args.toIndexedSeq, NoType, Some(block))
       case (None, bodyItems) =>
         mkBlock(bodyItems.flatMap {
           case (Seq(), exprs) => exprs

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -107,50 +107,50 @@ class TestingInterpreterSpecification extends PropSpec
 
   property("Evaluate array ops") {
     testEval("""{
-              |  let arr = Array(1, 2) ++ Array(3, 4)
+              |  val arr = Array(1, 2) ++ Array(3, 4)
               |  arr.size == 4
               |}""".stripMargin)
     testEval("""{
-              |  let arr = Array(1, 2, 3)
+              |  val arr = Array(1, 2, 3)
               |  arr.slice(1, 3) == Array(2, 3)
               |}""".stripMargin)
     testEval("""{
-              |  let arr = bytes1 ++ bytes2
+              |  val arr = bytes1 ++ bytes2
               |  arr.size == 6
               |}""".stripMargin)
     testEval("""{
-              |  let arr = bytes1 ++ Array[Byte]()
+              |  val arr = bytes1 ++ Array[Byte]()
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  let arr = Array[Byte]() ++ bytes1
+              |  val arr = Array[Byte]() ++ bytes1
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R4[Array[Int]].get
+              |  val arr = box1.R4[Array[Int]].get
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R5[Array[Boolean]].get
+              |  val arr = box1.R5[Array[Boolean]].get
               |  anyOf(arr)
               |}""".stripMargin)
     testEval("""{
-              |  let arr = box1.R5[Array[Boolean]].get
+              |  val arr = box1.R5[Array[Boolean]].get
               |  allOf(arr) == false
               |}""".stripMargin)
     testEval("""{
-              |  let arr = Array(1, 2, 3)
+              |  val arr = Array(1, 2, 3)
               |  arr.map({(i: Int) => i + 1}) == Array(2, 3, 4)
               |}""".stripMargin)
     testEval("""{
-              |  let arr = Array(1, 2, 3)
+              |  val arr = Array(1, 2, 3)
               |  arr.where({(i: Int) => i < 3}) == Array(1, 2)
               |}""".stripMargin)
   }
 
 //  property("Evaluate sigma in lambdas") {
 //    testeval("""{
-//              |  let arr = Array(dk1, dk2)
+//              |  val arr = Array(dk1, dk2)
 //              |  allOf(arr.map(fun (d: Boolean) = d && true))
 //              |}""".stripMargin)
 //  }

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -140,11 +140,11 @@ class TestingInterpreterSpecification extends PropSpec
               |}""".stripMargin)
     testEval("""{
               |  val arr = Array(1, 2, 3)
-              |  arr.map({(i: Int) => i + 1}) == Array(2, 3, 4)
+              |  arr.map {(i: Int) => i + 1} == Array(2, 3, 4)
               |}""".stripMargin)
     testEval("""{
               |  val arr = Array(1, 2, 3)
-              |  arr.where({(i: Int) => i < 3}) == Array(1, 2)
+              |  arr.where {(i: Int) => i < 3} == Array(1, 2)
               |}""".stripMargin)
   }
 

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -140,11 +140,11 @@ class TestingInterpreterSpecification extends PropSpec
               |}""".stripMargin)
     testEval("""{
               |  let arr = Array(1, 2, 3)
-              |  arr.map(fun (i: Int) = i + 1) == Array(2, 3, 4)
+              |  arr.map({(i: Int) => i + 1}) == Array(2, 3, 4)
               |}""".stripMargin)
     testEval("""{
               |  let arr = Array(1, 2, 3)
-              |  arr.where(fun (i: Int) = i < 3) == Array(1, 2)
+              |  arr.where({(i: Int) => i < 3}) == Array(1, 2)
               |}""".stripMargin)
   }
 

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -289,6 +289,32 @@ class TestingInterpreterSpecification extends PropSpec
 
     verify(prop3, env, proof, challenge).map(_._1).getOrElse(false) shouldBe false
   }
+
+  property("passing a lambda argument") {
+    // single expression
+    testEval(
+      """ Array[Int](1,2,3).map { (a: Int) =>
+        |   a + 1
+        | } == Array[Int](2,3,4) """.stripMargin)
+    // block
+    testEval(
+      """ Array[Int](1,2,3).map { (a: Int) =>
+        |   val b = a - 1
+        |   b + 2
+        | } == Array[Int](2,3,4) """.stripMargin)
+    // block with nested lambda
+    testEval(
+      """ Array[Int](1,2,3).exists { (a: Int) =>
+        |   Array[Int](1).exists{ (c: Int) => c == 1 }
+        | } == true """.stripMargin)
+
+    // block with nested lambda (assigned to a val)
+    testEval(
+      """ Array[Int](1,2,3).exists { (a: Int) =>
+        |   val g = { (c: Int) => c == 1 }
+        |   Array[Int](1).exists(g)
+        | } == true """.stripMargin)
+  }
 }
 
 

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -135,7 +135,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
       Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))
     bind(env, "{ (a: Int) => a + 1 }") shouldBe
       Lambda(IndexedSeq("a" -> SInt), NoType, plus(IntIdent("a"), 1))
-    bind(env, "{ (a: Int, box: Box): Long => a - box.value }") shouldBe
+    bind(env, "{ (a: Int, box: Box) => a - box.value }") shouldBe
       Lambda(IndexedSeq("a" -> SInt, "box" -> SBox), NoType,
         mkMinus(IntIdent("a"), Select(Ident("box"), "value").asValue[SLong.type]))
     bind(env, "{ (a) => a - 1 }") shouldBe

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -69,6 +69,6 @@ class SigmaCompilerTest extends PropSpec with PropertyChecks with Matchers with 
     fail(env, "X)", 1, "End")
     fail(env, "(X", 2, "\")\"")
     fail(env, "{ X", 3, "\"}\"")
-    fail(env, "{ let X", 7, "\"=\"")
+    fail(env, "{ val X", 7, "\"=\"")
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -1,6 +1,6 @@
 package sigmastate.lang
 
-import fastparse.core.ParseError
+import fastparse.core.{ParseError, Parsed}
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
@@ -13,8 +13,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   import StdSigmaBuilder._
 
   def parse(x: String): SValue = {
-    val res = SigmaParser(x, TransformingSigmaBuilder).get.value
-    res
+    SigmaParser(x, TransformingSigmaBuilder) match {
+      case Parsed.Success(v, _) => v
+      case f@Parsed.Failure(_, _, extra) =>
+        val traced = extra.traced
+        println(s"\nTRACE: ${traced.trace}")
+        f.get.value // force show error diagnostics
+    }
   }
 
   def parseType(x: String): SType = {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -8,6 +8,7 @@ import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.Terms._
+import sigmastate.lang.syntax.ParserException
 
 class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with LangTests {
   import StdSigmaBuilder._
@@ -405,7 +406,6 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
             Lambda(IndexedSeq("c" -> SInt), mkMinus(IntIdent("c"), IntConstant(1)))),
           Minus(IntIdent("a"), Apply(IntIdent("g"), IndexedSeq(IntIdent("a"))).asValue[SLong.type]))
       )))
-    // todo test in interpreter
   }
 
   property("function definitions") {
@@ -465,6 +465,14 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     fail("{ X", 3)
     fail("{ val X", 7)
     fail("\"str", 4)
+  }
+
+  property("not(yet) supported lambda syntax") {
+    // passing a lambda without curly braces is not supported yet :)
+    fail("arr.exists ( (a: Int) => a >= 1 )", 15)
+    // no argument type
+    an[ParserException] should be thrownBy parse("arr.exists ( a => a >= 1 )")
+    an[ParserException] should be thrownBy parse("arr.exists { a => a >= 1 }")
   }
 
   property("numeric casts") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -315,6 +315,8 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("lambdas") {
+    parse("{ (x) => x - 1 }") shouldBe
+      Lambda(IndexedSeq("x" -> NoType), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
     parse("{ (x: Int) => x - 1 }") shouldBe
       Lambda(IndexedSeq("x" -> SInt), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
     parse("{ (x: Int) => x + 1 }") shouldBe
@@ -369,6 +371,8 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("function definitions") {
+    parse("{let f = { (x: Int) => x - 1 }; f}") shouldBe
+      Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
     parse(
       """{let f = { (x: Int) => x - 1 }
        |f}

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -364,8 +364,15 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
         |}""".stripMargin) shouldBe
       Lambda(IndexedSeq("x" -> SInt),
         Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
-    // todo multiple parameters
-    // todo large body (multiple expressions)
+    parse("{ (x: Int, y: Int) =>  x - y }") shouldBe
+      Lambda(IndexedSeq("x" -> SInt, "y" -> SInt), mkMinus(Ident("x").asValue[SInt.type], Ident("y").asValue[SInt.type]))
+    parse("{ (p: (Int, SigmaProp), box: Box) => p._1 > box.value && p._2.isValid }") shouldBe
+      Lambda(IndexedSeq("p" -> STuple(SInt, SSigmaProp), "box" -> SBox), NoType,
+        and(
+          GT(Select(Ident("p"), "_1").asValue[SInt.type], Select(Ident("box"), "value").asValue[SLong.type]),
+          Select(Select(Ident("p"), "_2"), "isValid").asValue[SBoolean.type]
+        )
+      )
   }
 
   property("predefined Exists with lambda argument") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -357,6 +357,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("{ (x: Int) =>  let y = x - 1; y }") shouldBe
       Lambda(IndexedSeq("x" -> SInt),
         Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
+    parse(
+      """{ (x: Int) =>
+        |let y = x - 1
+        |y
+        |}""".stripMargin) shouldBe
+      Lambda(IndexedSeq("x" -> SInt),
+        Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
     // todo multiple parameters
     // todo large body (multiple expressions)
   }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -369,11 +369,18 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("predefined Exists with lambda argument") {
-    parse("OUTPUTS.exists({ (out: Box) => out.amount >= minToRaise })") shouldBe
-      Apply(Select(Ident("OUTPUTS"), "exists"),
-        IndexedSeq(
-          Lambda(IndexedSeq("out" -> SBox),
-            GE(Select(Ident("out"), "amount").asValue[SLong.type], IntIdent("minToRaise")))))
+    val tree = Apply(Select(Ident("OUTPUTS"), "exists"),
+      IndexedSeq(
+        Lambda(IndexedSeq("out" -> SBox),
+          GE(Select(Ident("out"), "amount").asValue[SLong.type], IntIdent("minToRaise")))))
+    // both parens and curly braces
+    parse("OUTPUTS.exists ({ (out: Box) => out.amount >= minToRaise })") shouldBe tree
+    // only curly braces (one line)
+    parse("OUTPUTS.exists { (out: Box) => out.amount >= minToRaise }") shouldBe tree
+    // only curly braces (multiline)
+    parse(
+      """OUTPUTS.exists { (out: Box) =>
+        |out.amount >= minToRaise }""".stripMargin) shouldBe tree
   }
 
   property("function definitions") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -122,6 +122,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("(1, 2L).size") shouldBe Select(Tuple(IntConstant(1), LongConstant(2)), "size")
     parse("(1, 2L)(0)") shouldBe Apply(Tuple(IntConstant(1), LongConstant(2)), IndexedSeq(IntConstant(0)))
     parse("(1, 2L).getOrElse(2, 3)") shouldBe Apply(Select(Tuple(IntConstant(1), LongConstant(2)), "getOrElse"), IndexedSeq(IntConstant(2), IntConstant(3)))
+    parse("{ (a: Int) => (1, 2L)(a) }") shouldBe Lambda(IndexedSeq("a" -> SInt), Apply(Tuple(IntConstant(1), LongConstant(2)), IndexedSeq(Ident("a"))))
   }
 
   property("let constructs") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -350,6 +350,17 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
           Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
   }
 
+  property("new lambda syntax") {
+    parse("{ (x: Int) =>  x - 1 }") shouldBe
+      Lambda(IndexedSeq("x" -> SInt), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
+    // todo single params without parenthesis
+    parse("{ (x: Int) =>  let y = x - 1; y }") shouldBe
+      Lambda(IndexedSeq("x" -> SInt),
+        Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
+    // todo multiple parameters
+    // todo large body (multiple expressions)
+  }
+
   property("predefined Exists with lambda argument") {
     parse("OUTPUTS.exists(fun (out: Box) = { out.amount >= minToRaise })") shouldBe
       Apply(Select(Ident("OUTPUTS"), "exists"),

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -130,36 +130,36 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("{ (a: Int) => (1, 2L)(a) }") shouldBe Lambda(IndexedSeq("a" -> SInt), Apply(Tuple(IntConstant(1), LongConstant(2)), IndexedSeq(Ident("a"))))
   }
 
-  property("let constructs") {
+  property("val constructs") {
     parse(
-      """{let X = 10
+      """{val X = 10
         |3 > 2}
-      """.stripMargin) shouldBe Block(Let("X", IntConstant(10)), GT(3, 2))
+      """.stripMargin) shouldBe Block(Val("X", IntConstant(10)), GT(3, 2))
 
-    parse("{let X = 10; 3 > 2}") shouldBe Block(Let("X", IntConstant(10)), GT(3, 2))
-    parse("{let X = 3 - 2; 3 > 2}") shouldBe Block(Let("X", Minus(3, 2)), GT(3, 2))
-    parse("{let X = 3 + 2; 3 > 2}") shouldBe Block(Let("X", plus(3, 2)), GT(3, 2))
-    parse("{let X = if (true) true else false; false}") shouldBe Block(Let("X", If(TrueLeaf, TrueLeaf, FalseLeaf)), FalseLeaf)
+    parse("{val X = 10; 3 > 2}") shouldBe Block(Val("X", IntConstant(10)), GT(3, 2))
+    parse("{val X = 3 - 2; 3 > 2}") shouldBe Block(Val("X", Minus(3, 2)), GT(3, 2))
+    parse("{val X = 3 + 2; 3 > 2}") shouldBe Block(Val("X", plus(3, 2)), GT(3, 2))
+    parse("{val X = if (true) true else false; false}") shouldBe Block(Val("X", If(TrueLeaf, TrueLeaf, FalseLeaf)), FalseLeaf)
 
     val expr = parse(
-      """{let X = 10
-        |let Y = 11
+      """{val X = 10
+        |val Y = 11
         |X > Y}
       """.stripMargin)
 
-    expr shouldBe Block(Seq(Let("X", IntConstant(10)),Let("Y", IntConstant(11))), GT(IntIdent("X"), IntIdent("Y")))
+    expr shouldBe Block(Seq(Val("X", IntConstant(10)),Val("Y", IntConstant(11))), GT(IntIdent("X"), IntIdent("Y")))
   }
 
   property("types") {
-    parse("{let X: Byte = 10; 3 > 2}") shouldBe Block(Seq(Let("X", SByte, IntConstant(10))), GT(3, 2))
-    parse("{let X: Int = 10; 3 > 2}") shouldBe Block(Seq(Let("X", SInt, IntConstant(10))), GT(3, 2))
-    parse("""{let X: (Int, Boolean) = (10, true); 3 > 2}""") shouldBe
-      Block(Seq(Let("X", STuple(SInt, SBoolean), Tuple(IntConstant(10), TrueLeaf))), GT(3, 2))
-    parse("""{let X: Array[Int] = Array(1,2,3); X.size}""") shouldBe
-      Block(Seq(Let("X", SCollection(SInt), Apply(Ident("Array"), IndexedSeq(IntConstant(1), IntConstant(2), IntConstant(3))))),
+    parse("{val X: Byte = 10; 3 > 2}") shouldBe Block(Seq(Val("X", SByte, IntConstant(10))), GT(3, 2))
+    parse("{val X: Int = 10; 3 > 2}") shouldBe Block(Seq(Val("X", SInt, IntConstant(10))), GT(3, 2))
+    parse("""{val X: (Int, Boolean) = (10, true); 3 > 2}""") shouldBe
+      Block(Seq(Val("X", STuple(SInt, SBoolean), Tuple(IntConstant(10), TrueLeaf))), GT(3, 2))
+    parse("""{val X: Array[Int] = Array(1,2,3); X.size}""") shouldBe
+      Block(Seq(Val("X", SCollection(SInt), Apply(Ident("Array"), IndexedSeq(IntConstant(1), IntConstant(2), IntConstant(3))))),
             Select(Ident("X"), "size"))
-    parse("""{let X: (Array[Int], Box) = (Array(1,2,3), INPUT); X._1}""") shouldBe
-        Block(Seq(Let("X", STuple(SCollection(SInt), SBox), Tuple(Apply(Ident("Array"), IndexedSeq(IntConstant(1), IntConstant(2), IntConstant(3))), Ident("INPUT")))),
+    parse("""{val X: (Array[Int], Box) = (Array(1,2,3), INPUT); X._1}""") shouldBe
+        Block(Seq(Val("X", STuple(SCollection(SInt), SBox), Tuple(Apply(Ident("Array"), IndexedSeq(IntConstant(1), IntConstant(2), IntConstant(3))), Ident("INPUT")))),
           Select(Ident("X"), "_1"))
   }
 
@@ -173,27 +173,27 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
       """.stripMargin) shouldBe FalseLeaf
 
     parse(
-      """{let X = 10;
+      """{val X = 10;
         |
         |true}
-      """.stripMargin) shouldBe Block(Seq(Let("X", IntConstant(10))), TrueLeaf)
+      """.stripMargin) shouldBe Block(Seq(Val("X", IntConstant(10))), TrueLeaf)
     parse(
-      """{let X = 11
+      """{val X = 11
         |true}
-      """.stripMargin) shouldBe Block(Seq(Let("X", IntConstant(11))), TrueLeaf)
+      """.stripMargin) shouldBe Block(Seq(Val("X", IntConstant(11))), TrueLeaf)
   }
 
   property("comments") {
     parse(
       """{
        |// line comment
-       |let X = 12
+       |val X = 12
        |/* comment // nested line comment
        |*/
        |3 - // end line comment
        |  2
        |}
-      """.stripMargin) shouldBe Block(Seq(Let("X", IntConstant(12))), Minus(3, 2))
+      """.stripMargin) shouldBe Block(Seq(Val("X", IntConstant(12))), Minus(3, 2))
   }
 
   property("if") {
@@ -212,11 +212,11 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
       """if
 
              (true)
-        |{ let A = 10;
+        |{ val A = 10;
         |  1 }
         |else if ( X == Y) 2 else 3""".stripMargin) shouldBe
         If(TrueLeaf,
-          Block(Seq(Let("A", IntConstant(10))), IntConstant(1)),
+          Block(Seq(Val("A", IntConstant(10))), IntConstant(1)),
           If(EQ(Ident("X"), Ident("Y")), IntConstant(2), IntConstant(3))
     )
 
@@ -312,7 +312,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("f(x, y)") shouldBe Apply(Ident("f"), IndexedSeq(Ident("x"), Ident("y")))
     parse("f(x, y).size") shouldBe Select(Apply(Ident("f"), IndexedSeq(Ident("x"), Ident("y"))), "size")
     parse("f(x, y).get(1)") shouldBe Apply(Select(Apply(Ident("f"), IndexedSeq(Ident("x"), Ident("y"))), "get"), IndexedSeq(IntConstant(1)))
-    parse("{let y = f(x); y}") shouldBe Block(Seq(Let("y", Apply(Ident("f"), IndexedSeq(Ident("x"))))), Ident("y"))
+    parse("{val y = f(x); y}") shouldBe Block(Seq(Val("y", Apply(Ident("f"), IndexedSeq(Ident("x"))))), Ident("y"))
     parse("getVar[Array[Byte]](10).get") shouldBe Select(Apply(ApplyTypes(Ident("getVar"), Seq(SByteArray)), IndexedSeq(IntConstant(10))), "get")
     parse("min(x, y)") shouldBe Apply(Ident("min"), IndexedSeq(Ident("x"), Ident("y")))
     parse("min(1, 2)") shouldBe Apply(Ident("min"), IndexedSeq(IntConstant(1), IntConstant(2)))
@@ -353,19 +353,19 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
         Lambda(IndexedSeq("x" -> NoType), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1)))
     parse("{ (x: Int) => { x - 1 } }") shouldBe
         Lambda(IndexedSeq("x" -> SInt), Block(Seq(), mkMinus(Ident("x").asValue[SInt.type], IntConstant(1))))
-    parse("{ (x: Int) =>  let y = x - 1; y }") shouldBe
+    parse("{ (x: Int) =>  val y = x - 1; y }") shouldBe
       Lambda(IndexedSeq("x" -> SInt),
-        Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
-    parse("{ (x: Int) => { let y = x - 1; y } }") shouldBe
+        Block(Val("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
+    parse("{ (x: Int) => { val y = x - 1; y } }") shouldBe
         Lambda(IndexedSeq("x" -> SInt),
-          Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
+          Block(Val("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
     parse(
       """{ (x: Int) =>
-        |let y = x - 1
+        |val y = x - 1
         |y
         |}""".stripMargin) shouldBe
       Lambda(IndexedSeq("x" -> SInt),
-        Block(Let("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
+        Block(Val("y", mkMinus(IntIdent("x"), 1)), Ident("y")))
   }
 
   property("predefined Exists with lambda argument") {
@@ -377,13 +377,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("function definitions") {
-    parse("{let f = { (x: Int) => x - 1 }; f}") shouldBe
-      Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
+    parse("{val f = { (x: Int) => x - 1 }; f}") shouldBe
+      Block(Val("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
     parse(
-      """{let f = { (x: Int) => x - 1 }
+      """{val f = { (x: Int) => x - 1 }
        |f}
       """.stripMargin) shouldBe
-        Block(Let("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
+        Block(Val("f", Lambda(IndexedSeq("x" -> SInt), mkMinus(IntIdent("x"), 1))), Ident("f"))
   }
 
   property("get field of ref") {
@@ -431,7 +431,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     fail("X)", 1)
     fail("(X", 2)
     fail("{ X", 3)
-    fail("{ let X", 7)
+    fail("{ val X", 7)
     fail("\"str", 4)
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -94,21 +94,21 @@ class SigmaSpecializerTest extends PropSpec
   }
 
   property("generic methods of arrays") {
-    spec("OUTPUTS.map(fun (out: Box) = { out.value >= 10 })") shouldBe
+    spec("OUTPUTS.map({ (out: Box) => out.value >= 10 })") shouldBe
       MapCollection(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
-    spec("OUTPUTS.exists(fun (out: Box) = { out.value >= 10 })") shouldBe
+    spec("OUTPUTS.exists({ (out: Box) => out.value >= 10 })") shouldBe
         Exists(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
-    spec("OUTPUTS.forall(fun (out: Box) = { out.value >= 10 })") shouldBe
+    spec("OUTPUTS.forall({ (out: Box) => out.value >= 10 })") shouldBe
         ForAll(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
-    spec("{ let arr = Array(1,2); arr.fold(0, fun (n1: Int, n2: Int) = n1 + n2)}") shouldBe
+    spec("{ let arr = Array(1,2); arr.fold(0, { (n1: Int, n2: Int) => n1 + n2 })}") shouldBe
         Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
              22, IntConstant(0), 21, Plus(TaggedInt(21), TaggedInt(22)))
-    spec("{ let arr = Array(1,2); arr.fold(true, fun (n1: Boolean, n2: Int) = n1 && (n2 > 1))}") shouldBe
+    spec("{ let arr = Array(1,2); arr.fold(true, {(n1: Boolean, n2: Int) => n1 && (n2 > 1)})}") shouldBe
       Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
         22, TrueLeaf, 21, AND(TaggedBoolean(21), GT(TaggedInt(22), IntConstant(1))))
     spec("OUTPUTS.slice(0, 10)") shouldBe
         Slice(Outputs, IntConstant(0), IntConstant(10))
-    spec("OUTPUTS.where(fun (out: Box) = { out.value >= 10 })") shouldBe
+    spec("OUTPUTS.where({ (out: Box) => out.value >= 10 })") shouldBe
         Where(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -63,14 +63,14 @@ class SigmaSpecializerTest extends PropSpec
          Plus(Ident("X", SLong).asValue[SLong.type], LongConstant(1))) shouldBe Plus(10L, 1L)
   }
 
-  property("substitute all let expressions in block result") {
-    spec("{ let X = 10; X }") shouldBe IntConstant(10)
-    spec("{ let X = 10; let Y = 20; X + Y }") shouldBe Plus(10, 20)
-    spec("{ let X = 10; let Y = 20; X + Y + X }") shouldBe Plus(Plus(10, 20), 10)
-    spec("{ let X = 10 + 1; X + X}") shouldBe Plus(Plus(10, 1), Plus(10, 1))
-    spec("{ let X = 10; let Y = X; Y}") shouldBe IntConstant(10)
-    spec("{ let X = 10; let Y = X; let Z = Y; Z }") shouldBe IntConstant(10)
-    spec("{ let X = 10; let Y = X + 1; let Z = Y + X; Z + Y + X }") shouldBe
+  property("substitute all val expressions in block result") {
+    spec("{ val X = 10; X }") shouldBe IntConstant(10)
+    spec("{ val X = 10; val Y = 20; X + Y }") shouldBe Plus(10, 20)
+    spec("{ val X = 10; val Y = 20; X + Y + X }") shouldBe Plus(Plus(10, 20), 10)
+    spec("{ val X = 10 + 1; X + X}") shouldBe Plus(Plus(10, 1), Plus(10, 1))
+    spec("{ val X = 10; val Y = X; Y}") shouldBe IntConstant(10)
+    spec("{ val X = 10; val Y = X; val Z = Y; Z }") shouldBe IntConstant(10)
+    spec("{ val X = 10; val Y = X + 1; val Z = Y + X; Z + Y + X }") shouldBe
       Plus(Plus(/*Z=*/Plus(/*Y=*/Plus(10, 1), 10), /*Y=*/Plus(10, 1)), 10)
   }
 
@@ -100,10 +100,10 @@ class SigmaSpecializerTest extends PropSpec
         Exists(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
     spec("OUTPUTS.forall({ (out: Box) => out.value >= 10 })") shouldBe
         ForAll(Outputs, 21, GE(ExtractAmount(TaggedBox(21)), LongConstant(10)))
-    spec("{ let arr = Array(1,2); arr.fold(0, { (n1: Int, n2: Int) => n1 + n2 })}") shouldBe
+    spec("{ val arr = Array(1,2); arr.fold(0, { (n1: Int, n2: Int) => n1 + n2 })}") shouldBe
         Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
              22, IntConstant(0), 21, Plus(TaggedInt(21), TaggedInt(22)))
-    spec("{ let arr = Array(1,2); arr.fold(true, {(n1: Boolean, n2: Int) => n1 && (n2 > 1)})}") shouldBe
+    spec("{ val arr = Array(1,2); arr.fold(true, {(n1: Boolean, n2: Int) => n1 && (n2 > 1)})}") shouldBe
       Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
         22, TrueLeaf, 21, AND(TaggedBoolean(21), GT(TaggedInt(22), IntConstant(1))))
     spec("OUTPUTS.slice(0, 10)") shouldBe

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -212,14 +212,14 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("lambdas") {
     typecheck(env, "{ (a: Int) => a + 1 }") shouldBe SFunc(IndexedSeq(SInt), SInt)
-    typecheck(env, "{ (a: Int): Int => a + 1 }") shouldBe SFunc(IndexedSeq(SInt), SInt)
+    typecheck(env, "{ (a: Int) => a + 1 }") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "{ (a: Int) => { a + 1 } }") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "{ (a: Int) => { let b = a + 1; b } }") shouldBe SFunc(IndexedSeq(SInt), SInt)
-    typecheck(env, "{ (a: Int, box: Box): Long => a + box.value }") shouldBe
+    typecheck(env, "{ (a: Int, box: Box) => a + box.value }") shouldBe
       SFunc(IndexedSeq(SInt, SBox), SLong)
-    typecheck(env, "{ (p: (Int, GroupElement), box: Box): Boolean => p._1 > box.value && p._2.isIdentity }") shouldBe
+    typecheck(env, "{ (p: (Int, GroupElement), box: Box) => p._1 > box.value && p._2.isIdentity }") shouldBe
       SFunc(IndexedSeq(STuple(SInt, SGroupElement), SBox), SBoolean)
-    typecheck(env, "{ (p: (Int, SigmaProp), box: Box): Boolean => p._1 > box.value && p._2.isValid }") shouldBe
+    typecheck(env, "{ (p: (Int, SigmaProp), box: Box) => p._1 > box.value && p._2.isValid }") shouldBe
       SFunc(IndexedSeq(STuple(SInt, SSigmaProp), SBox), SBoolean)
 
     typefail(env, "{ (a) => a + 1 }", "undefined type of argument")

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -97,17 +97,17 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, """PK("111")""") shouldBe SSigmaProp
   }
 
-  property("let constructs") {
-    typecheck(env, "{let X = 10; X > 2}") shouldBe SBoolean
-    typecheck(env, """{let X = 10; X >= X}""".stripMargin) shouldBe SBoolean
-    typecheck(env, """{let X = 10 + 1; X >= X}""".stripMargin) shouldBe SBoolean
+  property("val constructs") {
+    typecheck(env, "{val X = 10; X > 2}") shouldBe SBoolean
+    typecheck(env, """{val X = 10; X >= X}""".stripMargin) shouldBe SBoolean
+    typecheck(env, """{val X = 10 + 1; X >= X}""".stripMargin) shouldBe SBoolean
     typecheck(env,
-      """{let X = 10
-       |let Y = X + 1
+      """{val X = 10
+       |val Y = X + 1
        |X < Y}
       """.stripMargin) shouldBe SBoolean
-    typecheck(env, "{let X = (10, true); X._1 > 2 && X._2}") shouldBe SBoolean
-    typecheck(env, "{let X = (Array(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
+    typecheck(env, "{val X = (10, true); X._1 > 2 && X._2}") shouldBe SBoolean
+    typecheck(env, "{val X = (Array(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
   }
 
   property("generic methods of arrays") {
@@ -118,7 +118,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "OUTPUTS.map({ (out: Box) => out.value >= minToRaise })") shouldBe ty("Array[Boolean]")
     typecheck(env, "OUTPUTS.exists({ (out: Box) => out.value >= minToRaise })") shouldBe SBoolean
     typecheck(env, "OUTPUTS.forall({ (out: Box) => out.value >= minToRaise })") shouldBe SBoolean
-    typecheck(env, "{ let arr = Array(1,2,3); arr.fold(0, { (i1: Int, i2: Int) => i1 + i2 })}") shouldBe SInt
+    typecheck(env, "{ val arr = Array(1,2,3); arr.fold(0, { (i1: Int, i2: Int) => i1 + i2 })}") shouldBe SInt
     typecheck(env, "OUTPUTS.slice(0, 10)") shouldBe ty("Array[Box]")
     typecheck(env, "OUTPUTS.where({ (out: Box) => out.value >= minToRaise })") shouldBe ty("Array[Box]")
   }
@@ -147,12 +147,12 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("types") {
-    typecheck(env, "{let X: Int = 10; 3 > 2}") shouldBe SBoolean
-    typecheck(env, "{let X: (Int, Boolean) = (10, true); 3 > 2}") shouldBe SBoolean
-    typecheck(env, "{let X: Array[Int] = Array(1,2,3); X.size}") shouldBe SInt
-    typecheck(env, "{let X: (Array[Int], Int) = (Array(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
-    typecheck(env, "{let X: (Array[Int], Int) = (Array(1,2,3), x); X._1}") shouldBe SCollection(SInt)
-    typecheck(env, "{let X: (Array[Int], Int) = (Array(1,2,3), x); X._1}") shouldBe SCollection(SInt)
+    typecheck(env, "{val X: Int = 10; 3 > 2}") shouldBe SBoolean
+    typecheck(env, "{val X: (Int, Boolean) = (10, true); 3 > 2}") shouldBe SBoolean
+    typecheck(env, "{val X: Array[Int] = Array(1,2,3); X.size}") shouldBe SInt
+    typecheck(env, "{val X: (Array[Int], Int) = (Array(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
+    typecheck(env, "{val X: (Array[Int], Int) = (Array(1,2,3), x); X._1}") shouldBe SCollection(SInt)
+    typecheck(env, "{val X: (Array[Int], Int) = (Array(1,2,3), x); X._1}") shouldBe SCollection(SInt)
   }
 
   property("if") {
@@ -161,7 +161,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "if(c1) x else y") shouldBe SInt
     typecheck(env,
       """if (true) {
-        |  let A = 10; A
+        |  val A = 10; A
         |} else
         |  if ( x == y) 2 else 3""".stripMargin) shouldBe SInt
   }
@@ -214,7 +214,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "{ (a: Int) => a + 1 }") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "{ (a: Int) => a + 1 }") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "{ (a: Int) => { a + 1 } }") shouldBe SFunc(IndexedSeq(SInt), SInt)
-    typecheck(env, "{ (a: Int) => { let b = a + 1; b } }") shouldBe SFunc(IndexedSeq(SInt), SInt)
+    typecheck(env, "{ (a: Int) => { val b = a + 1; b } }") shouldBe SFunc(IndexedSeq(SInt), SInt)
     typecheck(env, "{ (a: Int, box: Box) => a + box.value }") shouldBe
       SFunc(IndexedSeq(SInt, SBox), SLong)
     typecheck(env, "{ (p: (Int, GroupElement), box: Box) => p._1 > box.value && p._2.isIdentity }") shouldBe
@@ -226,7 +226,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("function definitions") {
-    typecheck(env, "{ let f = { (x: Int) => x + 1 }; f }") shouldBe SFunc(IndexedSeq(SInt), SInt)
+    typecheck(env, "{ val f = { (x: Int) => x + 1 }; f }") shouldBe SFunc(IndexedSeq(SInt), SInt)
   }
 
   property("predefined primitives") {

--- a/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
@@ -77,10 +77,10 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val env = Map("proofId" -> proofId.toLong, "elementId" -> elementId.toLong)
     val propCompiled = compile(env,
       """{
-        |  let tree = SELF.R3[AvlTree].get
-        |  let proof = getVar[Array[Byte]](proofId).get
-        |  let element = getVar[Long](elementId).get
-        |  let elementKey = blake2b256(longToByteArray(element))
+        |  val tree = SELF.R3[AvlTree].get
+        |  val proof = getVar[Array[Byte]](proofId).get
+        |  val element = getVar[Long](elementId).get
+        |  val elementKey = blake2b256(longToByteArray(element))
         |  element >= 120 && isMember(tree, elementKey, proof)
         |}""".stripMargin).asBoolValue
 
@@ -136,9 +136,9 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val env = Map("proofId" -> proofId.toLong)
     val prop = compile(env,
       """{
-        |  let tree = SELF.R4[AvlTree].get
-        |  let key = SELF.R5[Array[Byte]].get
-        |  let proof = getVar[Array[Byte]](proofId).get
+        |  val tree = SELF.R4[AvlTree].get
+        |  val key = SELF.R5[Array[Byte]].get
+        |  val proof = getVar[Array[Byte]](proofId).get
         |  isMember(tree, key, proof)
         |}""".stripMargin).asBoolValue
 

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -147,7 +147,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
       true
     )
     test(env, ext,
-      "{ Array(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get).forall(fun (p: SigmaProp) = p.isValid) }",
+      "{ Array(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get).forall({ (p: SigmaProp) => p.isValid }) }",
       ForAll(ConcreteCollection(ExtractRegisterAs[SSigmaProp.type](Self, reg1), TaggedSigmaProp(propVar1)),
         21, SigmaPropIsValid(TaggedSigmaProp(21))),
       true
@@ -237,7 +237,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     test(env1, ext1,
       """{
         |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
-        |  data.exists(fun (p: (Array[Byte], Long)) = p._2 == 10L)
+        |  data.exists({ (p: (Array[Byte], Long)) => p._2 == 10L })
         |}""".stripMargin,
       {
         val data = TaggedVariable(dataVar, dataType)
@@ -247,7 +247,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     test(env1, ext1,
       """{
         |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
-        |  data.forall(fun (p: (Array[Byte], Long)) = p._1.size > 0)
+        |  data.forall({ (p: (Array[Byte], Long)) => p._1.size > 0 })
         |}""".stripMargin,
       {
         val data = TaggedVariable(dataVar, dataType)
@@ -258,7 +258,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     test(env1, ext1,
       """{
         |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
-        |  data.map(fun (p: (Array[Byte], Long)) = (p._2, p._1)).size == 1
+        |  data.map({ (p: (Array[Byte], Long)) => (p._2, p._1)}).size == 1
         |}""".stripMargin,
       {
         val data = TaggedVariable(dataVar, dataType)

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -192,8 +192,8 @@ class BasicOpsSpecification extends SigmaTestingCommons {
       EQ(SelectField(Tuple(TaggedInt(intVar1), TaggedInt(intVar2)), 2), IntConstant(2))
     )
     test(env, ext,
-      """{ let p = (getVar[Int](intVar1).get, getVar[Int](intVar2).get)
-        |  let res = p._1 + p._2
+      """{ val p = (getVar[Int](intVar1).get, getVar[Int](intVar2).get)
+        |  val res = p._1 + p._2
         |  res == 3 }""".stripMargin,
       {
         val p = Tuple(TaggedInt(intVar1), TaggedInt(intVar2))
@@ -205,14 +205,14 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
   property("Tuple as Collection operations") {
     test(env, ext,
-    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
+    """{ val p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
      |  p.size == 2 }""".stripMargin,
     {
       val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))
       EQ(SizeOf(p), IntConstant(2))
     })
     test(env, ext,
-    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
+    """{ val p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
      |  p(0) == 1 }""".stripMargin,
     {
       val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))
@@ -226,7 +226,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     val ext1 = ext :+ (dataVar, Constant[SCollection[STuple]](data, dataType))
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
+        |  val data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.size == 1
         |}""".stripMargin,
       {
@@ -236,7 +236,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
+        |  val data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.exists({ (p: (Array[Byte], Long)) => p._2 == 10L })
         |}""".stripMargin,
       {
@@ -246,7 +246,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
+        |  val data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.forall({ (p: (Array[Byte], Long)) => p._1.size > 0 })
         |}""".stripMargin,
       {
@@ -257,7 +257,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     )
     test(env1, ext1,
       """{
-        |  let data = getVar[Array[(Array[Byte], Long)]](dataVar).get
+        |  val data = getVar[Array[(Array[Byte], Long)]](dataVar).get
         |  data.map({ (p: (Array[Byte], Long)) => (p._2, p._1)}).size == 1
         |}""".stripMargin,
       {
@@ -270,7 +270,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
 // TODO uncomment after operations over Any are implemented
 //    test(env, ext,
-//    """{ let p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
+//    """{ val p = (getVar[Int](intVar1).get, getVar[Byte](byteVar2).get)
 //     |  p.getOrElse(2, 3).isInstanceOf[Int] }""".stripMargin,
 //    {
 //      val p = Tuple(TaggedInt(intVar1), TaggedByte(byteVar2))

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -56,7 +56,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = compile(Map(), "OUTPUTS.exists(fun (box: Box) = box.value + 5 > 10)").asBoolValue
+    val prop = compile(Map(), "OUTPUTS.exists({ (box: Box) => box.value + 5 > 10 })").asBoolValue
 
     val expProp = Exists(Outputs, 21, GT(Plus(ExtractAmount(TaggedBox(21)), LongConstant(5)), LongConstant(10)))
     prop shouldBe expProp
@@ -84,7 +84,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val verifier = new ErgoLikeInterpreter
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = compile(Map(), "OUTPUTS.forall(fun (box: Box) = box.value == 10)").asBoolValue
+    val prop = compile(Map(), "OUTPUTS.forall({ (box: Box) => box.value == 10 })").asBoolValue
 
     val propTree = ForAll(Outputs, 21, EQ(ExtractAmount(TaggedBox(21)), LongConstant(10)))
     prop shouldBe propTree
@@ -113,7 +113,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val pubkey = prover.dlogSecrets.head.publicImage
 
-    val prop = compile(Map(), "OUTPUTS.forall(fun (box: Box) = box.value == 10)").asBoolValue
+    val prop = compile(Map(), "OUTPUTS.forall({ (box: Box) => box.value == 10 })").asBoolValue
     val propTree = ForAll(Outputs, 21, EQ(ExtractAmount(TaggedBox(21)), LongConstant(10)))
     prop shouldBe propTree
 
@@ -140,7 +140,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val prop = compile(Map(),
-      """OUTPUTS.exists(fun (box: Box) = {
+      """OUTPUTS.exists({ (box: Box) =>
         |  box.R4[Long].get == SELF.R4[Long].get + 1
          })""".stripMargin).asBoolValue
 
@@ -174,7 +174,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val prop = compile(Map(),
-      """OUTPUTS.exists(fun (box: Box) = {
+      """OUTPUTS.exists({ (box: Box) =>
         |  box.R4[Long].getOrElse(0L) == SELF.R4[Long].get + 1
          })""".stripMargin).asBoolValue
 
@@ -238,7 +238,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
   property("slice") {
     val outputBoxValues = IndexedSeq(10L, 10L)
-    val code = "OUTPUTS.slice(1, OUTPUTS.size).forall(fun (box: Box) = box.value == 10)"
+    val code = "OUTPUTS.slice(1, OUTPUTS.size).forall({ (box: Box) => box.value == 10 })"
     val expectedPropTree = ForAll(
       Slice(Outputs, IntConstant(1), SizeOf(Outputs)),
       21,
@@ -285,7 +285,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map(fun (box: Box): Long = box.value).getOrElse(3, 0L)== 0""".stripMargin
+        |.map({ (box: Box): Long => box.value }).getOrElse(3, 0L)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
         MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),
@@ -311,8 +311,8 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map(fun (box: Box) = box.value)
-        |.fold(true, fun (acc: Boolean, val: Long) = acc && (val < 0)) == false""".stripMargin
+        |.map({ (box: Box) => box.value })
+        |.fold(true, { (acc: Boolean, val: Long) => acc && (val < 0) }) == false""".stripMargin
     val expectedPropTree = EQ(
       Fold(
         MapCollection(Outputs, 21, ExtractAmount(TaggedBox(21))),
@@ -329,7 +329,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val code =
       """{
         |  let indexCollection = Array(0, 1, 2, 3, 4, 5)
-        |  fun elementRule(index: Int) = {
+        |  let elementRule = {(index: Int) =>
         |    let boundaryIndex = if (index == 0) 5 else (index - 1)
         |    boundaryIndex >= 0 && boundaryIndex <= 5
         |  }
@@ -352,7 +352,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
       """{
         |  let string = Array(1, 1, 0, 0, 0, 1)
         |  let indexCollection = Array(0, 1, 2, 3, 4, 5)
-        |  fun elementRule(index: Int) = {
+        |  let elementRule = {(index: Int) =>
         |    let boundedIndex = if (index <= 0) 5 else (index - 1)
         |    let element = string(boundedIndex)
         |    element == 0 || element == 1

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -140,9 +140,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val prop = compile(Map(),
-      """OUTPUTS.exists({ (box: Box) =>
+      """OUTPUTS.exists { (box: Box) =>
         |  box.R4[Long].get == SELF.R4[Long].get + 1
-         })""".stripMargin).asBoolValue
+         }""".stripMargin).asBoolValue
 
     val propTree = Exists(Outputs, 21, EQ(ExtractRegisterAs(TaggedBox(21), reg1)(SLong),
       Plus(ExtractRegisterAs(Self, reg1)(SLong), LongConstant(1))))
@@ -174,9 +174,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val prop = compile(Map(),
-      """OUTPUTS.exists({ (box: Box) =>
+      """OUTPUTS.exists { (box: Box) =>
         |  box.R4[Long].getOrElse(0L) == SELF.R4[Long].get + 1
-         })""".stripMargin).asBoolValue
+         }""".stripMargin).asBoolValue
 
     val propTree = Exists(Outputs, 21,
       EQ(ExtractRegisterAs(TaggedBox(21), reg1, default = Some(LongConstant(0L))),
@@ -285,7 +285,8 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map({ (box: Box) => box.value }).getOrElse(3, 0L)== 0""".stripMargin
+        |.map { (box: Box) => box.value }
+        |.getOrElse(3, 0L)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
         MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -285,7 +285,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """OUTPUTS
-        |.map({ (box: Box): Long => box.value }).getOrElse(3, 0L)== 0""".stripMargin
+        |.map({ (box: Box) => box.value }).getOrElse(3, 0L)== 0""".stripMargin
     val expectedPropTree = EQ(
       ByIndex(
         MapCollection(Outputs,21,ExtractAmount(TaggedBox(21))),

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -328,9 +328,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """{
-        |  let indexCollection = Array(0, 1, 2, 3, 4, 5)
-        |  let elementRule = {(index: Int) =>
-        |    let boundaryIndex = if (index == 0) 5 else (index - 1)
+        |  val indexCollection = Array(0, 1, 2, 3, 4, 5)
+        |  val elementRule = {(index: Int) =>
+        |    val boundaryIndex = if (index == 0) 5 else (index - 1)
         |    boundaryIndex >= 0 && boundaryIndex <= 5
         |  }
         |  indexCollection.forall(elementRule)
@@ -350,11 +350,11 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code =
       """{
-        |  let string = Array(1, 1, 0, 0, 0, 1)
-        |  let indexCollection = Array(0, 1, 2, 3, 4, 5)
-        |  let elementRule = {(index: Int) =>
-        |    let boundedIndex = if (index <= 0) 5 else (index - 1)
-        |    let element = string(boundedIndex)
+        |  val string = Array(1, 1, 0, 0, 0, 1)
+        |  val indexCollection = Array(0, 1, 2, 3, 4, 5)
+        |  val elementRule = {(index: Int) =>
+        |    val boundedIndex = if (index <= 0) 5 else (index - 1)
+        |    val element = string(boundedIndex)
         |    element == 0 || element == 1
         |  }
         |  indexCollection.forall(elementRule)

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -157,10 +157,10 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       val env = Map("sender" -> sender, "timeout" -> timeout, "properHash" -> properHash)
       val compiledProp = compile(env,
         """{
-          |  let notTimePassed = HEIGHT <= timeout
-          |  let outBytes = OUTPUTS.map({(box: Box) => box.bytesWithNoRef})
-          |  let outSumBytes = outBytes.fold(Array[Byte](), {(arr1: Array[Byte], arr2: Array[Byte]) => arr1 ++ arr2})
-          |  let timePassed = HEIGHT > timeout
+          |  val notTimePassed = HEIGHT <= timeout
+          |  val outBytes = OUTPUTS.map({(box: Box) => box.bytesWithNoRef})
+          |  val outSumBytes = outBytes.fold(Array[Byte](), {(arr1: Array[Byte], arr2: Array[Byte]) => arr1 ++ arr2})
+          |  val timePassed = HEIGHT > timeout
           |  notTimePassed && blake2b256(outSumBytes) == properHash || timePassed && sender
            }""".stripMargin).asBoolValue
 
@@ -206,7 +206,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val env = Map("pubkey" -> pubkey)
     val prop = compile(env,
       """{
-        |  let outValues = OUTPUTS.map({ (box: Box) => box.value })
+        |  val outValues = OUTPUTS.map({ (box: Box) => box.value })
         |  pubkey && outValues.fold(0L, { (x: Long, y: Long) => x + y }) > 20
          }""".stripMargin).asBoolValue
 
@@ -312,8 +312,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val prop = compile(Map(),
       """{
-        |  let pubkey1 = SELF.R4[GroupElement].get
-        |  let pubkey2 = SELF.R5[GroupElement].get
+        |  val pubkey1 = SELF.R4[GroupElement].get
+        |  val pubkey2 = SELF.R5[GroupElement].get
         |  proveDlog(pubkey1) && proveDlog(pubkey2)
         |}""".stripMargin).asBoolValue
 
@@ -412,8 +412,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val env = Map("brother" -> brother)
     val prop = compile(env,
       """{
-        |  let okInputs = INPUTS.size == 2
-        |  let okIds = INPUTS(0).id == brother.id
+        |  val okInputs = INPUTS.size == 2
+        |  val okIds = INPUTS(0).id == brother.id
         |  okInputs && okIds
          }""".stripMargin).asBoolValue
 
@@ -453,8 +453,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val prop2 = compile(env,
       """{
-        |  let okInputs = INPUTS.size == 3
-        |  let okIds = INPUTS(0).id == brother.id
+        |  val okInputs = INPUTS.size == 3
+        |  val okIds = INPUTS(0).id == brother.id
         |  okInputs && okIds
          }""".stripMargin).asBoolValue
 
@@ -485,7 +485,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val prop = compile(env,
       """{
         |
-        | let isFriend = { (inputBox: Box) => inputBox.id == friend.id }
+        | val isFriend = { (inputBox: Box) => inputBox.id == friend.id }
         | INPUTS.exists (isFriend)
          }""".stripMargin).asBoolValue
 
@@ -554,8 +554,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val env = Map("helloHash" -> helloHash)
     val prop = compile(env,
       """{
-        |  let cond = INPUTS(0).value > 10
-        |  let preimage = if (cond)
+        |  val cond = INPUTS(0).value > 10
+        |  val preimage = if (cond)
         |    INPUTS(2).R4[Array[Byte]].get
         |  else
         |    INPUTS(1).R4[Array[Byte]].get

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -158,8 +158,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       val compiledProp = compile(env,
         """{
           |  let notTimePassed = HEIGHT <= timeout
-          |  let outBytes = OUTPUTS.map(fun (box: Box) = box.bytesWithNoRef)
-          |  let outSumBytes = outBytes.fold(Array[Byte](), fun (arr1: Array[Byte], arr2: Array[Byte]) = arr1 ++ arr2)
+          |  let outBytes = OUTPUTS.map({(box: Box) => box.bytesWithNoRef})
+          |  let outSumBytes = outBytes.fold(Array[Byte](), {(arr1: Array[Byte], arr2: Array[Byte]) => arr1 ++ arr2})
           |  let timePassed = HEIGHT > timeout
           |  notTimePassed && blake2b256(outSumBytes) == properHash || timePassed && sender
            }""".stripMargin).asBoolValue
@@ -206,8 +206,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val env = Map("pubkey" -> pubkey)
     val prop = compile(env,
       """{
-        |  let outValues = OUTPUTS.map(fun (box: Box) = box.value)
-        |  pubkey && outValues.fold(0L, fun (x: Long, y: Long) = x + y) > 20
+        |  let outValues = OUTPUTS.map({ (box: Box) => box.value })
+        |  pubkey && outValues.fold(0L, { (x: Long, y: Long) => x + y }) > 20
          }""".stripMargin).asBoolValue
 
     val propExp = AND(
@@ -485,7 +485,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val prop = compile(env,
       """{
         |
-        | let isFriend = fun (inputBox: Box) = {inputBox.id == friend.id}
+        | let isFriend = { (inputBox: Box) => inputBox.id == friend.id }
         | INPUTS.exists (isFriend)
          }""".stripMargin).asBoolValue
 
@@ -493,7 +493,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     prop shouldBe propExpected
 
     // same script written differently
-    val altProp = compile(env, "INPUTS.exists (fun (inputBox: Box) = {inputBox.id == friend.id})")
+    val altProp = compile(env, "INPUTS.exists ({ (inputBox: Box) => inputBox.id == friend.id })")
     altProp shouldBe prop
 
     val s = ErgoBox(10, prop, Seq(), Map())

--- a/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
@@ -47,7 +47,7 @@ class ThresholdSpecification extends SigmaTestingCommons {
     // this example is from the white paper
     val compiledProp2 = compile(env,
       """{
-        |    let array = Array(pubkeyA, pubkeyB, pubkeyC)
+        |    val array = Array(pubkeyA, pubkeyB, pubkeyC)
         |    atLeast(array.size, array)
         |}""".stripMargin).asBoolValue
 
@@ -69,7 +69,7 @@ class ThresholdSpecification extends SigmaTestingCommons {
     // this example is from the white paper
     val compiledProp3 = compile(env,
       """{
-        |    let array = Array(pubkeyA, pubkeyB, pubkeyC)
+        |    val array = Array(pubkeyA, pubkeyB, pubkeyC)
         |    atLeast(1, array)
         |}""".stripMargin).asBoolValue
     val prop3 = AtLeast(1, pubkeyA, pubkeyB, pubkeyC)
@@ -87,7 +87,7 @@ class ThresholdSpecification extends SigmaTestingCommons {
 
     val compiledProp4 = compile(env,
       """{
-        |    let array = Array(pubkeyA, pubkeyB, pubkeyC)
+        |    val array = Array(pubkeyA, pubkeyB, pubkeyC)
         |    atLeast(2, array)
         |}""".stripMargin).asBoolValue
     val prop4 = AtLeast(2, pubkeyA, pubkeyB, pubkeyC)

--- a/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingScriptContract.scala
+++ b/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingScriptContract.scala
@@ -25,8 +25,8 @@ class CrowdFundingScriptContract(
     )
     val compiledScript = compiler.compile(env,
       """{
-       | let c1 = HEIGHT >= timeout && backerPubKey
-       | let c2 = allOf(Array(
+       | val c1 = HEIGHT >= timeout && backerPubKey
+       | val c2 = allOf(Array(
        |   HEIGHT < timeout,
        |   projectPubKey,
        |   OUTPUTS.exists(fun (out: Box) = {

--- a/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingScriptContract.scala
+++ b/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingScriptContract.scala
@@ -29,7 +29,7 @@ class CrowdFundingScriptContract(
        | val c2 = allOf(Array(
        |   HEIGHT < timeout,
        |   projectPubKey,
-       |   OUTPUTS.exists(fun (out: Box) = {
+       |   OUTPUTS.exists({ (out: Box) =>
        |     out.value >= minToRaise && out.propositionBytes == projectPubKey.propBytes
        |   })
        | ))

--- a/src/test/scala/sigmastate/utxo/examples/AssetsAtomicExchangeSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/AssetsAtomicExchangeSpecification.scala
@@ -76,7 +76,7 @@ class AssetsAtomicExchangeSpecification extends SigmaTestingCommons {
     val buyerEnv = Map("pkA" -> tokenBuyerKey, "deadline" -> deadline, "token1" -> tokenId)
     val altBuyerProp = compile(buyerEnv,
       """(HEIGHT > deadline && pkA) || {
-        |  let tokenData = OUTPUTS(0).R2[Array[(Array[Byte], Long)]].get(0)
+        |  val tokenData = OUTPUTS(0).R2[Array[(Array[Byte], Long)]].get(0)
         |  allOf(Array(
         |      tokenData._1 == token1,
         |      tokenData._2 >= 60L,

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -78,14 +78,14 @@ class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
       "oneEpochReduction" -> s.oneEpochReduction)
     val prop1 = compile(env,
       """{
-        |    let epoch = 1 + ((HEIGHT - fixedRatePeriod) / epochLength)
-        |    let out = OUTPUTS(0)
-        |    let coinsToIssue = if(HEIGHT < fixedRatePeriod) fixedRate else fixedRate - (oneEpochReduction * epoch)
-        |    let correctCoinsConsumed = coinsToIssue == (SELF.value - out.value)
-        |    let sameScriptRule = SELF.propositionBytes == out.propositionBytes
-        |    let heightIncreased = HEIGHT > SELF.R4[Long].get
-        |    let heightCorrect = out.R4[Long].get == HEIGHT
-        |    let lastCoins = SELF.value <= oneEpochReduction
+        |    val epoch = 1 + ((HEIGHT - fixedRatePeriod) / epochLength)
+        |    val out = OUTPUTS(0)
+        |    val coinsToIssue = if(HEIGHT < fixedRatePeriod) fixedRate else fixedRate - (oneEpochReduction * epoch)
+        |    val correctCoinsConsumed = coinsToIssue == (SELF.value - out.value)
+        |    val sameScriptRule = SELF.propositionBytes == out.propositionBytes
+        |    val heightIncreased = HEIGHT > SELF.R4[Long].get
+        |    val heightCorrect = out.R4[Long].get == HEIGHT
+        |    val lastCoins = SELF.value <= oneEpochReduction
         |    allOf(Array(correctCoinsConsumed, heightCorrect, heightIncreased, sameScriptRule)) || (heightIncreased && lastCoins)
         |}""".stripMargin).asBoolValue
 

--- a/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
@@ -41,8 +41,8 @@ class CrowdfundingExampleSpecification extends SigmaTestingCommons {
     )
     val compiledScript = compile(env,
       """{
-        | let c1 = HEIGHT >= timeout && backerPubKey
-        | let c2 = allOf(Array(
+        | val c1 = HEIGHT >= timeout && backerPubKey
+        | val c2 = allOf(Array(
         |   HEIGHT < timeout,
         |   projectPubKey,
         |   OUTPUTS.exists({ (out: Box) =>
@@ -81,12 +81,12 @@ class CrowdfundingExampleSpecification extends SigmaTestingCommons {
     val altScript = compile(altEnv,
       """
         |       {
-        |                let fundraisingFailure = HEIGHT >= deadline && backerPubKey
-        |                let enoughRaised = {(outBox: Box) =>
+        |                val fundraisingFailure = HEIGHT >= deadline && backerPubKey
+        |                val enoughRaised = {(outBox: Box) =>
         |                        outBox.value >= minToRaise &&
         |                        outBox.propositionBytes == projectPubKey.propBytes
         |                }
-        |                let fundraisingSuccess = HEIGHT < deadline &&
+        |                val fundraisingSuccess = HEIGHT < deadline &&
         |                         projectPubKey &&
         |                         OUTPUTS.exists(enoughRaised)
         |

--- a/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
@@ -45,7 +45,7 @@ class CrowdfundingExampleSpecification extends SigmaTestingCommons {
         | let c2 = allOf(Array(
         |   HEIGHT < timeout,
         |   projectPubKey,
-        |   OUTPUTS.exists(fun (out: Box) = {
+        |   OUTPUTS.exists({ (out: Box) =>
         |     out.value >= minToRaise && out.propositionBytes == projectPubKey.propBytes
         |   })
         | ))
@@ -82,7 +82,7 @@ class CrowdfundingExampleSpecification extends SigmaTestingCommons {
       """
         |       {
         |                let fundraisingFailure = HEIGHT >= deadline && backerPubKey
-        |                let enoughRaised = fun(outBox: Box) = {
+        |                let enoughRaised = {(outBox: Box) =>
         |                        outBox.value >= minToRaise &&
         |                        outBox.propositionBytes == projectPubKey.propBytes
         |                }

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -44,7 +44,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     )
     val prop = compile(env,
       """{
-        | let c2 = allOf(Array(
+        | val c2 = allOf(Array(
         |   HEIGHT >= SELF.R4[Long].get + demurragePeriod,
         |   OUTPUTS.exists({ (out: Box) =>
         |     out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -46,7 +46,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
       """{
         | let c2 = allOf(Array(
         |   HEIGHT >= SELF.R4[Long].get + demurragePeriod,
-        |   OUTPUTS.exists(fun (out: Box) = {
+        |   OUTPUTS.exists({ (out: Box) =>
         |     out.value >= SELF.value - demurrageCost && out.propositionBytes == SELF.propositionBytes
         |   })
         | ))

--- a/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
@@ -43,12 +43,12 @@ class Rule110Specification extends SigmaTestingCommons {
 
     val prop = compile(Map(),
       """{
-        |  let indices: Array[Int] = Array(0, 1, 2, 3, 4, 5)
-        |  let inLayer: Array[Byte] = SELF.R4[Array[Byte]].get
-        |  let procCell = {(i: Int) =>
-        |    let l = inLayer((if (i == 0) 5 else (i - 1)))
-        |    let c = inLayer(i)
-        |    let r = inLayer((i + 1) % 6)
+        |  val indices: Array[Int] = Array(0, 1, 2, 3, 4, 5)
+        |  val inLayer: Array[Byte] = SELF.R4[Array[Byte]].get
+        |  val procCell = {(i: Int) =>
+        |    val l = inLayer((if (i == 0) 5 else (i - 1)))
+        |    val c = inLayer(i)
+        |    val r = inLayer((i + 1) % 6)
         |    ((l * c * r + c * r + c + r) % 2).toByte
         |  }
         |  (OUTPUTS(0).R4[Array[Byte]].get == indices.map(procCell)) &&

--- a/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
@@ -45,7 +45,7 @@ class Rule110Specification extends SigmaTestingCommons {
       """{
         |  let indices: Array[Int] = Array(0, 1, 2, 3, 4, 5)
         |  let inLayer: Array[Byte] = SELF.R4[Array[Byte]].get
-        |  fun procCell(i: Int): Byte = {
+        |  let procCell = {(i: Int) =>
         |    let l = inLayer((if (i == 0) 5 else (i - 1)))
         |    let c = inLayer(i)
         |    let r = inLayer((i + 1) % 6)


### PR DESCRIPTION
Close #227 

Todo:
- [x] single param in parenthesis;
- [x] body of multiple expressions;
- [x] multiple parameters;
- [x] switch to new lambda syntax in code (tests, examples, etc.);
- [x] error on multiple argument lists in lambda;
- [x] fix parsing of a tuple apply inside a lambda (`SigmaParserTest."tuple operations"` test);
- [x] fix parsing of function calls inside a tuple (`BasicOpsSpec."tuple *"`, `ContextEnrichingSpec."prover*` tests);
- [x] fix `Rule110Specification."rule110 - one layer in register"`;
- [x] change `let` to `val`
- [x] remove logging in parsers;
- [x] switch to new lambda syntax in wpaper;
- [x] switch to new lambda syntax in `LangSpec.md`;
- [x] clean up commented code in parser;
- [x] avoid `({...})`, allow to either omit ~~curly braces~~ or parenthesis; use `OUTPUTS.exists { (box: Box) => box.value > 1000 }` syntax;
- [x] complex tests (nested lambdas, etc.);
- [x] negative tests;