### PR TITLE
add ZKProof  function (zero-knowledge scope)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,12 +57,12 @@ version in ThisBuild := {
 
 git.gitUncommittedChanges in ThisBuild := true
 
-val specialVersion = "snapshot-publish-b32356d5-SNAPSHOT"
+val specialVersion = "master-c1654f39-SNAPSHOT"
 val specialCommon = "io.github.scalan" %% "common" % specialVersion
 val specialCore = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion
 
-val specialSigmaVersion = "special-snapshot-from-sonatype-0e5f4283-SNAPSHOT"
+val specialSigmaVersion = "master-696a31dc-SNAPSHOT"
 val sigmaImpl = "io.github.scalan" %% "sigma-impl" % specialSigmaVersion
 val sigmaLibrary = "io.github.scalan" %% "sigma-library" % specialSigmaVersion
 

--- a/lock.sbt
+++ b/lock.sbt
@@ -17,16 +17,16 @@ dependencyOverrides in ThisBuild ++= Seq(
   "com.typesafe.akka" % "akka-actor_2.12" % "2.4.20",
   "com.typesafe.scala-logging" % "scala-logging_2.12" % "3.9.0",
   "commons-io" % "commons-io" % "2.5",
-  "io.github.scalan" % "common_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "core_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "library-api_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "library-impl_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "library_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "macros_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "meta_2.12" % "snapshot-publish-b32356d5-SNAPSHOT",
-  "io.github.scalan" % "sigma-api_2.12" % "special-snapshot-from-sonatype-0e5f4283-SNAPSHOT",
-  "io.github.scalan" % "sigma-impl_2.12" % "special-snapshot-from-sonatype-0e5f4283-SNAPSHOT",
-  "io.github.scalan" % "sigma-library_2.12" % "special-snapshot-from-sonatype-0e5f4283-SNAPSHOT",
+  "io.github.scalan" % "common_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "core_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "library-api_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "library-impl_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "library_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "macros_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "meta_2.12" % "master-c1654f39-SNAPSHOT",
+  "io.github.scalan" % "sigma-api_2.12" % "master-696a31dc-SNAPSHOT",
+  "io.github.scalan" % "sigma-impl_2.12" % "master-696a31dc-SNAPSHOT",
+  "io.github.scalan" % "sigma-library_2.12" % "master-696a31dc-SNAPSHOT",
   "javax.activation" % "activation" % "1.1",
   "jline" % "jline" % "2.14.3",
   "org.apache.ant" % "ant" % "1.9.6",
@@ -47,4 +47,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH ab4cb73e399845d6b13fe9815b9204b21f5b7a4f
+// LIBRARY_DEPENDENCIES_HASH 275304f2bb9f6569bd042a2df62a353c5c51dc3e

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -696,9 +696,10 @@ object Values {
     *  Bit 7 == 1 if the header contains more than 1 byte (default == 0)
     *  Bit 6 == 1 if the bytes after the header are compressed using GZIP (default == 0)
     *  Bit 5 == 1 if context dependent costing should be used (default = 0)
-    *  Bit 4 - reserved
-    *  Bit 3 - reserved
-    *  Bits 2-0 - language version
+    *  Bit 4 == 1 if constant segregation is used for this ErgoTree (default = 0)
+    *                (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/264)
+    *  Bit 3 - reserved (should be 0)
+    *  Bits 2-0 - language version (current version == 0)
     *
     *  Currently we don't specify interpretation for the second and other bytes of the header.
     *  We reserve the possibility to extend header by using Bit 7 == 1 and chain additional bytes as in VLQ.

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -372,8 +372,8 @@ trait Interpreter extends ScorexLogging {
 
     val substTree = everywherebu(substRule)(exp) match {
       case Some(v: Value[SBoolean.type]@unchecked) if v.tpe == SBoolean => v
-      case Some(p @ SigmaPropConstant(_)) => p.asSigmaProp.isValid
-      case x => throw new Error(s"Context-dependent pre-processing should produce tree of type Boolean but was $x")
+      case Some(p: SValue) if p.tpe == SSigmaProp => p.asSigmaProp.isValid
+      case x => throw new Error(s"Context-dependent pre-processing should produce tree of type Boolean of SigmaProp but was $x")
     }
     val costingRes @ IR.Pair(calcF, costF) = doCosting(env, substTree)
     IR.onCostingResult(env, substTree, costingRes)

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -159,7 +159,7 @@ trait SigmaBuilder {
   def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType]
   def mkBlockValue(items: IndexedSeq[BlockItem], result: Value[SType]): Value[SType]
   def mkValUse(valId: Int, tpe: SType): Value[SType]
-  def mkZKProofBlock(body: Value[SType]): Value[SType]
+  def mkZKProofBlock(body: Value[SSigmaProp.type]): Value[SBoolean.type]
   def mkVal(name: String, givenType: SType, body: Value[SType]): Val
   def mkSelect(obj: Value[SType], field: String, resType: Option[SType] = None): Value[SType]
   def mkIdent(name: String, tpe: SType): Value[SType]
@@ -457,7 +457,7 @@ class StdSigmaBuilder extends SigmaBuilder {
   override def mkValUse(valId: Int, tpe: SType): Value[SType] =
     ValUse(valId, tpe)
 
-  override def mkZKProofBlock(body: Value[SType]): Value[SType] =
+  override def mkZKProofBlock(body: Value[SSigmaProp.type]): BoolValue =
     ZKProofBlock(body)
 
   override def mkVal(name: String, givenType: SType, body: Value[SType]): Val =

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -159,6 +159,7 @@ trait SigmaBuilder {
   def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType]
   def mkBlockValue(items: IndexedSeq[BlockItem], result: Value[SType]): Value[SType]
   def mkValUse(valId: Int, tpe: SType): Value[SType]
+  def mkZKProofBlock(body: Value[SType]): Value[SType]
   def mkVal(name: String, givenType: SType, body: Value[SType]): Val
   def mkSelect(obj: Value[SType], field: String, resType: Option[SType] = None): Value[SType]
   def mkIdent(name: String, tpe: SType): Value[SType]
@@ -455,6 +456,9 @@ class StdSigmaBuilder extends SigmaBuilder {
 
   override def mkValUse(valId: Int, tpe: SType): Value[SType] =
     ValUse(valId, tpe)
+
+  override def mkZKProofBlock(body: Value[SType]): Value[SType] =
+    ZKProofBlock(body)
 
   override def mkVal(name: String, givenType: SType, body: Value[SType]): Val =
     ValNode(name, givenType, body)

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -25,6 +25,9 @@ object SigmaPredef {
     "allOf" -> mkLambda(Vector("conditions" -> SCollection(SBoolean)), SBoolean, None),
     "anyOf" -> mkLambda(Vector("conditions" -> SCollection(SBoolean)), SBoolean, None),
     "atLeast" -> mkLambda(Vector("k" -> SInt, "conditions" -> SCollection(SBoolean)), SBoolean, None),
+    "ZKProof" -> mkLambda(Vector("block" -> SSigmaProp), SBoolean, None),
+    "sigmaProp" -> mkLambda(Vector("condition" -> SBoolean), SSigmaProp, None),
+
     "blake2b256" -> mkLambda(Vector("input" -> SByteArray), SByteArray, None),
     "sha256" -> mkLambda(Vector("input" -> SByteArray), SByteArray, None),
     "byteArrayToBigInt" -> mkLambda(Vector("input" -> SByteArray), SBigInt, None),
@@ -32,12 +35,13 @@ object SigmaPredef {
 
     "getVar" -> mkGenLambda(Seq(STypeParam(tT)), Vector("varId" -> SByte), SOption(tT), None),
 
-    "proveDHTuple" -> mkLambda(Vector(
-      "g" -> SGroupElement, "h" -> SGroupElement, "u" -> SGroupElement, "v" -> SGroupElement), SSigmaProp, None),
+    "proveDHTuple" -> mkLambda(Vector("g" -> SGroupElement, "h" -> SGroupElement, "u" -> SGroupElement, "v" -> SGroupElement), SSigmaProp, None),
     "proveDlog" -> mkLambda(Vector("value" -> SGroupElement), SSigmaProp, None),
+
     "isMember" -> mkLambda(Vector("tree" -> SAvlTree, "key" -> SByteArray, "proof" -> SByteArray), SBoolean, None),
     "treeLookup" -> mkLambda(Vector("tree" -> SAvlTree, "key" -> SByteArray, "proof" -> SByteArray), SOption[SByteArray], None),
     "treeModifications" -> mkLambda(Vector("tree" -> SAvlTree, "ops" -> SByteArray, "proof" -> SByteArray), SOption[SByteArray], None),
+
     "fromBase58" -> mkLambda(Vector("input" -> SString), SByteArray, None),
     "fromBase64" -> mkLambda(Vector("input" -> SString), SByteArray, None),
     "PK" -> mkLambda(Vector("input" -> SString), SSigmaProp, None),
@@ -52,6 +56,8 @@ object SigmaPredef {
   val AllSym = PredefIdent("allOf")
   val AnySym = PredefIdent("anyOf")
   val AtLeastSym = PredefIdent("atLeast")
+  val ZKProofSym = PredefIdent("ZKProof")
+  val SigmaPropSym = PredefIdent("sigmaProp")
 
   val GetVarSym = PredefIdent("getVar")
 

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -51,6 +51,10 @@ class SigmaSpecializer(val builder: SigmaBuilder, val networkPrefix: NetworkPref
     case Apply(AtLeastSym, Seq(bound: SValue, arr: Value[SCollection[SBoolean.type]]@unchecked)) =>
       Some(mkAtLeast(bound.asIntValue, arr))
 
+    // Rule: ZKProof(block) --> ZKProofBlock(block)
+    case Apply(ZKProofSym, Seq(block: SigmaPropValue@unchecked)) =>
+      Some(mkZKProofBlock(block))
+
     case Apply(Blake2b256Sym, Seq(arg: Value[SByteArray]@unchecked)) =>
       Some(mkCalcBlake2b256(arg))
 

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -55,6 +55,10 @@ class SigmaSpecializer(val builder: SigmaBuilder, val networkPrefix: NetworkPref
     case Apply(ZKProofSym, Seq(block: SigmaPropValue@unchecked)) =>
       Some(mkZKProofBlock(block))
 
+    // Rule: sigmaProp(condition) --> BoolToSigmaProp(condition)
+    case Apply(SigmaPropSym, Seq(condition: BoolValue@unchecked)) =>
+      Some(mkBoolToSigmaProp(condition))
+
     case Apply(Blake2b256Sym, Seq(arg: Value[SByteArray]@unchecked)) =>
       Some(mkCalcBlake2b256(arg))
 

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -30,6 +30,14 @@ object Terms {
       Block(Seq(let), result)
   }
 
+  case class ZKProofBlock(body: Value[SType]) extends Value[SType] {
+    override val opCode: OpCode = OpCodes.Undefined
+    override def tpe: SType = body.tpe
+    override def cost[C <: Context](context: C): Long = ???
+    override def evaluated: Boolean = false
+    override def opType: SFunc = SFunc(Vector(), tpe)
+  }
+
   trait Val extends Value[SType] {
     val name: String
     val givenType: SType

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -30,12 +30,24 @@ object Terms {
       Block(Seq(let), result)
   }
 
-  case class ZKProofBlock(body: Value[SType]) extends Value[SType] {
+  /** IR node to represent explicit Zero Knowledge scope in ErgoTree.
+    * Compiler checks Zero Knowledge properties and issue error message is case of violations.
+    * ZK-scoping is optional, at can be used when the user want to ensure Zero Knowledge of
+    * specific set of operations.
+    * Usually it will require simple restructuring of the code to make the scope body explicit.
+    * Invariants checked by the compiler:
+    *  - single ZKProof in ErgoTree in a root position
+    *  - no boolean operations in the body, because otherwise the result may be disclosed
+    *  - all the operations are over SigmaProp values
+    *
+    * For motivation and details see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/236
+    * */
+  case class ZKProofBlock(body: SigmaPropValue) extends BoolValue {
     override val opCode: OpCode = OpCodes.Undefined
-    override def tpe: SType = body.tpe
+    override def tpe = SBoolean
     override def cost[C <: Context](context: C): Long = ???
     override def evaluated: Boolean = false
-    override def opType: SFunc = SFunc(Vector(), tpe)
+    override def opType: SFunc = SFunc(SSigmaProp, SBoolean)
   }
 
   trait Val extends Value[SType] {

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -189,7 +189,13 @@ trait Exprs extends Core with Types {
       case UnitConstant => mkApply(acc, IndexedSeq.empty)
       case Tuple(xs) => mkApply(acc, xs)
       case STypeApply("", targs) => mkApplyTypes(acc, targs)
-      case arg: SValue => mkApply(acc, IndexedSeq(arg))
+      case arg: SValue => acc match {
+        case Ident(name, _) if name == "ZKProof" => arg match {
+          case Terms.Block(_, body) => builder.mkZKProofBlock(body)
+          case nonBlock => error(s"expected block parameter for ZKProof, got $nonBlock")
+        }
+        case _ => mkApply(acc, IndexedSeq (arg) )
+      }
       case _ => error(s"Error after expression $f: invalid suffixes $args")
     })
     rhs

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -3,7 +3,8 @@ package sigmastate.lang.syntax
 import fastparse.noApi._
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.lang.Terms.{Apply, ApplyTypes, Ident, Lambda, Val, MethodCall, Select, ValueOps}
+import sigmastate.lang.SigmaPredef.ZKProofSym
+import sigmastate.lang.Terms.{Lambda, ApplyTypes, MethodCall, Apply, Val, ValueOps, Select, Ident}
 import sigmastate.lang._
 import sigmastate.lang.syntax.Basic._
 
@@ -191,10 +192,10 @@ trait Exprs extends Core with Types {
       case STypeApply("", targs) => mkApplyTypes(acc, targs)
       case arg: SValue => acc match {
         case Ident(name, _) if name == "ZKProof" => arg match {
-          case Terms.Block(_, body) => builder.mkZKProofBlock(body)
+          case Terms.Block(_, body) => Apply(ZKProofSym, IndexedSeq(body))
           case nonBlock => error(s"expected block parameter for ZKProof, got $nonBlock")
         }
-        case _ => mkApply(acc, IndexedSeq (arg) )
+        case _ => mkApply(acc, IndexedSeq(arg))
       }
       case _ => error(s"Error after expression $f: invalid suffixes $args")
     })

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -514,4 +514,12 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     parse("""deserialize[(GroupElement, Array[(Int, Byte)])]("12345")""") shouldBe
       Apply(ApplyTypes(Ident("deserialize"), Seq(STuple(SGroupElement, SCollection(STuple(SInt, SByte))))), IndexedSeq(StringConstant("12345")))
   }
+
+  property("ZKProof") {
+    parse("ZKProof { HEIGHT > 1000 }") shouldBe ZKProofBlock(GT(Ident("HEIGHT"), IntConstant(1000)))
+  }
+
+  property("invalid ZKProof (non block parameter)") {
+    an[ParserException] should be thrownBy  parse("ZKProof HEIGHT > 1000 ")
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -516,7 +516,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("ZKProof") {
-    parse("ZKProof { HEIGHT > 1000 }") shouldBe ZKProofBlock(GT(Ident("HEIGHT"), IntConstant(1000)))
+    parse("ZKProof { condition }") shouldBe Apply(SigmaPredef.ZKProofSym, IndexedSeq(Ident("condition")))
   }
 
   property("invalid ZKProof (non block parameter)") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -517,9 +517,17 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   property("ZKProof") {
     parse("ZKProof { condition }") shouldBe Apply(SigmaPredef.ZKProofSym, IndexedSeq(Ident("condition")))
+    parse("ZKProof { sigmaProp(HEIGHT > 1000) }") shouldBe
+      Apply(SigmaPredef.ZKProofSym,
+        IndexedSeq(Apply(Ident("sigmaProp"), IndexedSeq(GT(Ident("HEIGHT"), IntConstant(1000))))))
   }
 
   property("invalid ZKProof (non block parameter)") {
     an[ParserException] should be thrownBy  parse("ZKProof HEIGHT > 1000 ")
   }
+
+  property("sigmaProp") {
+    parse("sigmaProp(HEIGHT > 1000)") shouldBe Apply(Ident("sigmaProp"), IndexedSeq(GT(Ident("HEIGHT"), IntConstant(1000))))
+  }
+
 }

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -4,13 +4,13 @@ import org.ergoplatform.ErgoAddressEncoder.{NetworkPrefix, TestnetNetworkPrefix}
 import org.ergoplatform.ErgoBox.R4
 import org.ergoplatform._
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.{PropSpec, Matchers}
 import scapi.sigma.DLogProtocol.ProveDlog
 import sigmastate.Values._
 import sigmastate._
-import sigmastate.lang.Terms.Ident
+import sigmastate.lang.Terms.{Ident, ZKProofBlock}
 import sigmastate.lang.exceptions.SpecializerException
-import sigmastate.serialization.generators.{ConcreteCollectionGenerators, TransformerGenerators, ValueGenerators}
+import sigmastate.serialization.generators.{ValueGenerators, TransformerGenerators, ConcreteCollectionGenerators}
 import sigmastate.utxo._
 
 class SigmaSpecializerTest extends PropSpec
@@ -236,5 +236,13 @@ class SigmaSpecializerTest extends PropSpec
     spec("SELF.creationInfo") shouldBe ExtractCreationInfo(Self)
     spec("SELF.creationInfo._1") shouldBe SelectField(ExtractCreationInfo(Self), 1)
     spec("SELF.creationInfo._2") shouldBe SelectField(ExtractCreationInfo(Self), 2)
+  }
+
+  property("sigmaProp") {
+    spec("sigmaProp(HEIGHT > 1000)") shouldBe BoolToSigmaProp(GT(Height, LongConstant(1000)))
+  }
+
+  property("ZKProof") {
+    spec("ZKProof { sigmaProp(HEIGHT > 1000) }") shouldBe ZKProofBlock(BoolToSigmaProp(GT(Height, LongConstant(1000))))
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -96,6 +96,9 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, """fromBase58("111")""") shouldBe SByteArray
     typecheck(env, """fromBase64("111")""") shouldBe SByteArray
     typecheck(env, """PK("111")""") shouldBe SSigmaProp
+    typecheck(env, """PK("111")""") shouldBe SSigmaProp
+    typecheck(env, "sigmaProp(HEIGHT > 1000)") shouldBe SSigmaProp
+    typecheck(env, "ZKProof { sigmaProp(HEIGHT > 1000) }") shouldBe SBoolean
   }
 
   property("val constructs") {

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -3,7 +3,7 @@ package sigmastate.utxo
 import java.lang.reflect.InvocationTargetException
 
 import org.ergoplatform.ErgoBox.{R6, R8}
-import org.ergoplatform.{ErgoBox, ErgoLikeContext, Self}
+import org.ergoplatform.{ErgoLikeContext, ErgoBox, Self, Height}
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate._
@@ -12,6 +12,7 @@ import sigmastate.interpreter.Interpreter._
 import sigmastate.lang.Terms._
 import sigmastate.lang.exceptions.OptionUnwrapNone
 import special.sigma.InvalidType
+
 import scalan.BaseCtxTests
 
 class BasicOpsSpecification extends SigmaTestingCommons {
@@ -48,7 +49,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 
   def test(name: String, env: ScriptEnv,
            ext: Seq[(Byte, EvaluatedValue[_ <: SType])],
-           script: String, propExp: Value[SBoolean.type],
+           script: String, propExp: SValue,
       onlyPositive: Boolean = false) = {
     val prover = new ErgoLikeTestProvingInterpreter() {
       override lazy val contextExtenders: Map[Byte, EvaluatedValue[_ <: SType]] = {
@@ -443,4 +444,16 @@ class BasicOpsSpecification extends SigmaTestingCommons {
       true
     )
   }
+
+  property("sigmaProp") {
+    test("prop1", env, ext, "sigmaProp(HEIGHT >= 0)",
+      BoolToSigmaProp(GE(Height, LongConstant(0))), true)
+    test("prop2", env, ext, "sigmaProp(HEIGHT >= 0) && getVar[SigmaProp](proofVar1).get",
+      BinAnd(BoolToSigmaProp(GE(Height, LongConstant(0))).isValid, GetVarSigmaProp(propVar1).get.isValid), true)
+  }
+
+//  property("ZKProof") {
+//    test("zk1", env, ext, "ZKProof { sigmaProp(HEIGHT >= 0) }",
+//      ZKProofBlock(BoolToSigmaProp(GE(Height, LongConstant(0)))), true)
+//  }
 }


### PR DESCRIPTION
Ref #236 

Todo: 
- [x] add `ZKProof` IR node and draft the parsing;
- [ ] `ZKProof` can only be at the root of the tree;
- [ ] `ZKProof` can only be single;
- [ ] Usage of `isValid` outside of `ZKProof` scope should lead to a compiler error (this is only in the presence of ZKProof scope. If it is not declared then no such limitation);
- [ ] In the scope of ZKProof no Boolean value or operation is allowed
- [ ] Closure of ZKProof shouldn't contain Boolean values.
...