### PR TITLE
Use sigma-coster in ergo 

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/ErgoAddress.scala
@@ -108,7 +108,7 @@ class Pay2SHAddress(val scriptHash: Array[Byte])(implicit val encoder: ErgoAddre
   //see ErgoLikeInterpreterSpecification."P2SH - 160 bits" test
   override val script: Value[SBoolean.type] = {
     val scriptId = 1: Byte
-    val hashEquals = EQ(Slice(CalcBlake2b256(GetVarByteArray(scriptId)), IntConstant(0), IntConstant(24)),
+    val hashEquals = EQ(Slice(CalcBlake2b256(GetVarByteArray(scriptId).get), IntConstant(0), IntConstant(24)),
       scriptHash)
     val scriptIsCorrect = DeserializeContext(scriptId, SBoolean)
     AND(hashEquals, scriptIsCorrect)

--- a/src/main/scala/org/ergoplatform/ErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/ErgoAddress.scala
@@ -8,7 +8,7 @@ import scorex.crypto.hash.{Blake2b256, Digest32}
 import scorex.util.encode.Base58
 import sigmastate.Values.{ConcreteCollection, ConstantNode, IntConstant, TaggedByteArray, Value}
 import sigmastate._
-import sigmastate.serialization.ValueSerializer
+import sigmastate.serialization.{ErgoTreeSerializer, ValueSerializer}
 import sigmastate.utxo.{DeserializeContext, Slice}
 
 import scala.util.Try
@@ -127,7 +127,7 @@ class Pay2SHAddress(val scriptHash: Array[Byte])(implicit val encoder: ErgoAddre
 object Pay2SHAddress {
 
   def apply(script: Value[SBoolean.type])(implicit encoder: ErgoAddressEncoder): Pay2SHAddress = {
-    val sb = ValueSerializer.serialize(script)
+    val sb = ErgoTreeSerializer.serialize(script)
     val sbh = ErgoAddressEncoder.hash192(sb)
     new Pay2SHAddress(sbh)
   }
@@ -154,7 +154,7 @@ class Pay2SAddress(override val script: Value[SBoolean.type],
 
 object Pay2SAddress {
   def apply(script: Value[SBoolean.type])(implicit encoder: ErgoAddressEncoder): Pay2SAddress = {
-    val sb = ValueSerializer.serialize(script)
+    val sb = ErgoTreeSerializer.serialize(script)
     new Pay2SAddress(script, sb)
   }
 
@@ -197,7 +197,7 @@ case class ErgoAddressEncoder(networkPrefix: Byte) {
         case Pay2SHAddress.addressTypePrefix =>
           new Pay2SHAddress(bs)
         case Pay2SAddress.addressTypePrefix =>
-          new Pay2SAddress(ValueSerializer.deserialize(bs).asInstanceOf[Value[SBoolean.type]], bs)
+          new Pay2SAddress(ErgoTreeSerializer.deserialize(bs).asInstanceOf[Value[SBoolean.type]], bs)
         case _ => throw new Exception("Unsupported address type: " + addressType)
       }
     }

--- a/src/main/scala/org/ergoplatform/ErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBox.scala
@@ -21,7 +21,7 @@ import scala.runtime.ScalaRunTime
   * is associated with some monetary value (arbitrary, but with predefined precision, so we use integer arithmetic to
   * work with the value), and also a guarding script (aka proposition) to protect the box from unauthorized opening.
   *
-  * In other way, a box is a state element locked by some proposition.
+  * In other way, a box is a state element locked by some proposition (ErgoTree).
   *
   * In Ergo, box is just a collection of registers, some with mandatory types and semantics, others could be used by
   * applications in any way.
@@ -35,7 +35,7 @@ import scala.runtime.ScalaRunTime
   * to the same box.
   *
   * @param value         - amount of money associated with the box
-  * @param proposition   guarding script, which should be evaluated to true in order to open this box
+  * @param ergoTree   guarding script, which should be evaluated to true in order to open this box
   * @param additionalTokens - secondary tokens the box contains
   * @param additionalRegisters - additional registers the box can carry over
   * @param transactionId - id of transaction which created the box
@@ -44,16 +44,17 @@ import scala.runtime.ScalaRunTime
   */
 class ErgoBox private(
                        override val value: Long,
-                       override val proposition: Value[SBoolean.type],
+                       override val ergoTree: ErgoTree,
                        override val additionalTokens: Seq[(TokenId, Long)] = Seq(),
                        override val additionalRegisters: Map[NonMandatoryRegisterId, _ <: EvaluatedValue[_ <: SType]] = Map(),
                        val transactionId: ModifierId,
                        val index: Short,
                        override val creationHeight: Long
-) extends ErgoBoxCandidate(value, proposition, creationHeight, additionalTokens, additionalRegisters) {
+) extends ErgoBoxCandidate(value, ergoTree, creationHeight, additionalTokens, additionalRegisters) {
 
   import ErgoBox._
 
+  lazy val bytes: Array[Byte] = ErgoBox.serializer.toBytes(this)
   lazy val id: BoxId = ADKey @@ Blake2b256.hash(bytes)
 
   override lazy val cost: Int = (bytesWithNoRef.length / 1024 + 1) * Cost.BoxPerKilobyte
@@ -67,20 +68,18 @@ class ErgoBox private(
     }
   }
 
-  lazy val bytes: Array[Byte] = ErgoBox.serializer.toBytes(this)
-
   override def equals(arg: Any): Boolean = arg match {
     case x: ErgoBox => java.util.Arrays.equals(id, x.id)
     case _ => false
   }
 
   override def hashCode(): Int =
-    ScalaRunTime._hashCode((value, proposition, additionalTokens, additionalRegisters, index, creationHeight))
+    ScalaRunTime._hashCode((value, ergoTree, additionalTokens, additionalRegisters, index, creationHeight))
 
   def toCandidate: ErgoBoxCandidate =
-    new ErgoBoxCandidate(value, proposition, creationHeight, additionalTokens, additionalRegisters)
+    new ErgoBoxCandidate(value, ergoTree, creationHeight, additionalTokens, additionalRegisters)
 
-  override def toString: Idn = s"ErgoBox(${Base16.encode(id)},$value,$proposition," +
+  override def toString: Idn = s"ErgoBox(${Base16.encode(id)},$value,$ergoTree," +
     s"tokens: (${additionalTokens.map(t => Base16.encode(t._1)+":"+t._2)}), $transactionId, " +
     s"$index, $additionalRegisters, $creationHeight)"
 }
@@ -142,13 +141,13 @@ object ErgoBox {
   def findRegisterByIndex(i: Byte): Option[RegisterId] = registerByIndex.get(i)
 
   def apply(value: Long,
-            proposition: Value[SBoolean.type],
+            ergoTree: ErgoTree,
             creationHeight: Long,
             additionalTokens: Seq[(TokenId, Long)] = Seq(),
             additionalRegisters: Map[NonMandatoryRegisterId, _ <: EvaluatedValue[_ <: SType]] = Map(),
             transactionId: ModifierId = Array.fill[Byte](32)(0.toByte).toModifierId,
             boxId: Short = 0): ErgoBox =
-    new ErgoBox(value, proposition, additionalTokens, additionalRegisters, transactionId, boxId, creationHeight)
+    new ErgoBox(value, ergoTree, additionalTokens, additionalRegisters, transactionId, boxId, creationHeight)
 
   object serializer extends Serializer[ErgoBox, ErgoBox] {
 

--- a/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -25,7 +25,7 @@ class ErgoBoxCandidate(val value: Long,
 
   lazy val cost: Int = (bytesWithNoRef.length / 1024 + 1) * Cost.BoxPerKilobyte
 
-  val propositionBytes: Array[Byte] = proposition.bytes
+  val propositionBytes: Array[Byte] = ErgoTreeSerializer.serialize(proposition)
 
   lazy val bytesWithNoRef: Array[Byte] = ErgoBoxCandidate.serializer.toBytes(this)
 

--- a/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -10,7 +10,7 @@ import sigmastate.Values._
 import sigmastate._
 import sigmastate.SType.AnyOps
 import sigmastate.lang.Terms._
-import sigmastate.serialization.Serializer
+import sigmastate.serialization.{ErgoTreeSerializer, Serializer}
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utils.Extensions._
@@ -72,7 +72,7 @@ object ErgoBoxCandidate {
                                         digestsInTx: Option[Array[Digest32]],
                                         w: SigmaByteWriter): Unit = {
       w.putULong(obj.value)
-      w.putValue(obj.proposition)
+      w.putBytes(ErgoTreeSerializer.serialize(obj.proposition))
       w.putULong(obj.creationHeight)
       w.putUByte(obj.additionalTokens.size)
       obj.additionalTokens.foreach { case (id, amount) =>
@@ -111,7 +111,7 @@ object ErgoBoxCandidate {
 
     def parseBodyWithIndexedDigests(digestsInTx: Option[Array[Digest32]], r: SigmaByteReader): ErgoBoxCandidate = {
       val value = r.getULong()
-      val prop = r.getValue().asBoolValue
+      val prop = ErgoTreeSerializer.deserialize(r, resolvePlaceholdersToConstants = true).asBoolValue
       val creationHeight = r.getULong()
       val addTokensCount = r.getByte()
       val addTokens = (0 until addTokensCount).map { _ =>

--- a/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -18,19 +18,21 @@ import sigmastate.utils.Extensions._
 import scala.runtime.ScalaRunTime
 
 class ErgoBoxCandidate(val value: Long,
-                       val proposition: Value[SBoolean.type],
+                       val ergoTree: ErgoTree,
                        val creationHeight: Long,
                        val additionalTokens: Seq[(TokenId, Long)] = Seq(),
                        val additionalRegisters: Map[NonMandatoryRegisterId, _ <: EvaluatedValue[_ <: SType]] = Map()) {
 
+  def proposition: BoolValue = ergoTree.proposition
+
   lazy val cost: Int = (bytesWithNoRef.length / 1024 + 1) * Cost.BoxPerKilobyte
 
-  val propositionBytes: Array[Byte] = ErgoTreeSerializer.serialize(proposition)
+  val propositionBytes: Array[Byte] = ErgoTreeSerializer.serialize(ergoTree.proposition)
 
   lazy val bytesWithNoRef: Array[Byte] = ErgoBoxCandidate.serializer.toBytes(this)
 
   def toBox(txId: ModifierId, boxId: Short) =
-    ErgoBox(value, proposition, creationHeight, additionalTokens, additionalRegisters, txId, boxId)
+    ErgoBox(value, ergoTree, creationHeight, additionalTokens, additionalRegisters, txId, boxId)
 
   def get(identifier: RegisterId): Option[Value[SType]] = {
     identifier match {
@@ -57,9 +59,9 @@ class ErgoBoxCandidate(val value: Long,
   }
 
   override def hashCode(): Int =
-    ScalaRunTime._hashCode((value, proposition, additionalTokens, additionalRegisters, creationHeight))
+    ScalaRunTime._hashCode((value, ergoTree, additionalTokens, additionalRegisters, creationHeight))
 
-  override def toString: Idn = s"ErgoBoxCandidate($value, $proposition," +
+  override def toString: Idn = s"ErgoBoxCandidate($value, $ergoTree," +
     s"tokens: (${additionalTokens.map(t => Base16.encode(t._1)+":"+t._2).mkString(", ")}), " +
     s"$additionalRegisters, creationHeight: $creationHeight)"
 }
@@ -72,7 +74,7 @@ object ErgoBoxCandidate {
                                         digestsInTx: Option[Array[Digest32]],
                                         w: SigmaByteWriter): Unit = {
       w.putULong(obj.value)
-      w.putBytes(ErgoTreeSerializer.serialize(obj.proposition))
+      w.putBytes(ErgoTreeSerializer.serialize(obj.ergoTree))
       w.putULong(obj.creationHeight)
       w.putUByte(obj.additionalTokens.size)
       obj.additionalTokens.foreach { case (id, amount) =>

--- a/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -10,7 +10,7 @@ import sigmastate.Values._
 import sigmastate._
 import sigmastate.SType.AnyOps
 import sigmastate.lang.Terms._
-import sigmastate.serialization.{ErgoTreeSerializer, Serializer}
+import sigmastate.serialization.{ErgoTreeSerializer, Serializer, ValueSerializer}
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utils.Extensions._

--- a/src/main/scala/sigmastate/UnprovenTree.scala
+++ b/src/main/scala/sigmastate/UnprovenTree.scala
@@ -8,7 +8,7 @@ import scapi.sigma.DLogProtocol.{FirstDLogProverMessage, ProveDlog}
 import scapi.sigma.VerifierMessage.Challenge
 import scapi.sigma.{FirstDiffieHellmanTupleProverMessage, FirstProverMessage, ProveDiffieHellmanTuple}
 import sigmastate.Values.SigmaBoolean
-import sigmastate.serialization.ValueSerializer
+import sigmastate.serialization.ErgoTreeSerializer
 
 import scala.language.existentials
 
@@ -138,7 +138,7 @@ object FiatShamirTree {
 
     def traverseNode(node: ProofTree): Array[Byte] = node match {
       case l: ProofTreeLeaf =>
-        val propBytes = ValueSerializer.serialize(l.proposition)
+        val propBytes = ErgoTreeSerializer.serialize(l.proposition)
         val commitmentBytes = l.commitmentOpt.get.bytes
         leafPrefix +:
           ((Shorts.toByteArray(propBytes.length.toShort) ++ propBytes) ++

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -1,18 +1,19 @@
 package sigmastate
 
 import java.math.BigInteger
-import java.util.{Arrays, Objects}
+import java.util.{Objects, Arrays}
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
+import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{strategy, everywherebu}
 import org.bouncycastle.math.ec.ECPoint
-import org.ergoplatform.{ErgoBox, ErgoLikeContext}
+import org.ergoplatform.{ErgoLikeContext, ErgoBox}
 import scorex.crypto.authds.SerializedAdProof
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
-import scorex.crypto.hash.{Blake2b256, Digest32}
+import scorex.crypto.hash.{Digest32, Blake2b256}
 import sigmastate.SCollection.SByteArray
 import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate.interpreter.{Context, CryptoConstants, CryptoFunctions}
-import sigmastate.serialization.{ErgoTreeSerializer, OpCodes, ValueSerializer}
+import sigmastate.serialization.{ValueSerializer, ErgoTreeSerializer, OpCodes, ConstantStore}
 import sigmastate.serialization.OpCodes._
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utils.Extensions._
@@ -700,8 +701,8 @@ object Values {
     * |  |  |  |  |  |  |  |  |
     * -------------------------
     *  Bit 7 == 1 if the header contains more than 1 byte (default == 0)
-    *  Bit 6 - reserved
-    *  Bit 5 == 1 - reserved for context dependent costing should be used (default = 0)
+    *  Bit 6 - reserved for GZIP compression (should be 0)
+    *  Bit 5 == 1 - reserved for context dependent costing (should be = 0)
     *  Bit 4 == 1 if constant segregation is used for this ErgoTree (default = 0)
     *                (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/264)
     *  Bit 3 - reserved (should be 0)
@@ -711,18 +712,49 @@ object Values {
     *  We reserve the possibility to extend header by using Bit 7 == 1 and chain additional bytes as in VLQ.
     *  Once the new bytes are required, a new version of the language should be created and implemented.
     *  That new language will give an interpretation for the new bytes.
+    *
+    *  Consistency between fields is ensured by private constructor and factory methods in `ErgoTree` object.
     * */
   case class ErgoTree private(
     header: Byte,
+    /** If isConstantSegregation == true contains all constants.
+      * Otherwise should be empty */
     constants: IndexedSeq[Constant[SType]],
-    root: Value[SType]) {
+    /** if isConstantSegregation == true contains ConstantPlaceholder instead of Constant nodes.
+      * Otherwise */
+    root: BoolValue,
+    /** When isConstantSegregation == false this is the same as root.
+      * Otherwise, it is equivalent to `root` where all placeholders are replaced by Constants */
+    proposition: BoolValue
+  ) {
+    assert(isConstantSegregation || constants.isEmpty)
+
+    def isConstantSegregation: Boolean = (header & ErgoTree.ConstantSegregationFlag) != 0
   }
+
   object ErgoTree {
     val DefaultHeader: Byte = 0
-    def withDefaultHeader(constants: IndexedSeq[Constant[SType]], root: Value[SType]) =
-      ErgoTree(DefaultHeader, constants, root)
-    def withHeader(header: Byte, constants: IndexedSeq[Constant[SType]], root: Value[SType]) =
-      ErgoTree(header, constants, root)
+    val ConstantSegregationFlag: Byte = 0x10
+
+    def substConstants(root: BoolValue, constants: IndexedSeq[Constant[SType]]): BoolValue = {
+      val store = new ConstantStore(constants)
+      val substRule = strategy[Value[_ <: SType]] {
+        case ph: ConstantPlaceholder[_] =>
+          Some(store.get(ph.id))
+        case _ => None
+      }
+      everywherebu(substRule)(root).fold(root)(_.asInstanceOf[BoolValue])
+    }
+
+    def apply(header: Byte, constants: IndexedSeq[Constant[SType]], root: BoolValue) = {
+      if ((header & ConstantSegregationFlag) != 0) {
+        val prop = substConstants(root, constants)
+        new ErgoTree(header, constants, root, prop)
+      } else
+        new ErgoTree(header, constants, root, root)
+    }
+
+    implicit def fromProposition(prop: BoolValue): ErgoTree = ErgoTree(DefaultHeader, IndexedSeq(), prop, prop)
   }
 
 }

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -1,18 +1,18 @@
 package sigmastate
 
 import java.math.BigInteger
-import java.util.{Objects, Arrays}
+import java.util.{Arrays, Objects}
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
 import org.bouncycastle.math.ec.ECPoint
-import org.ergoplatform.{ErgoLikeContext, ErgoBox}
+import org.ergoplatform.{ErgoBox, ErgoLikeContext}
 import scorex.crypto.authds.SerializedAdProof
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
-import scorex.crypto.hash.{Digest32, Blake2b256}
+import scorex.crypto.hash.{Blake2b256, Digest32}
 import sigmastate.SCollection.SByteArray
 import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate.interpreter.{Context, CryptoConstants, CryptoFunctions}
-import sigmastate.serialization.{ValueSerializer, OpCodes}
+import sigmastate.serialization.{ErgoTreeSerializer, OpCodes, ValueSerializer}
 import sigmastate.serialization.OpCodes._
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utils.Extensions._
@@ -46,7 +46,7 @@ object Values {
     /** Returns true if this value represent some constant or sigma statement, false otherwise */
     def evaluated: Boolean
 
-    lazy val bytes = ValueSerializer.serialize(this)
+    lazy val bytes = ErgoTreeSerializer.serialize(this)
 
     /** Every value represents an operation and that operation can be associated with a function type,
       * describing functional meaning of the operation, kind of operation signature.

--- a/src/main/scala/sigmastate/eval/IRContext.scala
+++ b/src/main/scala/sigmastate/eval/IRContext.scala
@@ -1,5 +1,7 @@
 package sigmastate.eval
 
+import java.lang.reflect.Method
+
 import sigmastate.SType
 import sigmastate.Values.SValue
 import sigmastate.interpreter.Interpreter.ScriptEnv
@@ -29,8 +31,16 @@ trait IRContext extends Evaluation with TreeBuilding {
 }
 
 /** IR context to be used by blockchain nodes to validate transactions. */
-class RuntimeIRContext extends IRContext
+class RuntimeIRContext extends IRContext {
+  override def invokeAll: Boolean = true
+  override def isInvokeEnabled(d: Def[_], m: Method): Boolean = invokeAll
+  override def shouldUnpack(e: Elem[_]): Boolean = true
+}
 
 /** IR context to be used by script development tools to compile ErgoScript into ErgoTree bytecode. */
-class CompiletimeIRContext extends IRContext
+class CompiletimeIRContext extends IRContext {
+  override def invokeAll: Boolean = true
+  override def isInvokeEnabled(d: Def[_], m: Method): Boolean = invokeAll
+  override def shouldUnpack(e: Elem[_]): Boolean = true
+}
 

--- a/src/main/scala/sigmastate/eval/IRContext.scala
+++ b/src/main/scala/sigmastate/eval/IRContext.scala
@@ -31,14 +31,14 @@ trait IRContext extends Evaluation with TreeBuilding {
 }
 
 /** IR context to be used by blockchain nodes to validate transactions. */
-class RuntimeIRContext extends IRContext {
+class RuntimeIRContext extends IRContext with CompiletimeCosting {
   override def invokeAll: Boolean = true
   override def isInvokeEnabled(d: Def[_], m: Method): Boolean = invokeAll
   override def shouldUnpack(e: Elem[_]): Boolean = true
 }
 
 /** IR context to be used by script development tools to compile ErgoScript into ErgoTree bytecode. */
-class CompiletimeIRContext extends IRContext {
+class CompiletimeIRContext extends IRContext with CompiletimeCosting {
   override def invokeAll: Boolean = true
   override def isInvokeEnabled(d: Def[_], m: Method): Boolean = invokeAll
   override def shouldUnpack(e: Elem[_]): Boolean = true

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -373,7 +373,7 @@ trait Interpreter extends ScorexLogging {
     val substTree = everywherebu(substRule)(exp) match {
       case Some(v: Value[SBoolean.type]@unchecked) if v.tpe == SBoolean => v
       case Some(p: SValue) if p.tpe == SSigmaProp => p.asSigmaProp.isValid
-      case x => throw new Error(s"Context-dependent pre-processing should produce tree of type Boolean of SigmaProp but was $x")
+      case x => throw new Error(s"Context-dependent pre-processing should produce tree of type Boolean or SigmaProp but was $x")
     }
     val costingRes @ IR.Pair(calcF, costF) = doCosting(env, substTree)
     IR.onCostingResult(env, substTree, costingRes)

--- a/src/main/scala/sigmastate/lang/SigmaCompiler.scala
+++ b/src/main/scala/sigmastate/lang/SigmaCompiler.scala
@@ -40,4 +40,5 @@ class SigmaCompiler(builder: SigmaBuilder) {
 }
 
 object SigmaCompiler {
+  def apply(builder: SigmaBuilder = TransformingSigmaBuilder): SigmaCompiler = new SigmaCompiler(builder)
 }

--- a/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
@@ -1,9 +1,11 @@
 package sigmastate.serialization
 
-import sigmastate.SType
-import sigmastate.Values.{Constant, ErgoTree, Value}
+import sigmastate.SCollection.SByteArray
+import sigmastate.Values.{ConcreteCollection, Constant, ErgoTree, Value}
 import sigmastate.lang.DeserializationSigmaBuilder
 import sigmastate.utils.SigmaByteReader
+import sigmastate.utxo.Append
+import sigmastate.{SGroupElement, SType}
 
 import scala.collection.mutable
 
@@ -84,5 +86,23 @@ object ErgoTreeSerializer {
     val tree = ValueSerializer.deserialize(r)
     tree
   }
+
+  def serializedPubkeyPropValue(pubkey: Value[SByteArray]): Value[SByteArray] =
+    Append(
+      Append(
+        ConcreteCollection(
+          0.toByte, // header
+          1.toByte, // const count
+          SGroupElement.typeCode // const type
+        ),
+        pubkey // const value
+      ),
+      ConcreteCollection(
+        OpCodes.ProveDlogCode,
+        OpCodes.ConstantPlaceholderIndexCode,
+        0.toByte // constant index in the store
+      )
+    )
+
 }
 

--- a/src/main/scala/sigmastate/utils/SigmaByteReader.scala
+++ b/src/main/scala/sigmastate/utils/SigmaByteReader.scala
@@ -7,8 +7,8 @@ import sigmastate.Values.SValue
 import sigmastate.serialization.{ConstantStore, TypeSerializer, ValDefTypeStore, ValueSerializer}
 
 class SigmaByteReader(b: ByteBuffer,
-                      val constantStore: ConstantStore,
-                      val resolvePlaceholdersToConstants: Boolean)
+                      var constantStore: ConstantStore,
+                      var resolvePlaceholdersToConstants: Boolean)
   extends ByteBufferReader(b) {
 
   val valDefTypeStore: ValDefTypeStore = new ValDefTypeStore()

--- a/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
+++ b/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
@@ -7,7 +7,7 @@ import org.scalatest.{Assertion, Matchers, PropSpec, TryValues}
 import scapi.sigma.DLogProtocol
 import scapi.sigma.DLogProtocol.DLogProverInput
 import sigmastate.Values
-import sigmastate.serialization.ValueSerializer
+import sigmastate.serialization.{ErgoTreeSerializer, ValueSerializer}
 import sigmastate.serialization.generators.ValueGenerators
 
 class ErgoAddressSpecification extends PropSpec
@@ -46,7 +46,7 @@ class ErgoAddressSpecification extends PropSpec
       val p2sh = Pay2SHAddress(s)
 
       //search we're doing to find a box potentially corresponding to some address
-      ValueSerializer.serialize(p2sh.script).containsSlice(p2sh.contentBytes) shouldBe true
+      ErgoTreeSerializer.serialize(p2sh.script).containsSlice(p2sh.contentBytes) shouldBe true
     }
   }
 
@@ -55,7 +55,7 @@ class ErgoAddressSpecification extends PropSpec
       val p2s = Pay2SAddress(s)
 
       //search we're doing to find a box potentially corresponding to some address
-      ValueSerializer.serialize(p2s.script).containsSlice(p2s.contentBytes) shouldBe true
+      ErgoTreeSerializer.serialize(p2s.script).containsSlice(p2s.contentBytes) shouldBe true
     }
   }
 

--- a/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -75,6 +75,13 @@ class EvaluationTest extends BaseCtxTests
        | }""".stripMargin, ctx, true)
   }
 
+  test("Measure IRContext creation speed") {
+    var ctx: RuntimeIRContext = null
+    measure(100) { i =>
+      ctx = new RuntimeIRContext
+    }
+    println(s"Def count: ${ctx.defCount}")
+  }
 //  test("Crowd Funding") {
 //    val backerProver = new ErgoLikeProvingInterpreter
 //    val projectProver = new ErgoLikeProvingInterpreter

--- a/src/test/scala/sigmastate/utxo/SpamSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SpamSpecification.scala
@@ -26,7 +26,7 @@ class SpamSpecification extends SigmaTestingCommons {
     (1 to 1000000).foreach(_ => hf(block))
 
     val t0 = System.currentTimeMillis()
-    (1 to 10000000).foreach(_ => hf(block))
+    (1 to 15000000).foreach(_ => hf(block))
     val t = System.currentTimeMillis()
     t - t0
   }

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -9,7 +9,7 @@ import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, SigmaTestingCommons}
 import sigmastate.interpreter.ContextExtension
 import sigmastate.interpreter.Interpreter.{ScriptEnv, ScriptNameProp, emptyEnv}
 import sigmastate.lang.Terms._
-import sigmastate.serialization.OpCodes
+import sigmastate.serialization.{ErgoTreeSerializer, OpCodes}
 import sigmastate.utxo.BlockchainSimulationSpecification.{Block, ValidationState}
 import sigmastate.utxo._
 import sigmastate.{SLong, _}
@@ -76,22 +76,9 @@ class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
     val correctCoinsConsumed = EQ(coinsToIssue, Minus(ExtractAmount(Self), ExtractAmount(rewardOut)))
     val lastCoins = LE(ExtractAmount(Self), s.oneEpochReduction)
     val outputsNum = EQ(SizeOf(Outputs), 2)
-    val correctMinerProposition = EQ(ExtractScriptBytes(minerOut),
-      Append(
-        Append(
-          ConcreteCollection(
-            0.toByte, // header
-            1.toByte, // const count
-            SGroupElement.typeCode // const type
-          ),
-          MinerPubkey // const value
-        ),
-        ConcreteCollection(
-          OpCodes.ProveDlogCode,
-          OpCodes.ConstantPlaceholderIndexCode,
-          0.toByte // constant index in the store
-        )
-      )
+    val correctMinerProposition = EQ(
+      ExtractScriptBytes(minerOut),
+      ErgoTreeSerializer.serializedPubkeyPropValue(MinerPubkey)
     )
 
     val prop = AND(

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -2,14 +2,15 @@ package sigmastate.utxo.examples
 
 import org.ergoplatform.{ErgoLikeContext, Height, _}
 import scorex.util.ScorexLogging
-import sigmastate.Values.{LongConstant, IntConstant, SValue}
+import sigmastate.Values.{IntConstant, LongConstant, SValue}
 import sigmastate.Values.{ConcreteCollection, IntConstant, LongConstant}
+import sigmastate.eval.RuntimeIRContext
 import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, SigmaTestingCommons}
 import sigmastate.interpreter.ContextExtension
-import sigmastate.interpreter.Interpreter.{ScriptNameProp, emptyEnv, ScriptEnv}
+import sigmastate.interpreter.Interpreter.{ScriptEnv, ScriptNameProp, emptyEnv}
 import sigmastate.lang.Terms._
 import sigmastate.serialization.OpCodes
-import sigmastate.utxo.BlockchainSimulationSpecification.{ValidationState, Block}
+import sigmastate.utxo.BlockchainSimulationSpecification.{Block, ValidationState}
 import sigmastate.utxo._
 import sigmastate.{SLong, _}
 
@@ -19,12 +20,8 @@ import sigmastate.{SLong, _}
   * that controls emission rules
   */
 class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
-  implicit lazy val IR = new TestingIRContext {
-    override val okPrintEvaluatedEntries: Boolean = false
-    // overrided to avoid outputing intermediate graphs in files (too many of them)
-    override def onCostingResult[T](env: ScriptEnv, tree: SValue, res: CostingResult[T]): Unit = {
-    }
-  }
+  // don't use TestingIRContext, this suite also serves the purpose of testing the RuntimeIRContext
+  implicit lazy val IR = new RuntimeIRContext
 
   private val reg1 = ErgoBox.nonMandatoryRegisters.head
 

--- a/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
@@ -99,7 +99,7 @@ class OracleExamplesSpecification extends SigmaTestingCommons {
 
     val oracleBox = ErgoBox(
       value = 1L,
-      proposition = oraclePubKey,
+      ergoTree = oraclePubKey,
       creationHeight = 0,
       additionalRegisters = Map(
         reg1 -> LongConstant(temperature),
@@ -214,7 +214,7 @@ class OracleExamplesSpecification extends SigmaTestingCommons {
 
     val oracleBox = ErgoBox(
       value = 1L,
-      proposition = oraclePubKey,
+      ergoTree = oraclePubKey,
       creationHeight = 0,
       additionalRegisters = Map(reg1 -> LongConstant(temperature))
     )


### PR DESCRIPTION
- [x] enable invocation in public facing IR contexts to fix `scalan.Base$StagingException: Cannot resolve companion instance for TableEntrySingle(s81,IntPlusMonoidCtor(s80),None)`
- [x] mix in CompiletimeCosting into RuntimeIRContext to fix `Don't know how to evalNode(ProveDlog...`
- [x] use `ErgoTreeSerializer` in box, addresses, etc. (for ergo);