### PR TITLE
New costing, etc.: Rewrite reduceToCrypto

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -63,12 +63,12 @@ class ErgoLikeContext(val currentHeight: Height,
     Cols.fromArray(res)
   }
 
-  override def toSigmaContext(IR: Evaluation): sigma.Context = {
+  override def toSigmaContext(IR: Evaluation, isCost: Boolean): sigma.Context = {
     implicit val IRForBox = IR
-    val inputs = boxesToSpend.toArray.map(_.toTestBox(true))
-    val outputs = spendingTransaction.outputs.toArray.map(_.toTestBox(true))
+    val inputs = boxesToSpend.toArray.map(_.toTestBox(isCost))
+    val outputs = spendingTransaction.outputs.toArray.map(_.toTestBox(isCost))
     val vars = contextVars(extension.values)
-    new CostingDataContext(IR, inputs, outputs, currentHeight, self.toTestBox(true), emptyAvlTree, vars.arr, true)
+    new CostingDataContext(IR, inputs, outputs, currentHeight, self.toTestBox(isCost), emptyAvlTree, vars.arr, true)
   }
 
   implicit class ErgoBoxOps(ebox: ErgoBox) {

--- a/src/main/scala/sigmastate/eval/Evaluation.scala
+++ b/src/main/scala/sigmastate/eval/Evaluation.scala
@@ -148,7 +148,7 @@ trait Evaluation extends Costing {
           case First(In(p: Tuple2[_,_])) => out(p._1)
           case Second(In(p: Tuple2[_,_])) => out(p._2)
           case wc: LiftedConst[_,_] => out(wc.constValue)
-          case _: DslBuilder | _: ColBuilder | _: IntPlusMonoid | _: LongPlusMonoid =>
+          case _: DslBuilder | _: ColBuilder | _: CostedBuilder | _: IntPlusMonoid | _: LongPlusMonoid =>
             out(dataEnv.getOrElse(te.sym, !!!(s"Cannot resolve companion instance for $te")))
           case SigmaM.propBytes(prop) =>
             val sigmaBool = dataEnv(prop).asInstanceOf[SigmaBoolean]

--- a/src/main/scala/sigmastate/interpreter/Context.scala
+++ b/src/main/scala/sigmastate/interpreter/Context.scala
@@ -2,9 +2,11 @@ package sigmastate.interpreter
 
 import sigmastate.SType
 import sigmastate.Values.EvaluatedValue
+import sigmastate.eval.Evaluation
 import sigmastate.serialization.Serializer
 import sigmastate.utils.{ByteReader, ByteWriter}
 import sigmastate.utils.Extensions._
+import special.sigma
 
 /**
   * Variables to be put into context
@@ -48,4 +50,6 @@ trait Context[C <: Context[C]] {
     val ext = extension.add(bindings:_*)
     withExtension(ext)
   }
+
+  def toSigmaContext(IR: Evaluation): sigma.Context
 }

--- a/src/main/scala/sigmastate/interpreter/Context.scala
+++ b/src/main/scala/sigmastate/interpreter/Context.scala
@@ -51,5 +51,5 @@ trait Context[C <: Context[C]] {
     withExtension(ext)
   }
 
-  def toSigmaContext(IR: Evaluation): sigma.Context
+  def toSigmaContext(IR: Evaluation, isCost: Boolean): sigma.Context
 }

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -4,32 +4,24 @@ import java.util
 import java.util.Objects
 
 import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{everywherebu, rule, strategy}
-import org.bitbucket.inkytonik.kiama.relation.Tree
-import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{everywherebu, rule, strategy}
 import org.bitbucket.inkytonik.kiama.rewriting.Strategy
 import org.bouncycastle.math.ec.custom.djb.Curve25519Point
 import scapi.sigma.DLogProtocol.{DLogInteractiveProver, FirstDLogProverMessage}
 import scapi.sigma._
-import scorex.crypto.authds.avltree.batch.Lookup
 import scorex.crypto.authds.avltree.batch.{Lookup, Operation}
 import scorex.crypto.authds.{ADKey, SerializedAdProof}
 import scorex.crypto.hash.Blake2b256
-import sigmastate.SCollection.SByteArray
-import sigmastate.Values.{ByteArrayConstant, _}
-import sigmastate.eval.Evaluation
 import scorex.util.ScorexLogging
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values.{ByteArrayConstant, _}
+import sigmastate.eval.Evaluation
 import sigmastate.interpreter.Interpreter.VerificationResult
 import sigmastate.lang.TransformingSigmaBuilder
-import sigmastate.serialization.{OpCodes, ValueSerializer}
-import sigmastate.utils.Extensions._
 import sigmastate.lang.exceptions.{InterpreterException, InvalidType}
 import sigmastate.serialization.{OpCodes, OperationSerializer, Serializer, ValueSerializer}
 import sigmastate.utils.Extensions._
 import sigmastate.utils.Helpers
-import sigmastate.utxo.{DeserializeContext, Transformer}
-import sigmastate.utxo.{CostTable, DeserializeContext, GetVar, Transformer}
+import sigmastate.utxo.{DeserializeContext, GetVar, Transformer}
 import sigmastate.{SType, _}
 
 import scala.util.{Failure, Success, Try}
@@ -351,14 +343,14 @@ trait Interpreter extends ScorexLogging {
   lazy val IR: Evaluation = new Evaluation {
     import TestSigmaDslBuilder._
 
-    val sigmaDslBuilder = RTestSigmaDslBuilder()
-    val builder = TransformingSigmaBuilder
+    override val sigmaDslBuilder = RTestSigmaDslBuilder()
+    override val builder = TransformingSigmaBuilder
 
     beginPass(new DefaultPass("mypass", Pass.defaultPassConfig.copy(constantPropagation = false)))
 
-    val sigmaDslBuilderValue = new special.sigma.TestSigmaDslBuilder()
-    val costedBuilderValue = new special.collection.ConcreteCostedBuilder()
-    val monoidBuilderValue = new special.collection.MonoidBuilderInst()
+    override val sigmaDslBuilderValue = new special.sigma.TestSigmaDslBuilder()
+    override val costedBuilderValue = new special.collection.ConcreteCostedBuilder()
+    override val monoidBuilderValue = new special.collection.MonoidBuilderInst()
   }
 
   import IR._

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -390,13 +390,13 @@ trait Interpreter extends ScorexLogging {
     require(IR.verifyIsValid(calcF).isSuccess)
     // check cost
     val costFun = IR.compile[SInt.type](IR.getDataEnv, costF)
-    val IntConstant(estimatedCost) = costFun(context.toSigmaContext(IR))
+    val IntConstant(estimatedCost) = costFun(context.toSigmaContext(IR, isCost = true))
     if (estimatedCost > maxCost) {
       throw new Error(s"Estimated expression complexity $estimatedCost exceeds the limit $maxCost in $exp")
     }
     // check calc
     val valueFun = IR.compile[SBoolean.type](IR.getDataEnv, calcF.asRep[IR.Context => SBoolean.WrappedType])
-    val res = valueFun(context.toSigmaContext(IR))
+    val res = valueFun(context.toSigmaContext(IR, isCost = false))
     res -> estimatedCost
   }
 

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -381,8 +381,6 @@ trait Interpreter extends ScorexLogging {
       case Some(v: Value[SBoolean.type]@unchecked) if v.tpe == SBoolean => v
       case x => throw new Error(s"Context-dependent pre-processing should produce tree of type Boolean but was $x")
     }
-
-    // todo get env
     val env = Map[String, Any]()
     val IR.Tuple(calcF, costF, sizeF) = doCosting[SType#WrappedType](env, substTree)
     require(IR.verifyCostFunc(costF).isSuccess)

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -334,7 +334,7 @@ case class TestingContext(height: Int,
                          ) extends Context[TestingContext] {
   override def withExtension(newExtension: ContextExtension): TestingContext = this.copy(extension = newExtension)
 
-  override def toSigmaContext(IR: Evaluation): sigma.Context = ???
+  override def toSigmaContext(IR: Evaluation, isCost: Boolean): sigma.Context = ???
 }
 
 /** An interpreter for tests with 2 random secrets*/

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -1,14 +1,17 @@
 package sigmastate
 
-import org.scalatest.prop.{PropertyChecks, GeneratorDrivenPropertyChecks}
-import org.scalatest.{PropSpec, Matchers}
-import scapi.sigma.DLogProtocol.{ProveDlog, DLogProverInput}
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+import org.scalatest.{Matchers, PropSpec}
+import scapi.sigma.DLogProtocol.{DLogProverInput, ProveDlog}
 import scorex.crypto.hash.Blake2b256
 import sigmastate.Values._
 import sigmastate.interpreter._
 import sigmastate.lang.{SigmaCompiler, TransformingSigmaBuilder}
 import sigmastate.utxo.CostTable
 import sigmastate.lang.Terms._
+import org.ergoplatform.{ErgoBox, Height}
+import sigmastate.eval.Evaluation
+import special.sigma
 import org.ergoplatform.{Height, ErgoBox}
 import scorex.util.encode.Base58
 import sigmastate.serialization.ValueSerializer
@@ -330,6 +333,8 @@ case class TestingContext(height: Int,
                           override val extension: ContextExtension = ContextExtension(values = Map())
                          ) extends Context[TestingContext] {
   override def withExtension(newExtension: ContextExtension): TestingContext = this.copy(extension = newExtension)
+
+  override def toSigmaContext(IR: Evaluation): sigma.Context = ???
 }
 
 /** An interpreter for tests with 2 random secrets*/

--- a/src/test/scala/sigmastate/eval/CostingTest.scala
+++ b/src/test/scala/sigmastate/eval/CostingTest.scala
@@ -217,7 +217,6 @@ class CostingTest extends BaseCtxTests with LangTests with ExampleContracts with
           ctx => ctx.INPUTS.length + ctx.OUTPUTS.length + i)
       }
     }
-    res.show
     println(s"Defs: $defCounter, Time: ${defTime / 1000000}")
   }
 

--- a/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
+++ b/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
@@ -18,14 +18,14 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests { self: BaseCtxT
   lazy val IR: TestContext with Evaluation = new TestContext with Evaluation {
     import TestSigmaDslBuilder._
 
-    val sigmaDslBuilder = RTestSigmaDslBuilder()
-    val builder = TransformingSigmaBuilder
+    override val sigmaDslBuilder = RTestSigmaDslBuilder()
+    override val builder = TransformingSigmaBuilder
 
     beginPass(new DefaultPass("mypass", Pass.defaultPassConfig.copy(constantPropagation = false)))
 
-    val sigmaDslBuilderValue = new special.sigma.TestSigmaDslBuilder()
-    val costedBuilderValue = new special.collection.ConcreteCostedBuilder()
-    val monoidBuilderValue = new special.collection.MonoidBuilderInst()
+    override val sigmaDslBuilderValue = new special.sigma.TestSigmaDslBuilder()
+    override val costedBuilderValue = new special.collection.ConcreteCostedBuilder()
+    override val monoidBuilderValue = new special.collection.MonoidBuilderInst()
   }
 
   import IR._

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -106,7 +106,7 @@ class SigmaSpecializerTest extends PropSpec
              22, IntConstant(0), 21, Plus(TaggedInt(21), TaggedInt(22)))
     spec("{ val arr = Array(1,2); arr.fold(true, {(n1: Boolean, n2: Int) => n1 && (n2 > 1)})}") shouldBe
       Fold(ConcreteCollection(IntConstant(1), IntConstant(2)),
-        22, TrueLeaf, 21, AND(TaggedBoolean(21), GT(TaggedInt(22), IntConstant(1))))
+        22, TrueLeaf, 21, BinAnd(TaggedBoolean(21), GT(TaggedInt(22), IntConstant(1))))
     spec("OUTPUTS.slice(0, 10)") shouldBe
         Slice(Outputs, IntConstant(0), IntConstant(10))
     spec("OUTPUTS.where({ (out: Box) => out.value >= 10 })") shouldBe


### PR DESCRIPTION
Todo: 
- [x] fill in proper `isCost` option values;
- [x] run through deserialization first;
- [x] fix missing `ColBuilder`("s3") in `DataEnv`;
- [x] fix `CostedBuilder` companion obj resolution upon evaluation;