### PR TITLE
Switch the rest of the tests to the compileWithCosting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,12 +57,12 @@ version in ThisBuild := {
 
 git.gitUncommittedChanges in ThisBuild := true
 
-val specialVersion = "master-98f4f086-SNAPSHOT"
+val specialVersion = "master-014a4749-SNAPSHOT"
 val specialCommon = "io.github.scalan" %% "common" % specialVersion
 val specialCore = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion
 
-val specialSigmaVersion = "master-c916619f-SNAPSHOT"
+val specialSigmaVersion = "master-a2f5a270-SNAPSHOT"
 val sigmaImpl = "io.github.scalan" %% "sigma-impl" % specialSigmaVersion
 val sigmaLibrary = "io.github.scalan" %% "sigma-library" % specialSigmaVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,12 +57,12 @@ version in ThisBuild := {
 
 git.gitUncommittedChanges in ThisBuild := true
 
-val specialVersion = "master-014a4749-SNAPSHOT"
+val specialVersion = "master-98f4f086-SNAPSHOT"
 val specialCommon = "io.github.scalan" %% "common" % specialVersion
 val specialCore = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion
 
-val specialSigmaVersion = "master-708072b5-SNAPSHOT"
+val specialSigmaVersion = "master-c916619f-SNAPSHOT"
 val sigmaImpl = "io.github.scalan" %% "sigma-impl" % specialSigmaVersion
 val sigmaLibrary = "io.github.scalan" %% "sigma-library" % specialSigmaVersion
 

--- a/lock.sbt
+++ b/lock.sbt
@@ -17,16 +17,16 @@ dependencyOverrides in ThisBuild ++= Seq(
   "com.typesafe.akka" % "akka-actor_2.12" % "2.4.20",
   "com.typesafe.scala-logging" % "scala-logging_2.12" % "3.9.0",
   "commons-io" % "commons-io" % "2.5",
-  "io.github.scalan" % "common_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "core_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "library-api_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "library-impl_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "library_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "macros_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "meta_2.12" % "master-98f4f086-SNAPSHOT",
-  "io.github.scalan" % "sigma-api_2.12" % "master-708072b5-SNAPSHOT",
-  "io.github.scalan" % "sigma-impl_2.12" % "master-708072b5-SNAPSHOT",
-  "io.github.scalan" % "sigma-library_2.12" % "master-708072b5-SNAPSHOT",
+  "io.github.scalan" % "common_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "core_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "library-api_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "library-impl_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "library_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "macros_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "meta_2.12" % "master-014a4749-SNAPSHOT",
+  "io.github.scalan" % "sigma-api_2.12" % "master-a2f5a270-SNAPSHOT",
+  "io.github.scalan" % "sigma-impl_2.12" % "master-a2f5a270-SNAPSHOT",
+  "io.github.scalan" % "sigma-library_2.12" % "master-a2f5a270-SNAPSHOT",
   "javax.activation" % "activation" % "1.1",
   "jline" % "jline" % "2.14.3",
   "org.apache.ant" % "ant" % "1.9.6",
@@ -47,4 +47,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.5.0"
 )
-// LIBRARY_DEPENDENCIES_HASH b522061cccc49b5850b42ab8588ba33a642953fe
+// LIBRARY_DEPENDENCIES_HASH 7f59af55a1891d1328d199766a7510ddf154fd00

--- a/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -134,7 +134,7 @@ object ErgoLikeContext {
     IR.sigmaDslBuilderValue.Cols.fromArray(res)
   }
 
-  implicit class ErgoBoxOps(ebox: ErgoBox) {
+  implicit class ErgoBoxOps(val ebox: ErgoBox) extends AnyVal {
     def toTestBox(isCost: Boolean)(implicit IR: Evaluation): Box = {
       if (ebox == null) return null
       val givenRegs = ebox.additionalRegisters ++ ErgoBox.mandatoryRegisters.map(id => (id, ebox.get(id).get))

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -647,7 +647,7 @@ object Values {
     lazy val tpe: SFunc = SFunc(args.map(_._2), body.tpe)
     val opCode: OpCode = FuncValueCode
     /** This is not used as operation, but rather to form a program structure */
-    def opType: SFunc = Value.notSupportedError(this, "opType")
+    override def opType: SFunc = SFunc(Vector(), tpe)
   }
   object FuncValue {
     def apply(argId: Int, tArg: SType, body: SValue): FuncValue =

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -275,7 +275,7 @@ object Values {
     }
   }
 
-  implicit class AvlTreeConstantOps(c: AvlTreeConstant) {
+  implicit class AvlTreeConstantOps(val c: AvlTreeConstant) extends AnyVal {
     def createVerifier(proof: SerializedAdProof) =
       new BatchAVLVerifier[Digest32, Blake2b256.type](
         c.value.startingDigest,
@@ -358,7 +358,7 @@ object Values {
     }
   }
 
-  implicit class CollectionConstantOps[T <: SType](c: CollectionConstant[T]) {
+  implicit class CollectionConstantOps[T <: SType](val c: CollectionConstant[T]) extends AnyVal {
     def toConcreteCollection: ConcreteCollection[T] = {
       val tElem = c.tpe.elemType
       val items = c.value.map(v => tElem.mkConstant(v.asInstanceOf[tElem.WrappedType]))
@@ -555,7 +555,7 @@ object Values {
 
   trait LazyCollection[V <: SType] extends NotReadyValue[SCollection[V]]
 
-  implicit class CollectionOps[T <: SType](coll: Value[SCollection[T]]) {
+  implicit class CollectionOps[T <: SType](val coll: Value[SCollection[T]]) extends AnyVal {
     def length: Int = matchCase(_.items.length, _.value.length, _.items.length)
     def items = matchCase(_.items, _ => sys.error(s"Cannot get 'items' property of node $coll"), _.items)
 //    def isEvaluatedCollection =
@@ -578,17 +578,17 @@ object Values {
       )
   }
 
-  implicit class SigmaPropValueOps(p: Value[SSigmaProp.type]) {
+  implicit class SigmaPropValueOps(val p: Value[SSigmaProp.type]) extends AnyVal {
     def isProven: Value[SBoolean.type] = SigmaPropIsProven(p)
     def propBytes: Value[SByteArray] = SigmaPropBytes(p)
   }
 
-  implicit class SigmaBooleanOps(sb: SigmaBoolean) {
+  implicit class SigmaBooleanOps(val sb: SigmaBoolean) extends AnyVal {
     def isProven: Value[SBoolean.type] = SigmaPropIsProven(SigmaPropConstant(sb))
     def propBytes: Value[SByteArray] = SigmaPropBytes(SigmaPropConstant(sb))
   }
 
-  implicit class BoolValueOps(b: BoolValue) {
+  implicit class BoolValueOps(val b: BoolValue) extends AnyVal {
     def toSigmaProp: SigmaPropValue = BoolToSigmaProp(b)
   }
 
@@ -658,7 +658,7 @@ object Values {
       FuncValue(IndexedSeq((argId,tArg)), body)
   }
 
-  implicit class OptionValueOps[T <: SType](p: Value[SOption[T]]) {
+  implicit class OptionValueOps[T <: SType](val p: Value[SOption[T]]) extends AnyVal {
     def get: Value[T] = OptionGet(p)
     def getOrElse(default: Value[T]): Value[T] = OptionGetOrElse(p, default)
     def isDefined: Value[SBoolean.type] = OptionIsDefined(p)

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -588,6 +588,10 @@ object Values {
     def propBytes: Value[SByteArray] = SigmaPropBytes(SigmaPropConstant(sb))
   }
 
+  implicit class BoolValueOps(b: BoolValue) {
+    def toSigmaProp: SigmaPropValue = BoolToSigmaProp(b)
+  }
+
   sealed trait BlockItem extends NotReadyValue[SType] {
     def id: Int
     def rhs: SValue

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -142,8 +142,8 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
       case Terms.Apply(Select(col, ForallMethod.name, _), Seq(l)) if l.tpe.isFunc =>
         eval(mkForAll(col.asValue[SCollection[SType]], l.asFunc))
 
-      case Terms.Apply(Select(col, MapMethod.name, _), Seq(l @ Terms.Lambda(_, _, _, _))) =>
-        eval(mkMapCollection(col.asValue[SCollection[SType]], l))
+      case Terms.Apply(Select(col, MapMethod.name, _), Seq(l)) if l.tpe.isFunc =>
+        eval(mkMapCollection(col.asValue[SCollection[SType]], l.asFunc))
 
       case Terms.Apply(Select(col, FoldMethod.name, _), Seq(zero, l @ Terms.Lambda(_, _, _, _))) =>
         eval(mkFold(col.asValue[SCollection[SType]], zero, l))

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -6,7 +6,7 @@ import scala.language.{existentials, implicitConversions}
 import scapi.sigma.{ProveDHTuple, DLogProtocol}
 import sigmastate.SCollection.SByteArray
 import sigmastate._
-import sigmastate.Values.{Constant, SigmaPropConstant, Value, NotReadyValue, SigmaBoolean}
+import sigmastate.Values.{Constant, NotReadyValue, SValue, SigmaBoolean, SigmaPropConstant, Value}
 import sigmastate.lang.Terms.{Apply, _}
 import sigmastate.lang.SigmaPredef._
 import sigmastate.utxo._
@@ -35,6 +35,10 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
       // Rule: anyOf(arr) --> OR(arr)
       case Terms.Apply(AnySym, Seq(arr: Value[SCollection[SBoolean.type]]@unchecked)) =>
         eval(mkOR(arr))
+
+      // Rule: atLeast(bound, arr) --> AtLeast(bound, arr)
+      case Terms.Apply(AtLeastSym, Seq(bound: SValue, arr: Value[SCollection[SSigmaProp.type]]@unchecked)) =>
+        eval(mkAtLeast(bound.asIntValue, arr))
 
       case Terms.Apply(Blake2b256Sym, Seq(arg: Value[SByteArray]@unchecked)) =>
         eval(mkCalcBlake2b256(arg))

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -57,6 +57,14 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
       case Terms.Apply(SigmaPropSym, Seq(bool: Value[SBoolean.type]@unchecked)) =>
         eval(mkBoolToSigmaProp(bool))
 
+      case Terms.Apply(ProveDHTupleSym, Seq(g, h, u, v)) =>
+        eval(SigmaPropConstant(
+          mkProveDiffieHellmanTuple(
+            g.asGroupElement,
+            h.asGroupElement,
+            u.asGroupElement,
+            v.asGroupElement)))
+
       case sigmastate.Upcast(Constant(value, _), toTpe: SNumericType) =>
         eval(mkConstant(toTpe.upcast(value.asInstanceOf[AnyVal]), toTpe))
 

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -69,6 +69,12 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
             u.asGroupElement,
             v.asGroupElement)))
 
+      case Terms.Apply(TreeModificationsSym, Seq(tree: Value[SAvlTree.type]@unchecked, operations: Value[SByteArray]@unchecked, proof: Value[SByteArray]@unchecked)) =>
+        eval(mkTreeModifications(tree, operations, proof))
+
+      case Terms.Apply(TreeLookupSym, Seq(tree: Value[SAvlTree.type]@unchecked, key: Value[SByteArray]@unchecked, proof: Value[SByteArray]@unchecked)) =>
+        eval(mkTreeLookup(tree, key, proof))
+
       case sigmastate.Upcast(Constant(value, _), toTpe: SNumericType) =>
         eval(mkConstant(toTpe.upcast(value.asInstanceOf[AnyVal]), toTpe))
 

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -952,7 +952,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
           case _: BoxElem[_] => element[CostedBox].asElem[Costed[Any]]
           case _ => costedElement(eAny)
         }
-        val condC = evalNode(ctx, env, node.condition).asRep[CostedFunc[Unit, Any, SType#WrappedType]].func
+        val condC = asRep[CostedFunc[Unit, Any, SType#WrappedType]](evalNode(ctx, env, node.condition)).func
         val (calcF, costF) = splitCostedFunc2(condC, okRemoveIsValid = true)
         val values = xs.values.map(calcF)
         val cost = xs.values.zip(xs.costs.zip(xs.sizes)).map(costF).sum(intPlusMonoid)
@@ -972,10 +972,10 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
 
       case MapCollection(input, sfunc) =>
         val eIn = stypeToElem(input.tpe.elemType)
-        val inputC = evalNode(ctx, env, input).asRep[CostedCol[Any]]
+        val inputC = asRep[CostedCol[Any]](evalNode(ctx, env, input))
         implicit val eAny = inputC.elem.asInstanceOf[CostedElem[Col[Any], _]].eVal.eA
         assert(eIn == eAny, s"Types should be equal: but $eIn != $eAny")
-        val mapperC = evalNode(ctx, env, sfunc).asRep[CostedFunc[Unit, Any, SType#WrappedType]].func
+        val mapperC = asRep[CostedFunc[Unit, Any, SType#WrappedType]](evalNode(ctx, env, sfunc)).func
         val res = inputC.mapCosted(mapperC)
         res
 
@@ -1045,8 +1045,8 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
 
 
       case Terms.Apply(f, Seq(x)) if f.tpe.isFunc =>
-        val fC = evalNode(ctx, env, f).asRep[CostedFunc[Unit, Any, Any]]
-        val xC = evalNode(ctx, env, x).asRep[Costed[Any]]
+        val fC = asRep[CostedFunc[Unit, Any, Any]](evalNode(ctx, env, f))
+        val xC = asRep[Costed[Any]](evalNode(ctx, env, x))
         if (f.tpe.asFunc.tRange.isCollection) {
           ???
         }
@@ -1255,8 +1255,8 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         import OpCodes._
         op.opCode match {
           case GtCode =>
-            val x = evalNode(ctx, env, op.left).asRep[Costed[WBigInteger]]
-            val y = evalNode(ctx, env, op.right).asRep[Costed[WBigInteger]]
+            val x = asRep[Costed[WBigInteger]](evalNode(ctx, env, op.left))
+            val y = asRep[Costed[WBigInteger]](evalNode(ctx, env, op.right))
             val resSize = x.dataSize.min(y.dataSize)
             val cost = x.cost + y.cost + costOf(op) + costOf(">_per_item", op.opType) * resSize.toInt
             RCCostedPrim(x.value.compareTo(y.value) > 0, cost, resSize)

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1037,18 +1037,6 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         val res = inputC.filterCosted(condC)
         res
 
-//      case Terms.Apply(Select(col,"map", _), Seq(Terms.Lambda(_, Seq((n, t)), _, Some(mapper)))) =>
-//        val input = col.asValue[SCollection[SType]]
-//        val eIn = stypeToElem(input.tpe.elemType)
-//        val inputC = evalNode(ctx, env, input).asRep[CostedCol[Any]]
-//        implicit val eAny = inputC.elem.asInstanceOf[CostedElem[Col[Any],_]].eVal.eA
-//        assert(eIn == eAny, s"Types should be equal: but $eIn != $eAny")
-//        val mapperC = fun { x: Rep[Costed[Any]] =>
-//          evalNode(ctx, env + (n -> x), mapper)
-//        }
-//        val res = inputC.mapCosted(mapperC)
-//        res
-
 //      case Terms.Apply(Select(col,"fold", _), Seq(zero, Terms.Lambda(Seq((zeroArg, tZero), (opArg, tOp)), _, Some(body)))) =>
 //        val taggedZero = mkTaggedVariable(21, tZero)
 //        val taggedOp = mkTaggedVariable(22, tOp)

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1173,11 +1173,9 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         val boxC = asRep[Costed[Box]](box)
         val bytes = boxC.value.bytes
         mkCostedCol(bytes, ErgoBox.MaxBoxSize, boxC.cost + costOf(node))
-
       case utxo.ExtractCreationInfo(In(box)) =>
         val boxC = asRep[CostedBox](box)
         boxC.creationInfo
-
       case utxo.ExtractRegisterAs(In(box), regId, optTpe) =>
         val boxC = asRep[CostedBox](box)
         implicit val elem = stypeToElem(optTpe.elemType).asElem[Any]

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -814,9 +814,6 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         case box: ErgoBox =>
           val boxV = liftConst(box.toTestBox(false)(IR))
           RCCostedBox(boxV, costOf(c))
-        case box: special.sigma.Box =>
-          val boxV = liftConst(box)
-          RCCostedBox(boxV, costOf(c))
         case treeData: AvlTreeData =>
           val tree: special.sigma.AvlTree = CostingAvlTree(IR, treeData)
           val treeV = liftConst(tree)

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -814,6 +814,9 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         case box: ErgoBox =>
           val boxV = liftConst(box.toTestBox(false)(IR))
           RCCostedBox(boxV, costOf(c))
+        case box: special.sigma.Box =>
+          val boxV = liftConst(box)
+          RCCostedBox(boxV, costOf(c))
         case treeData: AvlTreeData =>
           val tree: special.sigma.AvlTree = CostingAvlTree(IR, treeData)
           val treeV = liftConst(tree)

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -64,6 +64,8 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
       case _: NumericTimes[_]   => Some(MultiplyCode)
       case _: IntegralDivide[_] => Some(DivisionCode)
       case _: IntegralMod[_]    => Some(ModuloCode)
+      case _: OrderingMin[_]    => Some(MinCode)
+      case _: OrderingMax[_]    => Some(MaxCode)
       case _ => None
     }
   }
@@ -186,6 +188,10 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         mkArith(x.asNumValue, y.asNumValue, DivisionCode)
       case BIM.mod(In(x), In(y)) =>
         mkArith(x.asNumValue, y.asNumValue, ModuloCode)
+      case BIM.min(In(x), In(y)) =>
+        mkArith(x.asNumValue, y.asNumValue, MinCode)
+      case BIM.max(In(x), In(y)) =>
+        mkArith(x.asNumValue, y.asNumValue, MaxCode)
       case Def(ApplyBinOp(IsArithOp(opCode), xSym, ySym)) =>
         val Seq(x, y) = Seq(xSym, ySym).map(recurse)
         mkArith(x.asNumValue, y.asNumValue, opCode)

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -42,7 +42,7 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
   import WArray._
   import WOption._
   import WECPoint._
-  
+
   private val ContextM = ContextMethods
   private val SigmaM = SigmaPropMethods
   private val ColM = ColMethods
@@ -166,6 +166,8 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         val elemTpe = elemToSType(elemT)
         val col = colSyms.map(recurse(_).asValue[elemTpe.type])
         mkConcreteCollection[elemTpe.type](col.toIndexedSeq, elemTpe)
+      case CBM.xor(_, colSym1, colSym2) =>
+        mkXor(recurse(colSym1), recurse(colSym2))
 
       case Def(wc: LiftedConst[a,_]) =>
         val tpe = elemToSType(s.elem)

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -236,6 +236,10 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         mkExtractCreationInfo(box.asBox)
       case BoxM.id(In(box)) =>
         mkExtractId(box.asBox)
+      case BoxM.bytes(In(box)) =>
+        mkExtractBytes(box.asBox)
+      case BoxM.bytesWithoutRef(In(box)) =>
+        mkExtractBytesWithNoRef(box.asBox)
 
       case OM.get(In(optionSym)) =>
         mkOptionGet(optionSym.asValue[SOption[SType]])

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -259,6 +259,8 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         mkAND(recurse(items))
       case Def(SDBM.anyOf(_,  items)) =>
         mkOR(recurse(items))
+      case Def(SDBM.atLeast(_, bound, items)) =>
+        mkAtLeast(recurse(bound), recurse(items))
 
       case SigmaM.and_bool_&&(In(prop), In(cond)) =>
         SigmaAnd(Seq(prop.asSigmaProp, mkBoolToSigmaProp(cond.asBoolValue)))
@@ -288,6 +290,9 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
 
       case SDBM.byteArrayToBigInt(_, colSym) =>
         mkByteArrayToBigInt(recurse(colSym))
+
+      case SDBM.blake2b256(_, colSym) =>
+        mkCalcBlake2b256(recurse(colSym))
 
       case Def(IfThenElseLazy(condSym, thenPSym, elsePSym)) =>
         val Seq(cond, thenP, elseP) = Seq(condSym, thenPSym, elsePSym).map(recurse)

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -289,12 +289,16 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
 
       case SDBM.sigmaProp(_, In(cond)) =>
         mkBoolToSigmaProp(cond.asBoolValue)
-
       case SDBM.byteArrayToBigInt(_, colSym) =>
         mkByteArrayToBigInt(recurse(colSym))
-
       case SDBM.blake2b256(_, colSym) =>
         mkCalcBlake2b256(recurse(colSym))
+      case SDBM.treeModifications(_, treeSym, opsColSym, proofColSym) =>
+        mkTreeModifications(recurse(treeSym), recurse(opsColSym), recurse(proofColSym))
+      case SDBM.treeLookup(_, treeSym, keySym, proofColSym) =>
+        mkTreeLookup(recurse(treeSym), recurse(keySym), recurse(proofColSym))
+      case SDBM.longToByteArray(_, longSym) =>
+        mkLongToByteArray(recurse(longSym))
 
       case Def(IfThenElseLazy(condSym, thenPSym, elsePSym)) =>
         val Seq(cond, thenP, elseP) = Seq(condSym, thenPSym, elsePSym).map(recurse)

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -44,7 +44,7 @@ trait SigmaBuilder {
 
   def mkBinOr(left: BoolValue, right: BoolValue): BoolValue
   def mkBinAnd(left: BoolValue, right: BoolValue): BoolValue
-  def mkAtLeast(bound: Value[SInt.type], input: Value[SCollection[SBoolean.type]]): Value[SBoolean.type]
+  def mkAtLeast(bound: Value[SInt.type], input: Value[SCollection[SSigmaProp.type]]): SigmaPropValue
 
   def mkExponentiate(left: Value[SGroupElement.type],
                      right: Value[SBigInt.type]): Value[SGroupElement.type]
@@ -276,7 +276,7 @@ class StdSigmaBuilder extends SigmaBuilder {
 
   override def mkBinAnd(left: BoolValue, right: BoolValue) = BinAnd(left, right)
 
-  override def mkAtLeast(bound: Value[SInt.type], input: Value[SCollection[SBoolean.type]]): Value[SBoolean.type] =
+  override def mkAtLeast(bound: Value[SInt.type], input: Value[SCollection[SSigmaProp.type]]): SigmaPropValue =
     AtLeast(bound, input)
 
   override def mkExponentiate(left: Value[SGroupElement.type], right: Value[SBigInt.type]): Value[SGroupElement.type] =

--- a/src/main/scala/sigmastate/lang/SigmaPredef.scala
+++ b/src/main/scala/sigmastate/lang/SigmaPredef.scala
@@ -24,7 +24,7 @@ object SigmaPredef {
   val predefinedEnv: Map[String, SValue] = Seq(
     "allOf" -> mkLambda(Vector("conditions" -> SCollection(SBoolean)), SBoolean, None),
     "anyOf" -> mkLambda(Vector("conditions" -> SCollection(SBoolean)), SBoolean, None),
-    "atLeast" -> mkLambda(Vector("k" -> SInt, "conditions" -> SCollection(SBoolean)), SBoolean, None),
+    "atLeast" -> mkLambda(Vector("k" -> SInt, "conditions" -> SCollection(SSigmaProp)), SSigmaProp, None),
     "ZKProof" -> mkLambda(Vector("block" -> SSigmaProp), SBoolean, None),
     "sigmaProp" -> mkLambda(Vector("condition" -> SBoolean), SSigmaProp, None),
 

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -48,7 +48,7 @@ class SigmaSpecializer(val builder: SigmaBuilder, val networkPrefix: NetworkPref
       Some(mkOR(arr))
 
     // Rule: atLeast(bound, arr) --> AtLeast(bound, arr)
-    case Apply(AtLeastSym, Seq(bound: SValue, arr: Value[SCollection[SBoolean.type]]@unchecked)) =>
+    case Apply(AtLeastSym, Seq(bound: SValue, arr: Value[SCollection[SSigmaProp.type]]@unchecked)) =>
       Some(mkAtLeast(bound.asIntValue, arr))
 
     // Rule: ZKProof(block) --> ZKProofBlock(block)

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -125,9 +125,6 @@ class SigmaTyper(val builder: SigmaBuilder) {
           val newArgs = new_f match {
             case AllSym | AnySym =>
               adaptSigmaPropToBoolean(new_args, argTypes)
-            case AtLeastSym =>
-              // In new_args the first item is `bound`, the second - collection of logical values
-              new_args.head +: adaptSigmaPropToBoolean(new_args.tail, argTypes.tail)
             case _ => new_args
           }
           val actualTypes = newArgs.map(_.tpe)
@@ -213,9 +210,8 @@ class SigmaTyper(val builder: SigmaBuilder) {
               val res = if (m == "||") mkBinOr(a,b) else mkBinAnd(a,b)
               res
             case SSigmaProp =>
-              val a = Select(newObj, SSigmaProp.IsProven, Some(SBoolean)).asBoolValue
-              val b = Select(r, SSigmaProp.IsProven, Some(SBoolean)).asBoolValue
-              val res = if (m == "||") mkBinOr(a,b) else mkBinAnd(a,b)
+              val (a,b) = (newObj.asSigmaProp, r.asSigmaProp)
+              val res = if (m == "||") mkSigmaOr(Seq(a,b)) else mkSigmaAnd(Seq(a,b))
               res
             case _ =>
               error(s"Invalid argument type for $m, expected $SSigmaProp but was ${r.tpe}")

--- a/src/main/scala/sigmastate/serialization/transformers/AtLeastSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/transformers/AtLeastSerializer.scala
@@ -1,14 +1,13 @@
 package sigmastate.serialization.transformers
 
-import sigmastate.Values.Value
+import sigmastate.Values.{SigmaPropValue, Value}
+import sigmastate._
 import sigmastate.lang.Terms._
 import sigmastate.serialization.OpCodes.OpCode
-import sigmastate.serialization.{ValueSerializer, OpCodes}
-import sigmastate.utils.Extensions._
-import sigmastate.utils.{SigmaByteWriter, SigmaByteReader}
-import sigmastate._
+import sigmastate.serialization.{OpCodes, ValueSerializer}
+import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 
-case class AtLeastSerializer(cons: (Value[SInt.type], Value[SCollection[SBoolean.type]]) => Value[SBoolean.type])
+case class AtLeastSerializer(cons: (Value[SInt.type], Value[SCollection[SSigmaProp.type]]) => SigmaPropValue)
   extends ValueSerializer[AtLeast] {
 
   override val opCode: OpCode = OpCodes.AtLeastCode
@@ -17,9 +16,9 @@ case class AtLeastSerializer(cons: (Value[SInt.type], Value[SCollection[SBoolean
     w.putValue(obj.bound)
       .putValue(obj.input)
 
-  override def parseBody(r: SigmaByteReader): Value[SBoolean.type] = {
+  override def parseBody(r: SigmaByteReader): SigmaPropValue = {
     val bound = r.getValue().asIntValue
-    val input = r.getValue().asCollection[SBoolean.type]
+    val input = r.getValue().asCollection[SSigmaProp.type]
     cons(bound, input)
   }
 }

--- a/src/main/scala/sigmastate/trees.scala
+++ b/src/main/scala/sigmastate/trees.scala
@@ -164,18 +164,20 @@ object AND {
   * Logical threshold.
   * AtLeast has two inputs: integer bound and children same as in AND/OR. The result is true if at least bound children are true.
   */
-case class AtLeast(bound: Value[SInt.type], input: Value[SCollection[SBoolean.type]])
-  extends Transformer[SCollection[SBoolean.type], SBoolean.type]
-    with NotReadyValueBoolean {
+case class AtLeast(bound: Value[SInt.type], input: Value[SCollection[SSigmaProp.type]])
+  extends Transformer[SCollection[SSigmaProp.type], SSigmaProp.type]
+    with NotReadyValue[SSigmaProp.type] {
+  override def tpe: SSigmaProp.type = SSigmaProp
   override val opCode: OpCode = AtLeastCode
   override def opType: SFunc = SFunc(IndexedSeq(SInt, SCollection.SBooleanArray), SBoolean)
+
 }
 
 object AtLeast {
-  def apply(bound: Value[SInt.type], children: Seq[Value[SBoolean.type]]): AtLeast =
+  def apply(bound: Value[SInt.type], children: Seq[SigmaPropValue]): AtLeast =
     AtLeast(bound, ConcreteCollection(children.toIndexedSeq))
 
-  def apply(bound: Value[SInt.type], head: Value[SBoolean.type], tail: Value[SBoolean.type]*): AtLeast = apply(bound, head +: tail)
+  def apply(bound: Value[SInt.type], head: SigmaPropValue, tail: SigmaPropValue*): AtLeast = apply(bound, head +: tail)
 
   def reduce(bound: Int, children: Seq[SigmaBoolean]): SigmaBoolean = {
     import sigmastate.TrivialProp._

--- a/src/main/scala/sigmastate/trees.scala
+++ b/src/main/scala/sigmastate/trees.scala
@@ -109,6 +109,10 @@ case class SigmaAnd(items: Seq[SigmaPropValue]) extends SigmaTransformer[SigmaPr
   val opType = SFunc(SCollection.SSigmaPropArray, SSigmaProp)
 }
 
+object SigmaAnd {
+  def apply(head: SigmaPropValue, tail: SigmaPropValue*): SigmaAnd = SigmaAnd(head +: tail)
+}
+
 /**
   * OR disjunction for sigma propositions
   */

--- a/src/main/scala/sigmastate/trees.scala
+++ b/src/main/scala/sigmastate/trees.scala
@@ -122,6 +122,11 @@ case class SigmaOr(items: Seq[SigmaPropValue]) extends SigmaTransformer[SigmaPro
   val opType = SFunc(SCollection.SSigmaPropArray, SSigmaProp)
 }
 
+object SigmaOr {
+  def apply(head: SigmaPropValue, tail: SigmaPropValue*): SigmaOr = SigmaOr(head +: tail)
+}
+
+
 /**
   * OR logical conjunction
   */

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -100,7 +100,7 @@ object SType {
     SAvlTree, SBox
   ).map { t => (t.typeId, t) }.toMap
 
-  implicit class STypeOps(val tpe: SType) {
+  implicit class STypeOps(val tpe: SType) extends AnyVal {
     def isCollectionLike: Boolean = tpe.isInstanceOf[SCollection[_]]
     def isCollection: Boolean = tpe.isInstanceOf[SCollectionType[_]]
     def isSigmaProp: Boolean = tpe.isInstanceOf[SSigmaProp.type]
@@ -143,7 +143,7 @@ object SType {
     }).asInstanceOf[ClassTag[T]]
   }
 
-  implicit class AnyOps(x: Any) {
+  implicit class AnyOps(val x: Any) extends AnyVal {
     def asWrappedType: SType#WrappedType = x.asInstanceOf[SType#WrappedType]
   }
 

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -269,7 +269,7 @@ trait SNumericType extends SProduct {
   import SNumericType._
   override def ancestors: Seq[SType] = Nil
   def methods = SNumericType.methods
-  def isCastMethod (name: String): Boolean = Seq(ToByte, ToShort, ToInt, ToLong, ToBigInt).contains(name)
+  def isCastMethod (name: String): Boolean = castMethods.contains(name)
 
   def upcast(i: AnyVal): WrappedType
   def downcast(i: AnyVal): WrappedType
@@ -296,6 +296,7 @@ object SNumericType extends STypeCompanion {
     SMethod(this, ToLong, SLong, 4),    // see Downcast
     SMethod(this, ToBigInt, SBigInt, 5) // see Downcast
   )
+  val castMethods: Array[String] = Array(ToByte, ToShort, ToInt, ToLong, ToBigInt)
 }
 
 trait SLogical extends SType {

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -469,6 +469,7 @@ case object SSigmaProp extends SProduct with SPrimType with SEmbeddable with SLo
           GroupElementConstant(gv), GroupElementConstant(hv),
           GroupElementConstant(uv), GroupElementConstant(vv)) =>
       SGroupElement.dataSize(gv.asWrappedType) * 4 + 1
+    case CAND(inputs) => inputs.map(i => dataSize(i.asWrappedType)).sum
     case _ => ???
   }
   override def isConstantSize = false

--- a/src/main/scala/sigmastate/utils/Extensions.scala
+++ b/src/main/scala/sigmastate/utils/Extensions.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 
 object Extensions {
 
-  implicit class ByteOps(b: Byte) {
+  implicit class ByteOps(val b: Byte) extends AnyVal {
     @inline def toUByte: Int = b & 0xFF
     def addExact(b2: Byte): Byte = {
       val r = b + b2
@@ -36,7 +36,7 @@ object Extensions {
     }
   }
 
-  implicit class ShortOps(x: Short) {
+  implicit class ShortOps(val x: Short) extends AnyVal {
     def toByteExact: Byte = {
       if (x < Byte.MinValue || x > Byte.MaxValue)
         throw new ArithmeticException("Byte overflow")
@@ -65,7 +65,7 @@ object Extensions {
     }
   }
 
-  implicit class IntOps(x: Int) {
+  implicit class IntOps(val x: Int) extends AnyVal {
     def toByteExact: Byte = {
       if (x < Byte.MinValue || x > Byte.MaxValue)
         throw new ArithmeticException("Byte overflow")
@@ -79,7 +79,7 @@ object Extensions {
     }
   }
 
-  implicit class LongOps(x: Long) {
+  implicit class LongOps(val x: Long) extends AnyVal {
     def toByteExact: Byte = {
       if (x < Byte.MinValue || x > Byte.MaxValue)
         throw new ArithmeticException("Byte overflow")
@@ -99,12 +99,12 @@ object Extensions {
     }
   }
 
-  implicit class OptionOps[T](opt: Option[T]) {
+  implicit class OptionOps[T](val opt: Option[T]) extends AnyVal {
     /** Elvis operator for Option. See https://en.wikipedia.org/wiki/Elvis_operator*/
     def ?:(whenNone: => T): T = if (opt.isDefined) opt.get else whenNone
   }
 
-  implicit class TraversableOps[A, Source[X] <: Traversable[X]](xs: Source[A]) {
+  implicit class TraversableOps[A, Source[X] <: Traversable[X]](val xs: Source[A]) extends AnyVal {
 
     /** Applies 'f' to elements of 'xs' until 'f' returns Some(b),
       * which is immediately returned as result of this method.
@@ -137,7 +137,7 @@ object Extensions {
     }
   }
 
-  implicit class ByteArrayBuilderOps(b: ByteArrayBuilder) {
+  implicit class ByteArrayBuilderOps(val b: ByteArrayBuilder) extends AnyVal {
     def appendOption[T](opt: Option[T])(putValue: T => Unit): ByteArrayBuilder = {
       opt match {
         case Some(v) =>
@@ -150,7 +150,7 @@ object Extensions {
     }
   }
 
-  implicit class ByteBufferOps(buf: ByteBuffer) {
+  implicit class ByteBufferOps(val buf: ByteBuffer) extends AnyVal {
     def toBytes: Array[Byte] = {
       val res = new Array[Byte](buf.position())
       buf.array().copyToArray(res, 0, res.length)

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -126,39 +126,37 @@ class TestingInterpreterSpecification extends SigmaTestingCommons {
   }
 
   property("Evaluate array ops") {
-//    testEval("""{
-//              |  val arr = Array(1, 2) ++ Array(3, 4)
-//              |  arr.size == 4
-//              |}""".stripMargin)
-//    testEval("""{
-//              |  val arr = Array(1, 2, 3)
-//              |  arr.slice(1, 3) == Array(2, 3)
-//              |}""".stripMargin)
-//    testEval("""{
-//              |  val arr = bytes1 ++ bytes2
-//              |  arr.size == 6
-//              |}""".stripMargin)
-
-//    // TODO IndexOutOfBoundsException in ColsOverArraysDefs$ColOverArrayBuilder$ColOverArrayBuilderCtor.apply(...
-//    testEval("""{
-//              |  val arr = bytes1 ++ Array[Byte]()
-//              |  arr.size == 3
-//              |}""".stripMargin)
-//    testEval("""{
-//              |  val arr = Array[Byte]() ++ bytes1
-//              |  arr.size == 3
-//              |}""".stripMargin)
-
     testEval("""{
-              |  val arr = box1.R4[Coll[Int]].get
+              |  val arr = Coll(1, 2) ++ Coll(3, 4)
+              |  arr.size == 4
+              |}""".stripMargin)
+    testEval("""{
+              |  val arr = Coll(1, 2, 3)
+              |  arr.slice(1, 3) == Coll(2, 3)
+              |}""".stripMargin)
+    testEval("""{
+              |  val arr = bytes1 ++ bytes2
+              |  arr.size == 6
+              |}""".stripMargin)
+    testEval("""{
+              |  val arr = bytes1 ++ Coll[Byte]()
               |  arr.size == 3
               |}""".stripMargin)
     testEval("""{
-              |  val arr = box1.R5[Coll[Boolean]].get
+              |  val arr = Coll[Byte]() ++ bytes1
+              |  arr.size == 3
+              |}""".stripMargin)
+
+    testEval("""{
+              |  val arr = Coll(1, 2, 3)
+              |  arr.size == 3
+              |}""".stripMargin)
+    testEval("""{
+              |  val arr = Coll(true, false)
               |  anyOf(arr)
               |}""".stripMargin)
     testEval("""{
-              |  val arr = box1.R5[Coll[Boolean]].get
+              |  val arr = Coll(true, false)
               |  allOf(arr) == false
               |}""".stripMargin)
     testEval("""{

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -126,48 +126,72 @@ class TestingInterpreterSpecification extends SigmaTestingCommons {
   }
 
   property("Evaluate array ops") {
-    testEval("""{
-              |  val arr = Coll(1, 2) ++ Coll(3, 4)
-              |  arr.size == 4
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = Coll(1, 2, 3)
-              |  arr.slice(1, 3) == Coll(2, 3)
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = bytes1 ++ bytes2
-              |  arr.size == 6
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = bytes1 ++ Coll[Byte]()
-              |  arr.size == 3
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = Coll[Byte]() ++ bytes1
-              |  arr.size == 3
-              |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(1, 2) ++ Coll(3, 4)
+        |  arr.size == 4
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(1, 2, 3)
+        |  arr.slice(1, 3) == Coll(2, 3)
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = bytes1 ++ bytes2
+        |  arr.size == 6
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = bytes1 ++ Coll[Byte]()
+        |  arr.size == 3
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll[Byte]() ++ bytes1
+        |  arr.size == 3
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = box1.R4[Coll[Int]].get
+        |  arr.size == 3
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = box1.R5[Coll[Boolean]].get
+        |  anyOf(arr)
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = box1.R5[Coll[Boolean]].get
+        |  allOf(arr) == false
+        |}""".stripMargin)
 
-    testEval("""{
-              |  val arr = Coll(1, 2, 3)
-              |  arr.size == 3
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = Coll(true, false)
-              |  anyOf(arr)
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = Coll(true, false)
-              |  allOf(arr) == false
-              |}""".stripMargin)
-    testEval("""{
-              |  val arr = Coll(1, 2, 3)
-              |  arr.map {(i: Int) => i + 1} == Coll(2, 3, 4)
-              |}""".stripMargin)
-//    // TODO uncomment when Costing for where is implemented
-//    testEval("""{
-//              |  val arr = Array(1, 2, 3)
-//              |  arr.filter {(i: Int) => i < 3} == Array(1, 2)
-//              |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(1, 2, 3)
+        |  arr.size == 3
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(true, false)
+        |  anyOf(arr)
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(true, false)
+        |  allOf(arr) == false
+        |}""".stripMargin)
+    testEval(
+      """{
+        |  val arr = Coll(1, 2, 3)
+        |  arr.map {(i: Int) => i + 1} == Coll(2, 3, 4)
+        |}""".stripMargin)
+    //    // TODO uncomment when Costing for where is implemented
+    //    testEval("""{
+    //              |  val arr = Array(1, 2, 3)
+    //              |  arr.filter {(i: Int) => i < 3} == Array(1, 2)
+    //              |}""".stripMargin)
   }
 
 //  property("Evaluate sigma in lambdas") {

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -340,7 +340,6 @@ class TestingInterpreterSpecification extends SigmaTestingCommons {
 
   property("deserialize") {
     val str = Base58.encode(ValueSerializer.serialize(ByteArrayConstant(Array[Byte](2))))
-    testEval(s"""deserialize[Coll[Byte]]("$str").size == 1""")
     testEval(s"""deserialize[Coll[Byte]]("$str")(0) == 2""")
   }
 }

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -117,7 +117,7 @@ class TestingInterpreterSpecification extends SigmaTestingCommons {
       "box1" -> ErgoBox(10, TrueLeaf, 0, Seq(), Map(
           reg1 -> IntArrayConstant(Array[Int](1, 2, 3)),
           reg2 -> BoolArrayConstant(Array[Boolean](true, false, true)))))
-    val prop = compile(env, code).asBoolValue
+    val prop = compileWithCosting(env, code).asBoolValue
     println(code)
     println(prop)
     val challenge = Array.fill(32)(Random.nextInt(100).toByte)

--- a/src/test/scala/sigmastate/eval/CompilerItTest.scala
+++ b/src/test/scala/sigmastate/eval/CompilerItTest.scala
@@ -104,18 +104,15 @@ class CompilerItTest extends BaseCtxTests
   }
 
   def andSigmaPropConstsCase = {
+    import SigmaDslBuilder._
     val p1Sym: Rep[SigmaProp] = RProveDlogEvidence(liftConst(g1.asInstanceOf[ECPoint]))
     val p2Sym: Rep[SigmaProp] = RProveDlogEvidence(liftConst(g2.asInstanceOf[ECPoint]))
-    val resSym = (p1Sym && p2Sym)
     Case(env, "andSigmaPropConsts", "p1 && p2", ergoCtx,
-      calc = {_ => resSym },
-      cost = {_ =>
-        val c1 = costOfProveDlog + costOf("SigmaPropIsProven", SFunc(SSigmaProp, SBoolean))
-        c1 + c1 + costOf("BinAnd", SFunc(Vector(SBoolean, SBoolean), SBoolean))
-      },
-      size = {_ => typeSize[Boolean] },
+      calc = {_ => dsl.allZK(colBuilder.fromItems(p1Sym, p2Sym)) },
+      cost = null,
+      size = null,
       tree = SigmaAnd(Seq(SigmaPropConstant(p1), SigmaPropConstant(p2))),
-      Result(CAND(Seq(p1, p2)), 20107, 1))
+      Result(CAND(Seq(p1, p2)), 20106, 66))
   }
 
   test("andSigmaPropConstsCase") {

--- a/src/test/scala/sigmastate/eval/CompilerItTest.scala
+++ b/src/test/scala/sigmastate/eval/CompilerItTest.scala
@@ -274,7 +274,7 @@ class CompilerItTest extends BaseCtxTests
               )))),
             ValUse(1,SSigmaProp)
           ))))),
-      Result({ TrivialProp.FalseProp }, 40360, 1L)
+      Result({ TrivialProp.FalseProp }, 40361, 1L)
     )
   }
   test("crowdFunding_Case") {

--- a/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
+++ b/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
@@ -63,8 +63,8 @@ class ErgoTreeBuildingTest extends BaseCtxTests
 
   test("simple lambdas") {
     import IR.builder._
-    build(emptyEnv, "lam1", "{ (x: Long) => HEIGHT + x }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
-    build(emptyEnv, "lam2", "{ val f = { (x: Long) => HEIGHT + x }; f }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
+//    build(emptyEnv, "lam1", "{ (x: Long) => HEIGHT + x }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
+//    build(emptyEnv, "lam2", "{ val f = { (x: Long) => HEIGHT + x }; f }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
     build(emptyEnv, "lam3", "{ OUTPUTS.exists { (x: Box) => HEIGHT == x.value } }",
       Exists(Outputs, FuncValue(Vector((1,SBox)),EQ(Height,ExtractAmount(ValUse(1,SBox))))))
     build(emptyEnv, "lam4", "{ OUTPUTS.forall { (x: Box) => HEIGHT == x.value } }",

--- a/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
+++ b/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
@@ -63,8 +63,8 @@ class ErgoTreeBuildingTest extends BaseCtxTests
 
   test("simple lambdas") {
     import IR.builder._
-//    build(emptyEnv, "lam1", "{ (x: Long) => HEIGHT + x }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
-//    build(emptyEnv, "lam2", "{ val f = { (x: Long) => HEIGHT + x }; f }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
+    build(emptyEnv, "lam1", "{ (x: Long) => HEIGHT + x }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
+    build(emptyEnv, "lam2", "{ val f = { (x: Long) => HEIGHT + x }; f }", FuncValue(Vector((1,SLong)), mkPlus(Height, ValUse(1,SLong))))
     build(emptyEnv, "lam3", "{ OUTPUTS.exists { (x: Box) => HEIGHT == x.value } }",
       Exists(Outputs, FuncValue(Vector((1,SBox)),EQ(Height,ExtractAmount(ValUse(1,SBox))))))
     build(emptyEnv, "lam4", "{ OUTPUTS.forall { (x: Box) => HEIGHT == x.value } }",

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -40,7 +40,7 @@ trait SigmaTestingCommons extends PropSpec
   }
 
   def compileWithCosting(env: ScriptEnv, code: String)(implicit IR: IRContext): Value[SType] = {
-    val interProp = compiler.compile(env, code, TestnetNetworkPrefix)
+    val interProp = compiler.typecheck(env, code)
     val IR.Pair(calcF, _) = IR.doCosting(Map(), interProp)
     IR.buildTree(calcF)
   }

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -41,7 +41,7 @@ trait SigmaTestingCommons extends PropSpec
 
   def compileWithCosting(env: ScriptEnv, code: String)(implicit IR: IRContext): Value[SType] = {
     val interProp = compiler.typecheck(env, code)
-    val IR.Pair(calcF, _) = IR.doCosting(Map(), interProp)
+    val IR.Pair(calcF, _) = IR.doCosting(env, interProp)
     IR.buildTree(calcF)
   }
 

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -64,8 +64,8 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "col1 ++ col2") shouldBe SCollection(SLong)
     typecheck(env, "g1 ^ n1") shouldBe SGroupElement
     typecheck(env, "g1 * g2") shouldBe SGroupElement
-    typecheck(env, "p1 || p2") shouldBe SBoolean
-    typecheck(env, "p1 && p2") shouldBe SBoolean
+    typecheck(env, "p1 || p2") shouldBe SSigmaProp
+    typecheck(env, "p1 && p2") shouldBe SSigmaProp
     typecheck(env, "b1 < b2") shouldBe SBoolean
     typecheck(env, "b1 > b2") shouldBe SBoolean
     typecheck(env, "b1 <= b2") shouldBe SBoolean
@@ -84,9 +84,9 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "getVar[Byte](10).get") shouldBe SByte
     typecheck(env, "getVar[Coll[Byte]](10).get") shouldBe SByteArray
     typecheck(env, "getVar[SigmaProp](10).get") shouldBe SSigmaProp
-    typecheck(env, "p1 && getVar[SigmaProp](10).get") shouldBe SBoolean
-    typecheck(env, "getVar[SigmaProp](10).get || p2") shouldBe SBoolean
-    typecheck(env, "getVar[SigmaProp](10).get && getVar[SigmaProp](11).get") shouldBe SBoolean
+    typecheck(env, "p1 && getVar[SigmaProp](10).get") shouldBe SSigmaProp
+    typecheck(env, "getVar[SigmaProp](10).get || p2") shouldBe SSigmaProp
+    typecheck(env, "getVar[SigmaProp](10).get && getVar[SigmaProp](11).get") shouldBe SSigmaProp
     typecheck(env, "Coll(true, getVar[SigmaProp](11).get)") shouldBe SCollection(SBoolean)
     typecheck(env, "min(1, 2)") shouldBe SInt
     typecheck(env, "min(1L, 2)") shouldBe SLong

--- a/src/test/scala/sigmastate/serialization/generators/ConcreteCollectionGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ConcreteCollectionGenerators.scala
@@ -1,7 +1,7 @@
 package sigmastate.serialization.generators
 
 import org.scalacheck.{Arbitrary, Gen}
-import sigmastate.{SInt, SBoolean, SLong, SType}
+import sigmastate._
 import sigmastate.Values.{ConcreteCollection, EvaluatedValue, Value}
 
 trait ConcreteCollectionGenerators { self: ValueGenerators =>
@@ -22,4 +22,5 @@ trait ConcreteCollectionGenerators { self: ValueGenerators =>
 
   implicit val arbCCOfIntConstant: Arbitrary[ConcreteCollection[SInt.type]] = Arbitrary(intConstCollectionGen)
   implicit val arbCCOfBoolConstant: Arbitrary[ConcreteCollection[SBoolean.type]] = Arbitrary(concreteCollectionGen[SBoolean.type](booleanConstGen))
+  implicit val arbCCOfSigmaPropConstant: Arbitrary[ConcreteCollection[SSigmaProp.type]] = Arbitrary(concreteCollectionGen[SSigmaProp.type](sigmaPropGen))
 }

--- a/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
@@ -69,7 +69,7 @@ trait TransformerGenerators {
 
   val atLeastGen: Gen[AtLeast] = for {
     bound <- intConstGen
-    input <- arbCCOfBoolConstant.arbitrary
+    input <- arbCCOfSigmaPropConstant.arbitrary
   } yield mkAtLeast(bound, input).asInstanceOf[AtLeast]
 
   val filterGen: Gen[Filter[SInt.type]] = for {

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -43,7 +43,8 @@ trait ValueGenerators extends TypeGenerators {
 
   implicit val arbBigInteger = Arbitrary(arbBigInt.arbitrary.map(_.bigInteger))
   implicit val arbGroupElement = Arbitrary(Gen.const(()).flatMap(_ => CryptoConstants.dlogGroup.createRandomGenerator()))
-  implicit val arbSigmaProp: Arbitrary[SigmaBoolean] = Arbitrary(Gen.oneOf(proveDHTGen, proveDHTGen))
+  implicit val arbSigmaBoolean: Arbitrary[SigmaBoolean] = Arbitrary(Gen.oneOf(proveDHTGen, proveDHTGen))
+  implicit val arbSigmaProp: Arbitrary[SigmaPropValue] = Arbitrary(sigmaPropGen)
   implicit val arbBox = Arbitrary(ergoBoxGen)
   implicit val arbAvlTreeData = Arbitrary(avlTreeDataGen)
   implicit val arbBoxCandidate = Arbitrary(ergoBoxCandidateGen(tokensGen.sample.get))
@@ -95,6 +96,8 @@ trait ValueGenerators extends TypeGenerators {
   } yield mkProveDiffieHellmanTuple(gv, hv, uv, vv).asInstanceOf[ProveDHTuple]
 
   val sigmaBooleanGen: Gen[SigmaBoolean] = Gen.oneOf(proveDlogGen, proveDHTGen)
+  val sigmaPropGen: Gen[SigmaPropValue] =
+    Gen.oneOf(proveDlogGen.map(SigmaPropConstant(_)), proveDHTGen.map(SigmaPropConstant(_)))
 
   val registerIdentifierGen: Gen[RegisterId] = Gen.oneOf(R0, R1, R2, R3, R4, R5, R6, R7, R8, R9)
 
@@ -187,7 +190,7 @@ trait ValueGenerators extends TypeGenerators {
     case SLong => arbLong
     case SBigInt => arbBigInteger
     case SGroupElement => arbGroupElement
-    case SSigmaProp => arbSigmaProp
+    case SSigmaProp => arbSigmaBoolean
     case SBox => arbBox
     case SAvlTree => arbAvlTreeData
     case SAny => arbAnyVal

--- a/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
@@ -46,7 +46,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
       ByteArrayConstant(opsBytes),
       ByteArrayConstant(proof)).get, ByteArrayConstant(endDigest))
     val env = Map("ops" -> opsBytes, "proof" -> proof, "endDigest" -> endDigest)
-    val propCompiled = compile(env, """treeModifications(SELF.R4[AvlTree].get, ops, proof).get == endDigest""").asBoolValue
+    val propCompiled = compileWithCosting(env, """treeModifications(SELF.R4[AvlTree].get, ops, proof).get == endDigest""").asBoolValue
     prop shouldBe propCompiled
 
     val newBox1 = ErgoBox(10, pubkey, 0)
@@ -95,7 +95,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
       ByteArrayConstant(proof)).get, ByteArrayConstant(value))
 
     val env = Map("key" -> key, "proof" -> proof, "value" -> value)
-    val propCompiled = compile(env, """treeLookup(SELF.R4[AvlTree].get, key, proof).get == value""").asBoolValue
+    val propCompiled = compileWithCosting(env, """treeLookup(SELF.R4[AvlTree].get, key, proof).get == value""").asBoolValue
     prop shouldBe propCompiled
 
     val newBox1 = ErgoBox(10, pubkey, 0)
@@ -137,7 +137,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val treeData = new AvlTreeData(digest, 32, None)
 
     val env = Map("key" -> key, "proof" -> proof)
-    val prop = compile(env, """isMember(SELF.R4[AvlTree].get, key, proof)""").asBoolValue
+    val prop = compileWithCosting(env, """isMember(SELF.R4[AvlTree].get, key, proof)""").asBoolValue
 
     val propTree = OptionIsDefined(TreeLookup(ExtractRegisterAs[SAvlTree.type](Self, reg1).get,
       ByteArrayConstant(key),
@@ -180,7 +180,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
         GetVarByteArray(proofId).get))
     )
     val env = Map("proofId" -> proofId.toLong, "elementId" -> elementId.toLong)
-    val propCompiled = compile(env,
+    val propCompiled = compileWithCosting(env,
       """{
         |  val tree = SELF.R3[AvlTree].get
         |  val proof = getVar[Coll[Byte]](proofId).get
@@ -241,7 +241,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val env = Map("proofId" -> proofId.toLong)
-    val prop = compile(env,
+    val prop = compileWithCosting(env,
       """{
         |  val tree = SELF.R4[AvlTree].get
         |  val key = SELF.R5[Coll[Byte]].get

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -48,7 +48,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
   def test(name: String, env: ScriptEnv,
            ext: Seq[(Byte, EvaluatedValue[_ <: SType])],
            script: String, propExp: SValue,
-      onlyPositive: Boolean = false) = {
+      onlyPositive: Boolean = true) = {
     val prover = new ErgoLikeTestProvingInterpreter() {
       override lazy val contextExtenders: Map[Byte, EvaluatedValue[_ <: SType]] = {
         val p1 = dlogSecrets(0).publicImage
@@ -470,4 +470,17 @@ class BasicOpsSpecification extends SigmaTestingCommons {
 //    test("zk1", env, ext, "ZKProof { sigmaProp(HEIGHT >= 0) }",
 //      ZKProofBlock(BoolToSigmaProp(GE(Height, LongConstant(0)))), true)
 //  }
+
+  property("numeric cast") {
+    test("downcast", env, ext,
+      "{ getVar[Int](intVar2).get.toByte == 2.toByte }",
+      EQ(Downcast(GetVarInt(2).get, SByte), ByteConstant(2)),
+      onlyPositive = true
+    )
+    test("upcast", env, ext,
+      "{ getVar[Int](intVar2).get.toLong == 2L }",
+      EQ(Upcast(GetVarInt(2).get, SLong), LongConstant(2)),
+      onlyPositive = true
+    )
+  }
 }

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -272,12 +272,11 @@ class BasicOpsSpecification extends SigmaTestingCommons {
         |}""".stripMargin,
       {
         val data = GetVar(dataVar, dataType).get
-        OR(
-          MapCollection(data,
-            FuncValue(
-              Vector((1, STuple(SByteArray, SLong))),
-              EQ(SelectField(ValUse(1, STuple(SByteArray, SLong)), 2), LongConstant(10)))
-          ).asCollection[SBoolean.type])
+        Exists(data,
+          FuncValue(
+            Vector((1, STuple(SByteArray, SLong))),
+            EQ(SelectField(ValUse(1, STuple(SByteArray, SLong)), 2), LongConstant(10)))
+        )
       }
     )
     test("TupCol5", env1, ext1,
@@ -287,12 +286,11 @@ class BasicOpsSpecification extends SigmaTestingCommons {
         |}""".stripMargin,
       {
         val data = GetVar(dataVar, dataType).get
-        AND(
-          MapCollection(data,
-            FuncValue(
-              Vector((1, STuple(SByteArray, SLong))),
-              GT(SizeOf(SelectField(ValUse(1, STuple(SByteArray, SLong)), 1).asCollection[SByte.type]), IntConstant(0)))
-          ).asCollection[SBoolean.type])
+        ForAll(data,
+          FuncValue(
+            Vector((1, STuple(SByteArray, SLong))),
+            GT(SizeOf(SelectField(ValUse(1, STuple(SByteArray, SLong)), 1).asCollection[SByte.type]), IntConstant(0)))
+        )
       }
     )
     test("TupCol6", env1, ext1,

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -242,8 +242,8 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val env = Map("pubkey" -> pubkey)
-    val prop = compile(env, """pubkey && OUTPUTS.size == INPUTS.size + 1""").asBoolValue
-    val propTree = BinAnd(pubkey.isProven, EQ(SizeOf(Outputs), Plus(SizeOf(Inputs), IntConstant(1))))
+    val prop = compileWithCosting(env, """pubkey && OUTPUTS.size == INPUTS.size + 1""").asBoolValue
+    val propTree = SigmaAnd(pubkey, BoolToSigmaProp(EQ(SizeOf(Outputs), Plus(SizeOf(Inputs), IntConstant(1)))))
     prop shouldBe propTree
 
     val newBox1 = ErgoBox(11, pubkey, 0)

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -66,11 +66,10 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val prop = compileWithCosting(Map(), "OUTPUTS.exists({ (box: Box) => box.value + 5 > 10 })").asBoolValue
 
-    val expProp = OR(
-      MapCollection(Outputs,
-        FuncValue(Vector((1, SBox)),
-          GT(Plus(ExtractAmount(ValUse(1, SBox)), LongConstant(5)), LongConstant(10)))
-      ).asCollection[SBoolean.type])
+    val expProp = Exists(Outputs,
+      FuncValue(Vector((1, SBox)),
+        GT(Plus(ExtractAmount(ValUse(1, SBox)), LongConstant(5)), LongConstant(10)))
+    )
     prop shouldBe expProp
 
     val newBox1 = ErgoBox(16, pubkey, 0)
@@ -99,10 +98,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
 
     val prop = compileWithCosting(Map(), "OUTPUTS.forall({ (box: Box) => box.value == 10 })").asBoolValue
 
-    val propTree = AND(
-      MapCollection(Outputs,
+    val propTree = ForAll(Outputs,
         FuncValue(Vector((1, SBox)), EQ(ExtractAmount(ValUse(1, SBox)), LongConstant(10)))
-      ).asCollection[SBoolean.type])
+      )
     prop shouldBe propTree
 
     val newBox1 = ErgoBox(10, pubkey, 0)
@@ -131,10 +129,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val prop = compileWithCosting(Map(), "OUTPUTS.forall({ (box: Box) => box.value == 10 })").asBoolValue
-    val propTree = AND(
-      MapCollection(Outputs,
+    val propTree = ForAll(Outputs,
         FuncValue(Vector((1, SBox)), EQ(ExtractAmount(ValUse(1, SBox)), LongConstant(10)))
-      ).asCollection[SBoolean.type])
+      )
     prop shouldBe propTree
 
     val newBox1 = ErgoBox(10, pubkey, 0)
@@ -165,14 +162,14 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  box.R4[Long].get == SELF.R4[Long].get + 1
          }""".stripMargin).asBoolValue
 
-    val propTree = OR(MapCollection(Outputs,
+    val propTree = Exists(Outputs,
       FuncValue(
         Vector((1, SBox)),
         EQ(
           ExtractRegisterAs[SLong.type](ValUse(1, SBox), reg1).get,
           Plus(ExtractRegisterAs[SLong.type](Self, reg1).get, LongConstant(1)))
       )
-    ).asCollection[SBoolean.type])
+    )
     prop shouldBe propTree
 
     val newBox1 = ErgoBox(10, pubkey, 0, Seq(), Map(reg1 -> LongConstant(3)))
@@ -206,7 +203,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  box.R4[Long].getOrElse(0L) == SELF.R4[Long].get + 1
          }""".stripMargin).asBoolValue
 
-    val propTree = OR(MapCollection(Outputs,
+    val propTree = Exists(Outputs,
       FuncValue(
         Vector((1, SBox)),
         EQ(
@@ -214,8 +211,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
           Plus(ExtractRegisterAs[SLong.type](Self, reg1).get, LongConstant(1))
         )
       )
-    ).asCollection[SBoolean.type])
-
+    )
 
     prop shouldBe propTree
 
@@ -277,11 +273,9 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
   property("slice") {
     val outputBoxValues = IndexedSeq(10L, 10L)
     val code = "OUTPUTS.slice(1, OUTPUTS.size).forall({ (box: Box) => box.value == 10 })"
-    val expectedPropTree = AND(
-      MapCollection(
-        Slice(Outputs, IntConstant(1), SizeOf(Outputs)),
-        FuncValue(Vector((1, SBox)), EQ(ExtractAmount(ValUse(1, SBox)), LongConstant(10)))
-      ).asCollection[SBoolean.type]
+    val expectedPropTree = ForAll(
+      Slice(Outputs, IntConstant(1), SizeOf(Outputs)),
+      FuncValue(Vector((1, SBox)), EQ(ExtractAmount(ValUse(1, SBox)), LongConstant(10)))
     )
     assertProof(code, expectedPropTree, outputBoxValues)
   }
@@ -393,20 +387,15 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  indexCollection.forall(elementRule)
          }""".stripMargin
 
-    val expectedPropTree = AND(MapCollection(
+    val expectedPropTree = ForAll(
       ConcreteCollection(Vector(IntConstant(0), IntConstant(1), IntConstant(2), IntConstant(3), IntConstant(4), IntConstant(5)), SInt),
-      FuncValue(
-        Vector((1, SInt)),
+      FuncValue(Vector((1, SInt)),
         BlockValue(
-          Vector(ValDef(3, EQ(ValUse(1, SInt), IntConstant(0)))),
-          BinAnd(
-            GE(If(ValUse(3, SBoolean), IntConstant(5), Minus(ValUse(1, SInt), IntConstant(1))), IntConstant(0)),
-            LE(If(ValUse(3, SBoolean), IntConstant(5), Minus(ValUse(1, SInt), IntConstant(1))), IntConstant(5))
-          )
+          Vector(ValDef(3, If(EQ(ValUse(1, SInt), IntConstant(0)), IntConstant(5), Minus(ValUse(1, SInt), IntConstant(1))))),
+          BinAnd(GE(ValUse(3, SInt), IntConstant(0)), LE(ValUse(3, SInt), IntConstant(5)))
         )
       )
-    ).asCollection[SBoolean.type])
-
+    )
     assertProof(code, expectedPropTree, outputBoxValues)
   }
 
@@ -424,26 +413,23 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
         |  indexCollection.forall(elementRule)
          }""".stripMargin
 
-    val element = ByIndex(
-      ValUse(1, SCollectionType(SInt)),
-      If(ValUse(4, SBoolean), IntConstant(5), Minus(ValUse(2, SInt), IntConstant(1))),
-      None)
-    val expectedPropTree = BlockValue(
-      Vector(
-        ValDef(1,
-          ConcreteCollection(Vector(IntConstant(1), IntConstant(1), IntConstant(0), IntConstant(0), IntConstant(0), IntConstant(1)), SInt))),
-      AND(
-        MapCollection(
-          ConcreteCollection(Vector(IntConstant(0), IntConstant(1), IntConstant(2), IntConstant(3), IntConstant(4), IntConstant(5)), SInt),
-          FuncValue(Vector((2, SInt)),
-            BlockValue(
-              Vector(ValDef(4, LE(ValUse(2, SInt), IntConstant(0)))),
-              BinOr(
-                EQ(element, IntConstant(0)),
-                EQ(element, IntConstant(1)))
-            )
-          )
-        ).asCollection[SBoolean.type]
+    val expectedPropTree = ForAll(
+      ConcreteCollection(Vector(IntConstant(0), IntConstant(1), IntConstant(2), IntConstant(3), IntConstant(4), IntConstant(5)), SInt),
+      FuncValue(
+        Vector((1, SInt)),
+        BlockValue(
+          Vector(
+            ValDef(3,
+              ByIndex(
+                ConcreteCollection(Vector(IntConstant(1), IntConstant(1), IntConstant(0), IntConstant(0), IntConstant(0), IntConstant(1)), SInt),
+                If(
+                  LE(ValUse(1, SInt), IntConstant(0)),
+                  IntConstant(5),
+                  Minus(ValUse(1, SInt), IntConstant(1))
+                ),
+                None))),
+          BinOr(EQ(ValUse(3, SInt), IntConstant(0)), EQ(ValUse(3, SInt), IntConstant(1)))
+        )
       )
     )
 

--- a/src/test/scala/sigmastate/utxo/ComplexSigSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ComplexSigSpecification.scala
@@ -439,7 +439,8 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB)
     val compiledProp = compileWithCosting(env, """anyOf(Coll(pubkeyA, pubkeyB, HEIGHT > 500))""").asBoolValue
 
-    val prop = SigmaOr(pubkeyA, pubkeyB, GT(Height, LongConstant(500)).toSigmaProp)
+    // rewritten by http://github.com/aslesarenko/sigma/blob/2740b51c86bdf1917f688d4ccdb1a0eae9755e0c/sigma-library/src/main/scala/scalan/SigmaLibrary.scala#L91
+    val prop = SigmaOr(GT(Height, LongConstant(500)).toSigmaProp, SigmaOr(pubkeyA, pubkeyB))
     compiledProp shouldBe prop
 
     val ctx1 = ErgoLikeContext(

--- a/src/test/scala/sigmastate/utxo/ComplexSigSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ComplexSigSpecification.scala
@@ -4,6 +4,7 @@ import org.ergoplatform.{ErgoLikeContext, Height}
 import org.scalacheck.Gen
 import sigmastate.Values.LongConstant
 import sigmastate._
+import sigmastate.lang.Terms._
 import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, SigmaTestingCommons}
 
 import scala.util.Random
@@ -30,9 +31,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyB = proverB.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB)
-    val compiledProp = compile(env, """pubkeyA || pubkeyB""")
+    val compiledProp = compileWithCosting(env, """pubkeyA || pubkeyB""").asBoolValue
 
-    val prop = BinOr(pubkeyA.isProven, pubkeyB.isProven)
+    val prop = SigmaOr(pubkeyA, pubkeyB)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -43,13 +44,13 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
 
-    val prB = proverB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prB, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prB, fakeMessage).get._1 shouldBe true
 
-    proverC.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverC.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
   }
 
   property("simplest linear-sized ring signature (1-out-of-3 OR), with anyOf syntax") {
@@ -63,9 +64,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyC = proverC.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC)
-    val compiledProp = compile(env, """anyOf(Coll(pubkeyA, pubkeyB, pubkeyC))""")
+    val compiledProp = compileWithCosting(env, """anyOf(Coll(pubkeyA, pubkeyB, pubkeyC))""").asBoolValue
 
-    val prop = OR(pubkeyA.isProven, pubkeyB.isProven, pubkeyC.isProven)
+    val prop = SigmaOr(pubkeyA, pubkeyB, pubkeyC)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -76,14 +77,14 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
 
-    val prB = proverB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prB, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prB, fakeMessage).get._1 shouldBe true
 
-    val prC = proverC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prC, fakeMessage).get._1 shouldBe true
+    val prC = proverC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prC, fakeMessage).get._1 shouldBe true
   }
 
   property("simplest linear-sized ring signature (1-out-of-3 OR), with || syntax") {
@@ -97,9 +98,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyC = proverC.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC)
-    val compiledProp = compile(env, """pubkeyA || pubkeyB || pubkeyC""")
+    val compiledProp = compileWithCosting(env, """pubkeyA || pubkeyB || pubkeyC""").asBoolValue
 
-    val prop = BinOr(BinOr(pubkeyA.isProven, pubkeyB.isProven), pubkeyC.isProven)
+    val prop = SigmaOr(SigmaOr(pubkeyA, pubkeyB), pubkeyC)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -110,14 +111,14 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
 
-    val prB = proverB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prB, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prB, fakeMessage).get._1 shouldBe true
 
-    val prC = proverC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prC, fakeMessage).get._1 shouldBe true
+    val prC = proverC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prC, fakeMessage).get._1 shouldBe true
   }
 
   //two secrets are known, nevertheless, one will be simulated
@@ -132,9 +133,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyA4 = proverA.dlogSecrets(3).publicImage
 
     val env = Map("pubkeyA1" -> pubkeyA1, "pubkeyA2" -> pubkeyA2, "pubkeyA3" -> pubkeyA3, "pubkeyA4" -> pubkeyA4)
-    val compiledProp = compile(env, """anyOf(Coll(pubkeyA1, pubkeyA2, pubkeyA3, pubkeyA4))""")
+    val compiledProp = compileWithCosting(env, """anyOf(Coll(pubkeyA1, pubkeyA2, pubkeyA3, pubkeyA4))""").asBoolValue
 
-    val prop = OR(Seq(pubkeyA1.isProven, pubkeyA2.isProven, pubkeyA3.isProven, pubkeyA4.isProven))
+    val prop = SigmaOr(pubkeyA1, pubkeyA2, pubkeyA3, pubkeyA4)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -145,8 +146,8 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of two ANDs") {
@@ -163,9 +164,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyD = proverD.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC, "pubkeyD" -> pubkeyD)
-    val compiledProp = compile(env, """pubkeyA && pubkeyB || pubkeyC && pubkeyD""")
+    val compiledProp = compileWithCosting(env, """pubkeyA && pubkeyB || pubkeyC && pubkeyD""").asBoolValue
 
-    val prop = BinOr(BinAnd(pubkeyA.isProven, pubkeyB.isProven), BinAnd(pubkeyC.isProven, pubkeyD.isProven))
+    val prop = SigmaOr(SigmaAnd(pubkeyA, pubkeyB), SigmaAnd(pubkeyC, pubkeyD))
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -176,18 +177,18 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverC.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverD.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverC.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverD.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
     val proverAB = proverA.withSecrets(Seq(proverB.dlogSecrets.head))
-    val pr = proverAB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    val pr = proverAB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr, fakeMessage).get._1 shouldBe true
 
     val proverCD = proverC.withSecrets(Seq(proverD.dlogSecrets.head))
-    val pr2 = proverCD.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr2, fakeMessage).get._1 shouldBe true
+    val pr2 = proverCD.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr2, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of AND and OR") {
@@ -204,9 +205,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyD = proverD.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC, "pubkeyD" -> pubkeyD)
-    val compiledProp = compile(env, """pubkeyA && pubkeyB || (pubkeyC || pubkeyD)""")
+    val compiledProp = compileWithCosting(env, """pubkeyA && pubkeyB || (pubkeyC || pubkeyD)""").asBoolValue
 
-    val prop = BinOr(BinAnd(pubkeyA.isProven, pubkeyB.isProven), BinOr(pubkeyC.isProven, pubkeyD.isProven))
+    val prop = SigmaOr(SigmaAnd(pubkeyA, pubkeyB), SigmaOr(pubkeyC, pubkeyD))
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -217,18 +218,18 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
-    val prC = proverC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prC, fakeMessage).get._1 shouldBe true
+    val prC = proverC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prC, fakeMessage).get._1 shouldBe true
 
-    val prD = proverD.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prD, fakeMessage).get._1 shouldBe true
+    val prD = proverD.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prD, fakeMessage).get._1 shouldBe true
 
     val proverAB = proverA.withSecrets(Seq(proverB.dlogSecrets.head))
-    val pr = proverAB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    val pr = proverAB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr, fakeMessage).get._1 shouldBe true
   }
 
   property("simple sig scheme - AND of two") {
@@ -241,9 +242,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyB = proverB.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB)
-    val compiledProp = compile(env, """pubkeyA && pubkeyB""")
+    val compiledProp = compileWithCosting(env, """pubkeyA && pubkeyB""").asBoolValue
 
-    val prop = BinAnd(pubkeyA.isProven, pubkeyB.isProven)
+    val prop = SigmaAnd(pubkeyA, pubkeyB)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -254,12 +255,12 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
     val proverAB = proverA.withSecrets(Seq(proverB.dlogSecrets.head))
-    val pr = proverAB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    val pr = proverAB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of AND and DLOG") {
@@ -274,9 +275,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyC = proverC.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC)
-    val compiledProp = compile(env, """(pubkeyA && pubkeyB) || pubkeyC""")
+    val compiledProp = compileWithCosting(env, """(pubkeyA && pubkeyB) || pubkeyC""").asBoolValue
 
-    val prop = BinOr(BinAnd(pubkeyA.isProven, pubkeyB.isProven), pubkeyC.isProven)
+    val prop = SigmaOr(SigmaAnd(pubkeyA, pubkeyB), pubkeyC)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -287,17 +288,17 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverC.prove(prop, ctx, fakeMessage).isSuccess shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverC.prove(compiledProp, ctx, fakeMessage).isSuccess shouldBe true
 
     val proverAB = proverA.withSecrets(Seq(proverB.dlogSecrets.head))
-    val pr = proverAB.prove(prop, ctx, fakeMessage).get
+    val pr = proverAB.prove(compiledProp, ctx, fakeMessage).get
     println("proof size: " + pr.proof.length)
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    verifier.verify(compiledProp, ctx, pr, fakeMessage).get._1 shouldBe true
 
-    val pr2 = proverC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr2, fakeMessage).get._1 shouldBe true
+    val pr2 = proverC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr2, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - AND of two ORs") {
@@ -314,9 +315,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyD = proverD.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC, "pubkeyD" -> pubkeyD)
-    val compiledProp = compile(env, """(pubkeyA || pubkeyB) && (pubkeyC || pubkeyD)""")
+    val compiledProp = compileWithCosting(env, """(pubkeyA || pubkeyB) && (pubkeyC || pubkeyD)""").asBoolValue
 
-    val prop = BinAnd(BinOr(pubkeyA.isProven, pubkeyB.isProven), BinOr(pubkeyC.isProven, pubkeyD.isProven))
+    val prop = SigmaAnd(SigmaOr(pubkeyA, pubkeyB), SigmaOr(pubkeyC, pubkeyD))
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -327,18 +328,18 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverC.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverD.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverC.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverD.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
     val proverAC = proverA.withSecrets(Seq(proverC.dlogSecrets.head))
-    val pr = proverAC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    val pr = proverAC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr, fakeMessage).get._1 shouldBe true
 
     val proverBD = proverB.withSecrets(Seq(proverD.dlogSecrets.head))
-    val pr2 = proverBD.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr2, fakeMessage).get._1 shouldBe true
+    val pr2 = proverBD.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr2, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - AND of AND and OR") {
@@ -355,9 +356,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyD = proverD.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC, "pubkeyD" -> pubkeyD)
-    val compiledProp = compile(env, """(pubkeyA && pubkeyB) && (pubkeyC || pubkeyD)""")
+    val compiledProp = compileWithCosting(env, """(pubkeyA && pubkeyB) && (pubkeyC || pubkeyD)""").asBoolValue
 
-    val prop = BinAnd(BinAnd(pubkeyA.isProven, pubkeyB.isProven), BinOr(pubkeyC.isProven, pubkeyD.isProven))
+    val prop = SigmaAnd(SigmaAnd(pubkeyA, pubkeyB), SigmaOr(pubkeyC, pubkeyD))
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -368,21 +369,21 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    proverA.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverC.prove(prop, ctx, fakeMessage).isFailure shouldBe true
-    proverD.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverA.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverC.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
+    proverD.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
     val proverAB = proverA.withSecrets(Seq(proverB.dlogSecrets.head))
-    proverAB.prove(prop, ctx, fakeMessage).isFailure shouldBe true
+    proverAB.prove(compiledProp, ctx, fakeMessage).isFailure shouldBe true
 
     val proverABC = proverAB.withSecrets(Seq(proverC.dlogSecrets.head))
-    val prABC = proverABC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prABC, fakeMessage).get._1 shouldBe true
+    val prABC = proverABC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prABC, fakeMessage).get._1 shouldBe true
 
     val proverABD = proverAB.withSecrets(Seq(proverC.dlogSecrets.head))
-    val prABD = proverABD.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prABD, fakeMessage).get._1 shouldBe true
+    val prABD = proverABD.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prABD, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of two ORs") {
@@ -399,9 +400,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyD = proverD.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC, "pubkeyD" -> pubkeyD)
-    val compiledProp = compile(env, """(pubkeyA || pubkeyB) || (pubkeyC || pubkeyD)""")
+    val compiledProp = compileWithCosting(env, """(pubkeyA || pubkeyB) || (pubkeyC || pubkeyD)""").asBoolValue
 
-    val prop = BinOr(BinOr(pubkeyA.isProven, pubkeyB.isProven), BinOr(pubkeyC.isProven, pubkeyD.isProven))
+    val prop = SigmaOr(SigmaOr(pubkeyA, pubkeyB), SigmaOr(pubkeyC, pubkeyD))
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -412,17 +413,17 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
 
-    val prB = proverB.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prB, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prB, fakeMessage).get._1 shouldBe true
 
-    val prC = proverC.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prC, fakeMessage).get._1 shouldBe true
+    val prC = proverC.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prC, fakeMessage).get._1 shouldBe true
 
-    val prD = proverD.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prD, fakeMessage).get._1 shouldBe true
+    val prD = proverD.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prD, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR w. predicate") {
@@ -436,9 +437,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyB = proverB.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB)
-    val compiledProp = compile(env, """anyOf(Coll(pubkeyA, pubkeyB, HEIGHT > 500))""")
+    val compiledProp = compileWithCosting(env, """anyOf(Coll(pubkeyA, pubkeyB, HEIGHT > 500))""").asBoolValue
 
-    val prop = OR(pubkeyA.isProven, pubkeyB.isProven, GT(Height, LongConstant(500)))
+    val prop = SigmaOr(pubkeyA, pubkeyB, GT(Height, LongConstant(500)).toSigmaProp)
     compiledProp shouldBe prop
 
     val ctx1 = ErgoLikeContext(
@@ -448,11 +449,11 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       boxesToSpend = IndexedSeq(fakeSelf),
       spendingTransaction = null,
       self = fakeSelf)
-    val prA = proverA.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prA, fakeMessage).get._1 shouldBe true
-    val prB = proverB.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prB, fakeMessage).get._1 shouldBe true
-    proverC.prove(prop, ctx1, fakeMessage).isFailure shouldBe true
+    val prA = proverA.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prA, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prB, fakeMessage).get._1 shouldBe true
+    proverC.prove(compiledProp, ctx1, fakeMessage).isFailure shouldBe true
 
     val ctx2 = ErgoLikeContext(
       currentHeight = 501,
@@ -461,8 +462,8 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       boxesToSpend = IndexedSeq(fakeSelf),
       spendingTransaction = null,
       self = fakeSelf)
-    val prC = proverC.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prC, fakeMessage).get._1 shouldBe true
+    val prC = proverC.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prC, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of OR and AND w. predicate, parentheses") {
@@ -477,9 +478,10 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyC = proverC.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC)
-    val compiledProp = compile(env, """anyOf(Coll(pubkeyA || pubkeyB, pubkeyC && HEIGHT > 500))""")
+    val compiledProp = compileWithCosting(env,
+      """anyOf(Coll(pubkeyA || pubkeyB, pubkeyC && HEIGHT > 500))""").asBoolValue
 
-    val prop = OR(BinOr(pubkeyA.isProven, pubkeyB.isProven), BinAnd(pubkeyC.isProven, GT(Height, LongConstant(500))))
+    val prop = SigmaOr(SigmaOr(pubkeyA, pubkeyB), SigmaAnd(pubkeyC, GT(Height, LongConstant(500)).toSigmaProp))
     compiledProp shouldBe prop
 
     val ctx1 = ErgoLikeContext(
@@ -490,11 +492,11 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prA, fakeMessage).get._1 shouldBe true
-    val prB = proverB.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prB, fakeMessage).get._1 shouldBe true
-    proverC.prove(prop, ctx1, fakeMessage).isFailure shouldBe true
+    val prA = proverA.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prA, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prB, fakeMessage).get._1 shouldBe true
+    proverC.prove(compiledProp, ctx1, fakeMessage).isFailure shouldBe true
 
 
     val ctx2 = ErgoLikeContext(
@@ -505,12 +507,12 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA2 = proverA.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prA2, fakeMessage).get._1 shouldBe true
-    val prB2 = proverB.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prB2, fakeMessage).get._1 shouldBe true
-    val prC2 = proverC.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prC2, fakeMessage).get._1 shouldBe true
+    val prA2 = proverA.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prA2, fakeMessage).get._1 shouldBe true
+    val prB2 = proverB.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prB2, fakeMessage).get._1 shouldBe true
+    val prC2 = proverC.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prC2, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - OR of OR and AND w. predicate, no parentheses") {
@@ -525,9 +527,9 @@ class ComplexSigSpecification extends SigmaTestingCommons {
     val pubkeyC = proverC.dlogSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubkeyB" -> pubkeyB, "pubkeyC" -> pubkeyC)
-    val compiledProp = compile(env, """pubkeyA || pubkeyB ||  (pubkeyC && HEIGHT > 500)""")
+    val compiledProp = compileWithCosting(env, """pubkeyA || pubkeyB ||  (pubkeyC && HEIGHT > 500)""").asBoolValue
 
-    val prop = BinOr(BinOr(pubkeyA.isProven, pubkeyB.isProven), BinAnd(pubkeyC.isProven, GT(Height, LongConstant(500))))
+    val prop = SigmaOr(SigmaOr(pubkeyA, pubkeyB), SigmaAnd(pubkeyC, GT(Height, LongConstant(500)).toSigmaProp))
     compiledProp shouldBe prop
 
     val ctx1 = ErgoLikeContext(
@@ -538,11 +540,11 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prA, fakeMessage).get._1 shouldBe true
-    val prB = proverB.prove(prop, ctx1, fakeMessage).get
-    verifier.verify(prop, ctx1, prB, fakeMessage).get._1 shouldBe true
-    proverC.prove(prop, ctx1, fakeMessage).isFailure shouldBe true
+    val prA = proverA.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prA, fakeMessage).get._1 shouldBe true
+    val prB = proverB.prove(compiledProp, ctx1, fakeMessage).get
+    verifier.verify(compiledProp, ctx1, prB, fakeMessage).get._1 shouldBe true
+    proverC.prove(compiledProp, ctx1, fakeMessage).isFailure shouldBe true
 
 
     val ctx2 = ErgoLikeContext(
@@ -553,12 +555,12 @@ class ComplexSigSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA2 = proverA.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prA2, fakeMessage).get._1 shouldBe true
-    val prB2 = proverB.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prB2, fakeMessage).get._1 shouldBe true
-    val prC2 = proverC.prove(prop, ctx2, fakeMessage).get
-    verifier.verify(prop, ctx2, prC2, fakeMessage).get._1 shouldBe true
+    val prA2 = proverA.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prA2, fakeMessage).get._1 shouldBe true
+    val prB2 = proverB.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prB2, fakeMessage).get._1 shouldBe true
+    val prC2 = proverC.prove(compiledProp, ctx2, fakeMessage).get
+    verifier.verify(compiledProp, ctx2, prC2, fakeMessage).get._1 shouldBe true
   }
 
   property("complex sig scheme - k-out-of-n threshold") {

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -1,8 +1,7 @@
 package sigmastate.utxo
 
 import com.google.common.primitives.Bytes
-import org.ergoplatform.ErgoLikeContext.Metadata
-import org.ergoplatform.ErgoLikeContext.Metadata._
+import org.ergoplatform.ErgoLikeContext._
 import org.ergoplatform._
 import org.scalatest.TryValues._
 import scapi.sigma.DLogProtocol.ProveDlog
@@ -160,7 +159,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     def mixingRequestProp(sender: ProveDlog, timeout: Int) = {
       val env = Map("sender" -> sender, "timeout" -> timeout, "properHash" -> properHash)
-      val compiledProp = compile(env,
+      val compiledProp = compileWithCosting(env,
         """{
           |  val notTimePassed = HEIGHT <= timeout
           |  val outBytes = OUTPUTS.map({(box: Box) => box.bytesWithNoRef})
@@ -577,7 +576,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val helloHash = Blake2b256.hash(preimageHello)
 
     val env = Map("helloHash" -> helloHash)
-    val prop = compile(env,
+    val prop = compileWithCosting(env,
       """{
         |  val cond = INPUTS(0).value > 10
         |  val preimage = if (cond)

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -56,8 +56,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val wrongProp = SigmaPropConstant(ProveDHTuple(ci.g, ci.h, ci.u, ci.u)).isProven
 
     val env = Map("g" -> ci.g, "h" -> ci.h, "u" -> ci.u, "v" -> ci.v, "s" -> secret.publicImage)
-    val compiledProp1 = compile(env, "s.isProven").asBoolValue
-    val compiledProp2 = compile(env, "proveDHTuple(g, h, u, v).isProven").asBoolValue
+    val compiledProp1 = compileWithCosting(env, "s.isProven").asBoolValue
+    val compiledProp2 = compileWithCosting(env, "proveDHTuple(g, h, u, v).isProven").asBoolValue
     compiledProp1 shouldBe prop
     compiledProp2 shouldBe prop
 

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -51,8 +51,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val ci = secret.commonInput
 
-    val prop = SigmaPropConstant(ProveDHTuple(ci.g, ci.h, ci.u, ci.v)).isProven
-    val wrongProp = SigmaPropConstant(ProveDHTuple(ci.g, ci.h, ci.u, ci.u)).isProven
+    val prop = SigmaPropConstant(ProveDHTuple(ci.g, ci.h, ci.u, ci.v))
+    val wrongProp = SigmaPropConstant(ProveDHTuple(ci.g, ci.h, ci.u, ci.u))
 
     val env = Map("g" -> ci.g, "h" -> ci.h, "u" -> ci.u, "v" -> ci.v, "s" -> secret.publicImage)
     val compiledProp1 = compileWithCosting(env, "s.isProven").asBoolValue
@@ -69,11 +69,11 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val pr = prover.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage).get._1 shouldBe true
+    val pr = prover.prove(prop.isProven, ctx, fakeMessage).get
+    verifier.verify(prop.isProven, ctx, pr, fakeMessage).get._1 shouldBe true
 
-    fakeProver.prove(prop, ctx, fakeMessage).isSuccess shouldBe false
-    prover.prove(wrongProp, ctx, fakeMessage).isSuccess shouldBe false
+    fakeProver.prove(prop.isProven, ctx, fakeMessage).isSuccess shouldBe false
+    prover.prove(wrongProp.isProven, ctx, fakeMessage).isSuccess shouldBe false
   }
 
   property("DH tuple - simulation") {

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -31,8 +31,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val ctx = ErgoLikeContext.dummy(fakeSelf)
 
-    val e = compile(Map("h1" -> h1.bytes, "h2" -> h2.bytes), "h1 == h1")
-    val exp = EQ(ByteArrayConstant(h1.bytes), ByteArrayConstant(h1.bytes))
+    val e = compileWithCosting(Map("h1" -> h1.bytes, "h2" -> h2.bytes), "h1 == h1")
+    val exp = TrueLeaf
     e shouldBe exp
 
     verifier.reduceToCrypto(ctx, exp)

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -325,16 +325,16 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val regPubkey1 = ErgoBox.nonMandatoryRegisters.head
     val regPubkey2 = ErgoBox.nonMandatoryRegisters.tail.head
 
-    val prop = compile(Map(),
+    val prop = compileWithCosting(Map(),
       """{
         |  val pubkey1 = SELF.R4[GroupElement].get
         |  val pubkey2 = SELF.R5[GroupElement].get
         |  proveDlog(pubkey1) && proveDlog(pubkey2)
         |}""".stripMargin).asBoolValue
 
-    val propTree = BinAnd(
-      ProveDlog(ExtractRegisterAs[SGroupElement.type](Self, regPubkey1).get).isProven,
-      ProveDlog(ExtractRegisterAs[SGroupElement.type](Self, regPubkey2).get).isProven)
+    val propTree = SigmaAnd(
+      ProveDlog(ExtractRegisterAs[SGroupElement.type](Self, regPubkey1).get),
+      ProveDlog(ExtractRegisterAs[SGroupElement.type](Self, regPubkey2).get))
     prop shouldBe propTree
 
     val newBox1 = ErgoBox(10, pubkey3, 0)

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -87,9 +87,9 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val pubdhB = proverB.dhSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubdhB" -> pubdhB)
-    val compiledProp = compile(env, """pubkeyA || pubdhB""")
+    val compiledProp = compileWithCosting(env, """pubkeyA || pubdhB""").asBoolValue
 
-    val prop = BinOr(pubkeyA.isProven, pubdhB.isProven)
+    val prop = SigmaOr(pubkeyA, pubdhB)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -100,8 +100,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
   }
 
   property("DH tuple and DLOG") {
@@ -114,9 +114,9 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val pubdhA = proverA.dhSecrets.head.publicImage
 
     val env = Map("pubkeyA" -> pubkeyA, "pubdhA" -> pubdhA)
-    val compiledProp = compile(env, """pubkeyA && pubdhA""")
+    val compiledProp = compileWithCosting(env, """pubkeyA && pubdhA""").asBoolValue
 
-    val prop = BinAnd(pubkeyA.isProven, pubdhA.isProven)
+    val prop = SigmaAnd(pubkeyA, pubdhA)
     compiledProp shouldBe prop
 
     val ctx = ErgoLikeContext(
@@ -127,11 +127,11 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       spendingTransaction = null,
       self = fakeSelf)
 
-    val prA = proverA.prove(prop, ctx, fakeMessage).get
+    val prA = proverA.prove(compiledProp, ctx, fakeMessage).get
 
-    verifier.verify(prop, ctx, prA, fakeMessage).get._1 shouldBe true
+    verifier.verify(compiledProp, ctx, prA, fakeMessage).get._1 shouldBe true
 
-    proverB.prove(prop, ctx, fakeMessage).isSuccess shouldBe false
+    proverB.prove(compiledProp, ctx, fakeMessage).isSuccess shouldBe false
   }
 
   ignore("mixing scenario w. timeout") {  // TODO Cost of the folded function depends on data

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -254,9 +254,9 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val pubkey = prover.dlogSecrets.head.publicImage
 
     val env = Map("pubkey" -> pubkey)
-    val compiledProp = compile(env, """pubkey && OUTPUTS(0).value > 10""")
+    val compiledProp = compileWithCosting(env, """pubkey && OUTPUTS(0).value > 10""").asBoolValue
 
-    val prop = BinAnd(pubkey.isProven, GT(ExtractAmount(ByIndex(Outputs, 0)), LongConstant(10)))
+    val prop = SigmaAnd(pubkey, BoolToSigmaProp(GT(ExtractAmount(ByIndex(Outputs, 0)), LongConstant(10))))
     compiledProp shouldBe prop
 
     val newBox1 = ErgoBox(11, pubkey, 0)
@@ -273,8 +273,8 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       spendingTransaction,
       self = fakeSelf)
 
-    val pr = prover.prove(prop, ctx, fakeMessage).get
-    verifier.verify(prop, ctx, pr, fakeMessage)
+    val pr = prover.prove(compiledProp, ctx, fakeMessage).get
+    verifier.verify(compiledProp, ctx, pr, fakeMessage)
 
 
     val fProp1 = AND(pubkey, GT(ExtractAmount(ByIndex(Outputs, 0)), LongConstant(11)))

--- a/src/test/scala/sigmastate/utxo/SigmaCompilerSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SigmaCompilerSpecification.scala
@@ -9,12 +9,13 @@ import sigmastate.lang.Terms._
   * Specification for compile function
   */
 class SigmaCompilerSpecification extends SigmaTestingCommons {
+  implicit lazy val IR = new TestingIRContext
 
   property(">= compile") {
     val elementId = 1: Byte
     val env = Map("elementId" -> elementId)
     val propTree = GE(GetVarInt(elementId).get, IntConstant(120))
-    val propComp = compile(env,
+    val propComp = compileWithCosting(env,
       """{
         |  getVar[Int](elementId).get >= 120
         |}""".stripMargin).asBoolValue

--- a/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
@@ -2,7 +2,7 @@ package sigmastate.utxo
 
 import org.ergoplatform.ErgoLikeContext
 import scapi.sigma.DLogProtocol.{DLogProverInput, ProveDlog}
-import sigmastate.Values.{BlockValue, ConcreteCollection, FalseLeaf, SigmaBoolean, SigmaPropConstant, SigmaPropValue, TrueLeaf, ValDef, ValUse, Value}
+import sigmastate.Values.{BlockValue, ConcreteCollection, FalseLeaf, IntConstant, SigmaBoolean, SigmaPropConstant, SigmaPropValue, TrueLeaf, ValDef, ValUse, Value}
 import sigmastate._
 import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, SigmaTestingCommons}
 import sigmastate.lang.Terms._
@@ -56,10 +56,8 @@ class ThresholdSpecification extends SigmaTestingCommons {
         |}""".stripMargin).asBoolValue
 
 
-    val prop2 = BlockValue(
-      Vector(ValDef(1, ConcreteCollection(Vector[SigmaPropValue](pubkeyA, pubkeyB, pubkeyC), SSigmaProp))),
-      AtLeast(SizeOf(ValUse(1, SCollection(SSigmaProp))), ValUse(1, SCollection(SSigmaProp)))
-    )
+    val prop2 = AtLeast(IntConstant(3),
+      ConcreteCollection(Vector[SigmaPropValue](pubkeyA, pubkeyB, pubkeyC), SSigmaProp))
     compiledProp2 shouldBe prop2
 
     val proof = proverABC.prove(compiledProp2, ctx, fakeMessage).get

--- a/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ThresholdSpecification.scala
@@ -342,12 +342,12 @@ class ThresholdSpecification extends SigmaTestingCommons {
     val verifier = new ErgoLikeTestInterpreter
 
     def canProve(prover: ErgoLikeTestProvingInterpreter, proposition: SigmaPropValue): Unit = {
-      val proof = prover.prove(proposition.isValid, ctx, fakeMessage).get
-      verifier.verify(proposition.isValid, ctx, proof, fakeMessage).get._1 shouldBe true
+      val proof = prover.prove(proposition.isProven, ctx, fakeMessage).get
+      verifier.verify(proposition.isProven, ctx, proof, fakeMessage).get._1 shouldBe true
     }
 
     def cannotProve(prover: ErgoLikeTestProvingInterpreter, proposition: SigmaPropValue): Unit = {
-      prover.prove(proposition.isValid, ctx, fakeMessage).isFailure shouldBe true
+      prover.prove(proposition.isProven, ctx, fakeMessage).isFailure shouldBe true
     }
 
 

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -92,7 +92,7 @@ class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
       "fixedRate" -> s.fixedRate,
       "oneEpochReduction" -> s.oneEpochReduction)
 
-    val prop1 = compile(env,
+    val prop1 = compileWithCosting(env,
       """{
         |    val epoch = 1 + ((HEIGHT - fixedRatePeriod) / epochLength)
         |    val out = OUTPUTS(0)

--- a/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
@@ -116,7 +116,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       "pubkeyConstr3" -> constructionRing(2)
     )
 
-     val spendingProp1 = compile(spendingEnv,
+     val spendingProp1 = compileWithCosting(spendingEnv,
       s"""
          |{
          | val spendingSuccess = (pubkeyTool1 || pubkeyTool2 || pubkeyTool3 || pubkeyTool4) && businessKey
@@ -153,7 +153,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       "pubkeyConstr3" -> constructionRing(2)
     )
 
-    val spendingProp2 = compile(spendingEnv2,
+    val spendingProp2 = compileWithCosting(spendingEnv2,
       s"""
          |{
          | val spendingSuccess = (pubkeyTool1 || pubkeyTool2 || pubkeyTool3 || pubkeyTool4) && businessKey
@@ -205,7 +205,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
     }
 
 
-    val spendingProp3 = compile(spendingEnv,
+    val spendingProp3 = compileWithCosting(spendingEnv,
       s"""
          | {
          |
@@ -246,7 +246,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       "pubkeyConstr3" -> SBoolean.mkConstant(false)
     )
 
-    val spendingProp4 = compile(spendingEnv3,
+    val spendingProp4 = compileWithCosting(spendingEnv3,
       s"""
          | {
          |
@@ -269,7 +269,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       successProofTest(spendingProp4, ctx, coopA, verifier)
     }
 
-    val spendingProp5 = compile(spendingEnv, "businessKey").asBoolValue
+    val spendingProp5 = compileWithCosting(spendingEnv, "businessKey").asBoolValue
 
     {
       val self = ErgoBox(totalValue, spendingProp5, 0)
@@ -293,7 +293,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
     )
 
     // Basic compilation
-    val thresholdProp = compile(thresholdEnv,
+    val thresholdProp = compileWithCosting(thresholdEnv,
       s""" {
          | val votingSuccess = atLeast(3, Coll(pubkeyA, pubkeyB, pubkeyC, pubkeyD))
          | val properSpending = OUTPUTS(0).value >= ${toolValue}L &&
@@ -362,7 +362,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       "pubkeyA" -> pubkeyA
     )
 
-    val inputProp = compile(inputEnv,
+    val inputProp = compileWithCosting(inputEnv,
       s"""(OUTPUTS(0).value == $totalValue && blake2b256(OUTPUTS(0).propositionBytes) == thresholdProp) ||
          | (HEIGHT > 1000 && pubkeyA)
        """.stripMargin).asBoolValue

--- a/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CrowdfundingExampleSpecification.scala
@@ -67,15 +67,14 @@ class CrowdfundingExampleSpecification extends SigmaTestingCommons {
         SigmaAnd(List(
           BoolToSigmaProp(AND(ConcreteCollection(Vector(
             LT(Height, LongConstant(100)),
-            OR(
-              MapCollection(Outputs,
-                FuncValue(Vector((2, SBox)),
-                  BinAnd(
-                    GE(ExtractAmount(ValUse(2, SBox)), LongConstant(1000)),
-                    EQ(ExtractScriptBytes(ValUse(2, SBox)), SigmaPropBytes(ValUse(1, SSigmaProp)))
-                  )
+            Exists(Outputs,
+              FuncValue(Vector((2, SBox)),
+                BinAnd(
+                  GE(ExtractAmount(ValUse(2, SBox)), LongConstant(1000)),
+                  EQ(ExtractScriptBytes(ValUse(2, SBox)), SigmaPropBytes(ValUse(1, SSigmaProp)))
                 )
-              ).asCollection[SBoolean.type])
+              )
+            )
           ), SBoolean))),
           ValUse(1, SSigmaProp)))
       ))

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -56,7 +56,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     )
 
     //todo: add condition on
-    val prop = compile(env,
+    val prop = compileWithCosting(env,
       """{
         | val outIdx = getVar[Short](127).get
         | val out = OUTPUTS(outIdx)


### PR DESCRIPTION
Close #314
Close #294 

Todo:
- [x] remove `SigmaSpecializer.specialize` from `compileWithCosting`;
- [x] make `AtLeast` to operate on SigmaProps;
- [x] look into failing `anyOf(Col(pubkeyA, pubkeyB, HEIGHT > 500))` ComplexSigSpec test (re-arranged args); 
- [x] switch tests(mostly);
- [x] `CostingBox` leaking through the `TreeBuilding`;

