### PR TITLE
Generic `deserialize` for constants

### DIFF
--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -165,6 +165,9 @@ def proveDlog(value: GroupElement): Boolean
 
 /** Predicate which checks whether a key is in a tree, by using a membership proof. */
 def isMember(tree: AvlTree, key: Array[Byte], proof: Array[Byte]): Boolean
+
+/** Deserializes values from Base58 encoded binary data at compile time */
+def deserialize[T](string: String): T
 ```
 
 ## Examples

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -40,6 +40,7 @@ object SigmaPredef {
     "fromBase58" -> mkLambda(Vector("input" -> SString), SByteArray, None),
     "fromBase64" -> mkLambda(Vector("input" -> SString), SByteArray, None),
     "PK" -> mkLambda(Vector("input" -> SString), SSigmaProp, None),
+    "deserialize" -> mkGenLambda(Seq(STypeParam(tT)), Vector("str" -> SString), SOption(tT), None),
   ).toMap
 
   def PredefIdent(name: String): Value[SType] = {
@@ -66,4 +67,6 @@ object SigmaPredef {
   val FromBase64Sym = PredefIdent("fromBase64")
 
   val PKSym = PredefIdent("PK")
+
+  val DeserializeSym = PredefIdent("deserialize")
 }

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaBinderExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaBinderExceptions.scala
@@ -2,3 +2,6 @@ package sigmastate.lang.exceptions
 
 final class InvalidArguments(message: String, source: Option[SourceContext] = None)
   extends BinderException(message, source)
+
+final class InvalidTypeArguments(message: String, source: Option[SourceContext] = None)
+  extends BinderException(message, source)

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -10,6 +10,8 @@ import sigmastate.lang.SigmaCompiler
 import sigmastate.utxo.CostTable
 import sigmastate.lang.Terms._
 import org.ergoplatform.{ErgoBox, Height}
+import scorex.util.encode.Base58
+import sigmastate.serialization.ValueSerializer
 
 import scala.util.Random
 
@@ -314,6 +316,12 @@ class TestingInterpreterSpecification extends PropSpec
         |   val g = { (c: Int) => c == 1 }
         |   Array[Int](1).exists(g)
         | } == true """.stripMargin)
+  }
+
+  property("deserialize") {
+    val str = Base58.encode(ValueSerializer.serialize(ByteArrayConstant(Array[Byte](2))))
+    testEval(s"""deserialize[Array[Byte]]("$str").size == 1""")
+    testEval(s"""deserialize[Array[Byte]]("$str")(0) == 2""")
   }
 }
 

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -3,11 +3,12 @@ package sigmastate.lang
 import org.ergoplatform.{Height, Inputs, Outputs, Self}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
-import sigmastate.SCollection.SByteArray
+import scorex.util.encode.Base58
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.Terms._
-import sigmastate.lang.exceptions.{BinderException, InvalidArguments}
+import sigmastate.lang.exceptions.{BinderException, InvalidArguments, InvalidTypeArguments}
+import sigmastate.serialization.ValueSerializer
 import sigmastate.utxo._
 
 class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with LangTests {
@@ -173,4 +174,24 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "Array[Int]()") shouldBe ConcreteCollection()(SInt)
   }
 
+  property("deserialize") {
+    def roundtrip[T <: SType](c: EvaluatedValue[T], typeSig: String) = {
+      val bytes = ValueSerializer.serialize(c)
+      val str = Base58.encode(bytes)
+      bind(env, s"deserialize[$typeSig](" + "\"" + str + "\")") shouldBe c
+    }
+    roundtrip(ByteArrayConstant(Array[Byte](2)), "Array[Byte]")
+    roundtrip(Tuple(ByteArrayConstant(Array[Byte](2)), LongConstant(4)), "(Array[Byte], Long)")
+  }
+
+  property("deserialize fails") {
+    // more than one type
+    an[InvalidTypeArguments] should be thrownBy bind(env, """deserialize[Int, Byte]("test")""")
+    // more then one argument
+    an[InvalidArguments] should be thrownBy bind(env, """deserialize[Int]("test", "extra argument")""")
+    // not a string constant
+    an[InvalidArguments] should be thrownBy bind(env, """deserialize[Int]("a" + "b")""")
+    // invalid chat in Base58 string
+    an[AssertionError] should be thrownBy bind(env, """deserialize[Int]("0")""")
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -506,4 +506,11 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   property("PK") {
     parse("""PK("111")""") shouldBe Apply(Ident("PK"), IndexedSeq(StringConstant("111")))
   }
+
+  property("deserialize") {
+    parse("""deserialize[GroupElement]("12345")""") shouldBe
+      Apply(ApplyTypes(Ident("deserialize"), Seq(SGroupElement)), IndexedSeq(StringConstant("12345")))
+    parse("""deserialize[(GroupElement, Array[(Int, Byte)])]("12345")""") shouldBe
+      Apply(ApplyTypes(Ident("deserialize"), Seq(STuple(SGroupElement, SCollection(STuple(SInt, SByte))))), IndexedSeq(StringConstant("12345")))
+  }
 }


### PR DESCRIPTION
Close #230 

Todo:
- [x] parser;
- [x] build a deserialized constant and introduce it in the binder;
- [x] test for failing in binder (non-constant string, decoding failed, etc.);
- [x] test interpreter;
- [x] update the docs;