### PR TITLE
Error-reporting in ErgoScript (compilation/runtime)

### DIFF
--- a/sigma-impl/src/main/scala/sigma/util/Extensions.scala
+++ b/sigma-impl/src/main/scala/sigma/util/Extensions.scala
@@ -5,6 +5,15 @@ import java.nio.ByteBuffer
 import special.collection.{Coll, Builder}
 import com.google.common.primitives.Ints
 
+import scalan.Nullable
+import sigmastate.SType
+import sigmastate.Values.{SValue, Value}
+import sigmastate.serialization.{TypeSerializer, ValueSerializer}
+
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+
 object Extensions {
   implicit class BooleanOps(val b: Boolean) extends AnyVal {
     /** Convert true to 1 and false to 0
@@ -232,4 +241,8 @@ object Extensions {
     }
   }
 
+  implicit def nullableToOption[A](nullable: Nullable[A]): Option[A] = nullable match {
+    case Nullable(v) => Some(v)
+    case _ => None
+  }
 }

--- a/sigma-impl/src/main/scala/sigma/util/Extensions.scala
+++ b/sigma-impl/src/main/scala/sigma/util/Extensions.scala
@@ -236,8 +236,10 @@ object Extensions {
     }
   }
 
-  implicit def nullableToOption[A](nullable: Nullable[A]): Option[A] = nullable match {
-    case Nullable(v) => Some(v)
-    case _ => None
+  implicit class NullableOps[T](val nul: Nullable[T]) {
+    def toOption: Option[T] = nul match {
+      case Nullable(v) => Some(v)
+      case _ => None
+    }
   }
 }

--- a/sigma-impl/src/main/scala/sigma/util/Extensions.scala
+++ b/sigma-impl/src/main/scala/sigma/util/Extensions.scala
@@ -6,13 +6,8 @@ import special.collection.{Coll, Builder}
 import com.google.common.primitives.Ints
 
 import scalan.Nullable
-import sigmastate.SType
-import sigmastate.Values.{SValue, Value}
-import sigmastate.serialization.{TypeSerializer, ValueSerializer}
 
-import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
-import scala.reflect.ClassTag
 
 object Extensions {
   implicit class BooleanOps(val b: Boolean) extends AnyVal {

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -80,7 +80,14 @@ object Values {
     * This property will not participate in equality and other operations, so will be invisible for existing code.
     * But Builder can use it to set sourceContext if it is present.
     */
-    def sourceContext: Nullable[SourceContext] = Nullable.None
+    private[sigmastate] var _sourceContext: Nullable[SourceContext] = Nullable.None
+    def sourceContext: Nullable[SourceContext] = _sourceContext
+    def sourceContext_=(srcCtx: Nullable[SourceContext]): Unit =
+      if (_sourceContext.isEmpty) {
+        _sourceContext = srcCtx
+      } else {
+        sys.error("_sourceContext can be set only once")
+      }
   }
 
   trait ValueCompanion extends SigmaNodeCompanion {

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -1,20 +1,21 @@
 package sigmastate
 
 import java.math.BigInteger
-import java.util.{Objects, Arrays}
+import java.util.{Arrays, Objects}
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
-import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{strategy, everywherebu}
+import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{everywherebu, strategy}
 import org.bouncycastle.math.ec.ECPoint
-import org.ergoplatform.{ErgoLikeContext, ErgoBox}
+import org.ergoplatform.{ErgoBox, ErgoLikeContext}
+import scalan.Nullable
 import scorex.crypto.authds.SerializedAdProof
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
-import scorex.crypto.hash.{Digest32, Blake2b256}
+import scorex.crypto.hash.{Blake2b256, Digest32}
 import scalan.util.CollectionUtil._
 import sigmastate.SCollection.SByteArray
 import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate.interpreter.{Context, CryptoConstants, CryptoFunctions}
-import sigmastate.serialization.{ValueSerializer, ErgoTreeSerializer, OpCodes, ConstantStore}
+import sigmastate.serialization.{ConstantStore, ErgoTreeSerializer, OpCodes, ValueSerializer}
 import sigmastate.serialization.OpCodes._
 import sigmastate.utxo.CostTable.Cost
 import sigma.util.Extensions._
@@ -27,6 +28,7 @@ import scala.reflect.ClassTag
 import sigmastate.lang.DefaultSigmaBuilder._
 import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 import special.sigma.{Extensions, AnyValue, TestValue}
+import sigmastate.lang.SourceContext
 
 
 object Values {
@@ -63,6 +65,8 @@ object Values {
     def opName: String = this.getClass.getSimpleName
 
     def opId: OperationId = OperationId(opName, opType)
+
+    def sourceContext: Nullable[SourceContext] = Nullable.None
   }
 
   trait ValueCompanion extends SigmaNodeCompanion {

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -197,7 +197,7 @@ object Values {
       TaggedVariableNode(varId, tpe)
   }
 
-  case object UnitConstant extends EvaluatedValue[SUnit.type] {
+  case class UnitConstant() extends EvaluatedValue[SUnit.type] {
     override val opCode = UnitConstantCode
     override def tpe = SUnit
     val value = ()

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -66,6 +66,20 @@ object Values {
 
     def opId: OperationId = OperationId(opName, opType)
 
+    /** Parser has some source information like line,column in the text. We need to keep it up until RuntimeCosting.
+    * The way to do this is to add Nullable property to every Value. Since Parser is always using SigmaBuilder
+    * to create nodes,
+    * Adding additional (implicit source: SourceContext) parameter to every builder method would pollute its API
+    * and also doesn't make sence during deserialization, where Builder is also used.
+    * We can assume some indirect mechanism to pass current source context into every mkXXX method of Builder.
+    * We can pass it using `scala.util.DynamicVariable` by wrapping each mkXXX call into `withValue { }` calls.
+    * The same will happen in Typer.
+    * We can take sourceContext from untyped nodes and use it while creating typed nodes.
+    * And we can make sourceContext of every Value writeOnce value, i.e. it will be Nullable.Null by default,
+    * but can be set afterwards, but only once.
+    * This property will not participate in equality and other operations, so will be invisible for existing code.
+    * But Builder can use it to set sourceContext if it is present.
+    */
     def sourceContext: Nullable[SourceContext] = Nullable.None
   }
 

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -16,6 +16,7 @@ import sigmastate.Values.Value.Typed
 import sigmastate.basics.{DLogProtocol, ProveDHTuple}
 import sigmastate.lang.SigmaSpecializer.error
 import sigmastate.lang.{Terms, TransformingSigmaBuilder}
+import sigma.util.Extensions.nullableToOption
 
 trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
   import builder._
@@ -37,7 +38,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
         if (obj.tpe.isCollectionLike)
           eval(mkSizeOf(obj.asValue[SCollection[SType]]))
         else
-          error(s"The type of $obj is expected to be Collection to select 'size' property")
+          error(s"The type of $obj is expected to be Collection to select 'size' property", obj.sourceContext)
 
       // Rule: proof.isProven --> IsValid(proof)
       case Select(p, SSigmaProp.IsProven, _) if p.tpe == SSigmaProp =>
@@ -50,7 +51,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
       // box.R$i[valType] =>
       case sel @ Select(Typed(box, SBox), regName, Some(SOption(valType))) if regName.startsWith("R") =>
         val reg = ErgoBox.registerByName.getOrElse(regName,
-          error(s"Invalid register name $regName in expression $sel"))
+          error(s"Invalid register name $regName in expression $sel", sel.sourceContext))
         eval(mkExtractRegisterAs(box.asBox, reg, SOption(valType)).asValue[SOption[valType.type]])
 
       // col.getOrElse(i, default) =>
@@ -79,7 +80,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
           case (box, SBox.Bytes) => eval(mkExtractBytes(box))
           case (box, SBox.BytesWithNoRef) => eval(mkExtractBytesWithNoRef(box))
           case (box, SBox.CreationInfo) => eval(mkExtractCreationInfo(box))
-          case _ => error(s"Invalid access to Box property in $sel: field $field is not found")
+          case _ => error(s"Invalid access to Box property in $sel: field $field is not found", sel.sourceContext)
         }
 
       case Select(obj: SigmaBoolean, field, _) =>

--- a/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -16,7 +16,7 @@ import sigmastate.Values.Value.Typed
 import sigmastate.basics.{DLogProtocol, ProveDHTuple}
 import sigmastate.lang.SigmaSpecializer.error
 import sigmastate.lang.{Terms, TransformingSigmaBuilder}
-import sigma.util.Extensions.nullableToOption
+import sigma.util.Extensions._
 
 trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
   import builder._
@@ -38,7 +38,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
         if (obj.tpe.isCollectionLike)
           eval(mkSizeOf(obj.asValue[SCollection[SType]]))
         else
-          error(s"The type of $obj is expected to be Collection to select 'size' property", obj.sourceContext)
+          error(s"The type of $obj is expected to be Collection to select 'size' property", obj.sourceContext.toOption)
 
       // Rule: proof.isProven --> IsValid(proof)
       case Select(p, SSigmaProp.IsProven, _) if p.tpe == SSigmaProp =>
@@ -51,7 +51,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
       // box.R$i[valType] =>
       case sel @ Select(Typed(box, SBox), regName, Some(SOption(valType))) if regName.startsWith("R") =>
         val reg = ErgoBox.registerByName.getOrElse(regName,
-          error(s"Invalid register name $regName in expression $sel", sel.sourceContext))
+          error(s"Invalid register name $regName in expression $sel", sel.sourceContext.toOption))
         eval(mkExtractRegisterAs(box.asBox, reg, SOption(valType)).asValue[SOption[valType.type]])
 
       // col.getOrElse(i, default) =>
@@ -80,7 +80,7 @@ trait CompiletimeCosting extends RuntimeCosting { IR: Evaluation =>
           case (box, SBox.Bytes) => eval(mkExtractBytes(box))
           case (box, SBox.BytesWithNoRef) => eval(mkExtractBytesWithNoRef(box))
           case (box, SBox.CreationInfo) => eval(mkExtractCreationInfo(box))
-          case _ => error(s"Invalid access to Box property in $sel: field $field is not found", sel.sourceContext)
+          case _ => error(s"Invalid access to Box property in $sel: field $field is not found", sel.sourceContext.toOption)
         }
 
       case Select(obj: SigmaBoolean, field, _) =>

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -21,7 +21,7 @@ import scalan.compilation.GraphVizConfig
 import SType._
 import scorex.crypto.hash.{Sha256, Blake2b256}
 import sigmastate.interpreter.Interpreter.ScriptEnv
-import sigmastate.lang.Terms
+import sigmastate.lang.{SourceContext, Terms}
 import scalan.staged.Slicing
 import sigmastate.basics.{ProveDHTuple, DLogProtocol}
 import special.sigma.TestGroupElement
@@ -1004,8 +1004,8 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
 
       case Terms.Block(binds, res) =>
         var curEnv = env
-        for (Val(n, _, b) <- binds) {
-          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
+        for (Val(n, _, b, Nullable(srcCtx)) <- binds) {
+          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", srcCtx)
           val bC = evalNode(ctx, curEnv, b)
           curEnv = curEnv + (n -> bC)
         }
@@ -1554,4 +1554,5 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
   }
 
   def error(msg: String) = throw new CosterException(msg, None)
+  def error(msg: String, srcCtx: SourceContext) = throw new CosterException(msg, Some(srcCtx))
 }

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -16,7 +16,7 @@ import sigmastate.lang.exceptions.CosterException
 import sigmastate.serialization.OpCodes
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utxo._
-import sigma.util.Extensions.nullableToOption
+import sigma.util.Extensions._
 import ErgoLikeContext._
 import scalan.compilation.GraphVizConfig
 import SType._
@@ -1006,7 +1006,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
       case Terms.Block(binds, res) =>
         var curEnv = env
         for (v @ Val(n, _, b) <- binds) {
-          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", v.sourceContext)
+          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", v.sourceContext.toOption)
           val bC = evalNode(ctx, curEnv, b)
           curEnv = curEnv + (n -> bC)
         }
@@ -1016,7 +1016,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
       case BlockValue(binds, res) =>
         var curEnv = env
         for (vd @ ValDef(n, _, b) <- binds) {
-          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", vd.sourceContext)
+          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", vd.sourceContext.toOption)
           val bC = evalNode(ctx, curEnv, b)
           curEnv = curEnv + (n -> bC)
         }
@@ -1233,7 +1233,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         }
 
       case opt: OptionValue[_] =>
-        error(s"Option constructors are not supported: $opt", opt.sourceContext)
+        error(s"Option constructors are not supported: $opt", opt.sourceContext.toOption)
 
       case CalcBlake2b256(In(input)) =>
         val bytesC = asRep[Costed[Coll[Byte]]](input)
@@ -1321,7 +1321,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         if (inputC.values.length.isConst) {
           val inputCount = inputC.values.length.asValue
           if (inputCount > AtLeast.MaxChildrenCount)
-            error(s"Expected input elements count should not exceed ${AtLeast.MaxChildrenCount}, actual: $inputCount", node.sourceContext)
+            error(s"Expected input elements count should not exceed ${AtLeast.MaxChildrenCount}, actual: $inputCount", node.sourceContext.toOption)
         }
         val boundC = eval(bound)
         val res = sigmaDslBuilder.atLeast(boundC.value, asRep[Coll[SigmaProp]](inputC.values))
@@ -1350,7 +1350,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
             v = xC.value.min(yC.value)
           case MaxCode =>
             v = xC.value.max(yC.value)
-          case code => error(s"Cannot perform Costing.evalNode($op): unknown opCode ${code}", op.sourceContext)
+          case code => error(s"Cannot perform Costing.evalNode($op): unknown opCode ${code}", op.sourceContext.toOption)
         }
         val c = xC.cost + yC.cost + costOf(op)
         RCCostedPrim(v, c, s)
@@ -1532,7 +1532,7 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
         withDefaultSize(res, costOf(node))
 
       case _ =>
-        error(s"Don't know how to evalNode($node)", node.sourceContext)
+        error(s"Don't know how to evalNode($node)", node.sourceContext.toOption)
     }
     val resC = asRep[Costed[T#WrappedType]](res)
     onTreeNodeCosted(ctx, env, node, resC)

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -16,7 +16,7 @@ import sigmastate.lang.exceptions.CosterException
 import sigmastate.serialization.OpCodes
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utxo._
-import sigmastate.utils.Extensions.nullableToOption
+import sigma.util.Extensions.nullableToOption
 import ErgoLikeContext._
 import scalan.compilation.GraphVizConfig
 import SType._

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -16,6 +16,7 @@ import sigmastate.lang.exceptions.CosterException
 import sigmastate.serialization.OpCodes
 import sigmastate.utxo.CostTable.Cost
 import sigmastate.utxo._
+import sigmastate.utils.Extensions.nullableToOption
 import ErgoLikeContext._
 import scalan.compilation.GraphVizConfig
 import SType._
@@ -1004,8 +1005,8 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
 
       case Terms.Block(binds, res) =>
         var curEnv = env
-        for (Val(n, _, b, Nullable(srcCtx)) <- binds) {
-          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", srcCtx)
+        for (v @ Val(n, _, b) <- binds) {
+          if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", v.sourceContext)
           val bC = evalNode(ctx, curEnv, b)
           curEnv = curEnv + (n -> bC)
         }
@@ -1554,5 +1555,5 @@ trait RuntimeCosting extends SigmaLibrary with DataCosting with Slicing { IR: Ev
   }
 
   def error(msg: String) = throw new CosterException(msg, None)
-  def error(msg: String, srcCtx: SourceContext) = throw new CosterException(msg, Some(srcCtx))
+  def error(msg: String, srcCtx: Option[SourceContext]) = throw new CosterException(msg, srcCtx)
 }

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -12,7 +12,7 @@ import sigmastate.interpreter.Interpreter.ScriptEnv
 import sigmastate.lang.SigmaPredef.PredefinedFuncRegistry
 import sigmastate.lang.Terms._
 import sigmastate.lang.exceptions.{BinderException, InvalidArguments}
-import sigmastate.utils.Extensions._
+import sigma.util.Extensions._
 
 object SrcCtxCallbackRewriter extends CallbackRewriter {
   override def rewriting[T](oldTerm: T, newTerm: T): T = (oldTerm, newTerm) match {

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -37,12 +37,12 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
   private val PKFunc = predefFuncRegistry.PKFunc(networkPrefix)
 
   /**
-    * Set source context to all nodes missing it in the given tree
+    * Set source context to all nodes missing source context in the given tree.
     * @param tree AST to traverse
     * @param srcCtx source context to set
     * @return AST where all nodes with missing source context are set to the given srcCtx
     */
-  def propagateSrcCtx(tree: SValue, srcCtx: Nullable[SourceContext]): SValue = {
+  private def propagateSrcCtx(tree: SValue, srcCtx: Nullable[SourceContext]): SValue = {
     import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
     rewrite(everywherebu(rule[SValue] {
       case node if node.sourceContext.isEmpty =>

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -36,25 +36,11 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
 
   private val PKFunc = predefFuncRegistry.PKFunc(networkPrefix)
 
-  /**
-    * Set source context to all nodes missing source context in the given tree.
-    * @param tree AST to traverse
-    * @param srcCtx source context to set
-    * @return AST where all nodes with missing source context are set to the given srcCtx
-    */
-  private def propagateSrcCtx(tree: SValue, srcCtx: Nullable[SourceContext]): SValue = {
-    import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
-    rewrite(everywherebu(rule[SValue] {
-      case node if node.sourceContext.isEmpty =>
-        node.withSrcCtx(srcCtx)
-    }))(tree)
-  }
-
   /** Rewriting of AST with respect to environment to resolve all references to global names
     * and infer their types. */
   private def eval(e: SValue, env: ScriptEnv): SValue = rewrite(reduce(strategy[SValue]({
     case i @ Ident(n, NoType) => env.get(n) match {
-      case Some(v) => Option(propagateSrcCtx(liftAny(v).get, i.sourceContext))
+      case Some(v) => Option(liftAny(v).get.withPropagatedSrcCtx(i.sourceContext))
       case None => n match {
         case "HEIGHT" => Some(Height)
         case "MinerPubkey" => Some(MinerPubkey)
@@ -91,7 +77,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
     // Rule: min(x, y) -->
     case Apply(i @ Ident("min", _), args) => args match {
       case Seq(l: SValue, r: SValue) =>
-        builder.currentSrcCtx.withValue(i.sourceContext) { Some(mkMin(l.asNumValue, r.asNumValue)) }
+        Some(mkMin(l.asNumValue, r.asNumValue))
       case _ =>
         throw new InvalidArguments(s"Invalid arguments for min: $args", i.sourceContext)
     }
@@ -99,7 +85,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
     // Rule: max(x, y) -->
     case Apply(i @ Ident("max", _), args) => args match {
       case Seq(l: SValue, r: SValue) =>
-        builder.currentSrcCtx.withValue(i.sourceContext) { Some(mkMax(l.asNumValue, r.asNumValue)) }
+        Some(mkMax(l.asNumValue, r.asNumValue))
       case _ =>
         throw new InvalidArguments(s"Invalid arguments for max: $args", i.sourceContext)
     }
@@ -129,8 +115,8 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
       else
         None
 
-    case Apply(PKFunc.symNoType, args) =>
-      Some(PKFunc.irBuilder(PKFunc.sym, args))
+    case a @ Apply(PKFunc.symNoType, args) =>
+      Some(PKFunc.irBuilder(PKFunc.sym, args).withPropagatedSrcCtx(a.sourceContext))
 
   })))(e)
 

--- a/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -79,7 +79,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
       case Seq(l: SValue, r: SValue) =>
         Some(mkMin(l.asNumValue, r.asNumValue))
       case _ =>
-        throw new InvalidArguments(s"Invalid arguments for min: $args", i.sourceContext)
+        throw new InvalidArguments(s"Invalid arguments for min: $args", i.sourceContext.toOption)
     }
 
     // Rule: max(x, y) -->
@@ -87,7 +87,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
       case Seq(l: SValue, r: SValue) =>
         Some(mkMax(l.asNumValue, r.asNumValue))
       case _ =>
-        throw new InvalidArguments(s"Invalid arguments for max: $args", i.sourceContext)
+        throw new InvalidArguments(s"Invalid arguments for max: $args", i.sourceContext.toOption)
     }
 
     // Rule: lambda (...) = ... --> lambda (...): T = ...
@@ -126,5 +126,5 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
 }
 
 object SigmaBinder {
-  def error(msg: String, srcCtx: Option[SourceContext]) = throw new BinderException(msg, srcCtx)
+  def error(msg: String, srcCtx: Nullable[SourceContext]) = throw new BinderException(msg, srcCtx.toOption)
 }

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -5,7 +5,7 @@ import java.math.BigInteger
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.ErgoBox.RegisterId
 import sigmastate.SCollection.SByteArray
-import sigmastate.Values.{StringConstant, FuncValue, FalseLeaf, Constant, SValue, TrueLeaf, BlockValue, ConstantNode, SomeValue, ConstantPlaceholder, BigIntValue, BoolValue, Value, SigmaPropValue, Tuple, GroupElementValue, TaggedVariableNode, SigmaBoolean, BlockItem, ValUse, TaggedVariable, ConcreteCollection, NoneValue}
+import sigmastate.Values.{StringConstant, FuncValue, FalseLeaf, Constant, SValue, TrueLeaf, BlockValue, ConstantNode, SomeValue, ConstantPlaceholder, BigIntValue, BoolValue, Value, SigmaPropValue, Tuple, GroupElementValue, TaggedVariableNode, SigmaBoolean, BlockItem, UnitConstant, ValUse, TaggedVariable, ConcreteCollection, NoneValue}
 import sigmastate._
 import sigmastate.interpreter.CryptoConstants
 import sigmastate.lang.Constraints.{TypeConstraint2, sameType2, onlyNumeric2}
@@ -207,6 +207,8 @@ trait SigmaBuilder {
   def mkBitShiftLeft[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T]
   def mkBitShiftRightZeroed[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T]
 
+  def mkUnitConstant: Value[SUnit.type]
+
   def liftAny(v: Any): Nullable[SValue] = v match {
     case arr: Array[Boolean] => Nullable(mkCollectionConstant[SBoolean.type](arr, SBoolean))
     case arr: Array[Byte] => Nullable(mkCollectionConstant[SByte.type](arr, SByte))
@@ -281,25 +283,25 @@ class StdSigmaBuilder extends SigmaBuilder {
       .withSrcCtx(currentSrcCtx.value)
 
   override def mkPlus[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.PlusCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.PlusCode)
 
   override def mkMinus[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MinusCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.MinusCode)
 
   override def mkMultiply[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MultiplyCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.MultiplyCode)
 
   override def mkDivide[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.DivisionCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.DivisionCode)
 
   override def mkModulo[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.ModuloCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.ModuloCode)
 
   override def mkMin[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MinCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.MinCode)
 
   override def mkMax[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MaxCode).withSrcCtx(currentSrcCtx.value)
+    mkArith(left, right, OpCodes.MaxCode)
 
   override def mkOR(input: Value[SCollection[SBoolean.type]]): Value[SBoolean.type] =
     OR(input).withSrcCtx(currentSrcCtx.value)
@@ -515,7 +517,8 @@ class StdSigmaBuilder extends SigmaBuilder {
                         resType: Option[SType] = None): Value[SType] =
     Select(obj, field, resType).withSrcCtx(currentSrcCtx.value)
 
-  override def mkIdent(name: String, tpe: SType): Value[SType] = Ident(name, tpe)
+  override def mkIdent(name: String, tpe: SType): Value[SType] =
+    Ident(name, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType] =
     Apply(func, args).withSrcCtx(currentSrcCtx.value)
@@ -607,6 +610,8 @@ class StdSigmaBuilder extends SigmaBuilder {
 
   override def mkBitShiftRightZeroed[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T] =
     BitOp(bits, shift, OpCodes.BitShiftRightZeroedCode).withSrcCtx(currentSrcCtx.value)
+
+  override def mkUnitConstant: Value[SUnit.type] = UnitConstant().withSrcCtx(currentSrcCtx.value)
 }
 
 trait TypeConstraintCheck {

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -21,7 +21,11 @@ import sigmastate.eval.CostingSigmaDslBuilder
 import sigmastate.interpreter.CryptoConstants.EcPointType
 import special.sigma.{GroupElement, SigmaProp}
 
+import scala.util.DynamicVariable
+
 trait SigmaBuilder {
+
+  val currentSrcCtx = new DynamicVariable[Nullable[SourceContext]](Nullable.None)
 
   def mkEQ[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type]
   def mkNEQ[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type]
@@ -159,7 +163,7 @@ trait SigmaBuilder {
   def mkBlockValue(items: IndexedSeq[BlockItem], result: Value[SType]): Value[SType]
   def mkValUse(valId: Int, tpe: SType): Value[SType]
   def mkZKProofBlock(body: Value[SSigmaProp.type]): Value[SBoolean.type]
-  def mkVal(name: String, givenType: SType, body: Value[SType], srcCtx: SourceContext): Val
+  def mkVal(name: String, givenType: SType, body: Value[SType]): Val
   def mkSelect(obj: Value[SType], field: String, resType: Option[SType] = None): Value[SType]
   def mkIdent(name: String, tpe: SType): Value[SType]
   def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType]
@@ -490,8 +494,11 @@ class StdSigmaBuilder extends SigmaBuilder {
 
   override def mkVal(name: String,
                      givenType: SType,
-                     body: Value[SType], srcCtx: SourceContext): Val =
-    ValNode(name, givenType, body, Nullable(srcCtx))
+                     body: Value[SType]): Val = {
+    val v = ValNode(name, givenType, body)
+    v.sourceContext = currentSrcCtx.value
+    v
+  }
 
   override def mkSelect(obj: Value[SType],
                         field: String,

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -141,8 +141,7 @@ trait SigmaBuilder {
                                 uv: Value[SGroupElement.type],
                                 vv: Value[SGroupElement.type]): SigmaBoolean
   def mkProveDlog(value: Value[SGroupElement.type]): SigmaBoolean
-
-  /** Logically inverse to mkSigmaPropIsProven */
+/** Logically inverse to mkSigmaPropIsProven */
   def mkBoolToSigmaProp(value: BoolValue): SigmaPropValue
   /** Logically inverse to mkBoolToSigmaProp */
   def mkSigmaPropIsProven(value: Value[SSigmaProp.type]): BoolValue
@@ -260,342 +259,354 @@ class StdSigmaBuilder extends SigmaBuilder {
                                             cons: (Value[T], Value[T]) => R): R = cons(left, right)
 
   override def mkEQ[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    equalityOp(left, right, EQ.apply[T])
+    equalityOp(left, right, EQ.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkNEQ[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    equalityOp(left, right, NEQ.apply[T])
+    equalityOp(left, right, NEQ.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkGT[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    comparisonOp(left, right, GT.apply[T])
+    comparisonOp(left, right, GT.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkGE[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    comparisonOp(left, right, GE.apply[T])
+    comparisonOp(left, right, GE.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkLT[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    comparisonOp(left, right, LT.apply[T])
+    comparisonOp(left, right, LT.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkLE[T <: SType](left: Value[T], right: Value[T]): Value[SBoolean.type] =
-    comparisonOp(left, right, LE.apply[T])
+    comparisonOp(left, right, LE.apply[T]).withSrcCtx(currentSrcCtx.value)
 
   override def mkArith[T <: SNumericType](left: Value[T], right: Value[T], opCode: Byte): Value[T] =
     arithOp(left, right, { (l: Value[T], r: Value[T]) => ArithOp[T](l, r, opCode) })
+      .withSrcCtx(currentSrcCtx.value)
 
   override def mkPlus[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.PlusCode)
+    mkArith(left, right, OpCodes.PlusCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkMinus[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MinusCode)
+    mkArith(left, right, OpCodes.MinusCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkMultiply[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MultiplyCode)
+    mkArith(left, right, OpCodes.MultiplyCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkDivide[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.DivisionCode)
+    mkArith(left, right, OpCodes.DivisionCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkModulo[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.ModuloCode)
+    mkArith(left, right, OpCodes.ModuloCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkMin[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MinCode)
+    mkArith(left, right, OpCodes.MinCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkMax[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    mkArith(left, right, OpCodes.MaxCode)
+    mkArith(left, right, OpCodes.MaxCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkOR(input: Value[SCollection[SBoolean.type]]): Value[SBoolean.type] =
-    OR(input)
+    OR(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkAND(input: Value[SCollection[SBoolean.type]]): Value[SBoolean.type] =
-    AND(input)
+    AND(input).withSrcCtx(currentSrcCtx.value)
 
-  override def mkAnyOf(input: Seq[Value[SBoolean.type]]) = OR(input)
-  override def mkAllOf(input: Seq[Value[SBoolean.type]]) = AND(input)
+  override def mkAnyOf(input: Seq[Value[SBoolean.type]]) =
+    OR(input).withSrcCtx(currentSrcCtx.value)
+  override def mkAllOf(input: Seq[Value[SBoolean.type]]) =
+    AND(input).withSrcCtx(currentSrcCtx.value)
 
-  override def mkBinOr(left: BoolValue, right: BoolValue) = BinOr(left, right)
+  override def mkBinOr(left: BoolValue, right: BoolValue) =
+    BinOr(left, right).withSrcCtx(currentSrcCtx.value)
 
-  override def mkBinAnd(left: BoolValue, right: BoolValue) = BinAnd(left, right)
+  override def mkBinAnd(left: BoolValue, right: BoolValue) =
+    BinAnd(left, right).withSrcCtx(currentSrcCtx.value)
 
   override def mkAtLeast(bound: Value[SInt.type], input: Value[SCollection[SSigmaProp.type]]): SigmaPropValue =
-    AtLeast(bound, input)
+    AtLeast(bound, input).withSrcCtx(currentSrcCtx.value)
 
-  override def mkBinXor(left: BoolValue, right: BoolValue): BoolValue = BinXor(left, right)
+  override def mkBinXor(left: BoolValue, right: BoolValue): BoolValue =
+    BinXor(left, right).withSrcCtx(currentSrcCtx.value)
 
   override def mkExponentiate(left: Value[SGroupElement.type], right: Value[SBigInt.type]): Value[SGroupElement.type] =
-    Exponentiate(left, right)
+    Exponentiate(left, right).withSrcCtx(currentSrcCtx.value)
 
   override def mkMultiplyGroup(left: Value[SGroupElement.type], right: Value[SGroupElement.type]): Value[SGroupElement.type] =
-    MultiplyGroup(left, right)
+    MultiplyGroup(left, right).withSrcCtx(currentSrcCtx.value)
 
   override def mkXor(left: Value[SByteArray], right: Value[SByteArray]): Value[SByteArray] =
-    Xor(left, right)
+    Xor(left, right).withSrcCtx(currentSrcCtx.value)
 
   override def mkTreeLookup(tree: Value[SAvlTree.type],
                             key: Value[SByteArray],
                             proof: Value[SByteArray]): Value[SOption[SByteArray]] =
-    TreeLookup(tree, key, proof)
+    TreeLookup(tree, key, proof).withSrcCtx(currentSrcCtx.value)
 
   override def mkTreeModifications(tree: Value[SAvlTree.type],
                                    operations: Value[SByteArray],
                                    proof: Value[SByteArray]): Value[SOption[SByteArray]] =
-    TreeModifications(tree, operations, proof)
+    TreeModifications(tree, operations, proof).withSrcCtx(currentSrcCtx.value)
 
   override def mkIsMember(tree: Value[SAvlTree.type],
                           key: Value[SByteArray],
                           proof: Value[SByteArray]): Value[SBoolean.type] =
-    OptionIsDefined(TreeLookup(tree, key, proof))
+    OptionIsDefined(TreeLookup(tree, key, proof)).withSrcCtx(currentSrcCtx.value)
 
   override def mkIf[T <: SType](condition: Value[SBoolean.type],
                                 trueBranch: Value[T],
                                 falseBranch: Value[T]): Value[T] =
-    If(condition, trueBranch, falseBranch)
+    If(condition, trueBranch, falseBranch).withSrcCtx(currentSrcCtx.value)
 
   override def mkLongToByteArray(input: Value[SLong.type]): Value[SByteArray] =
-    LongToByteArray(input)
+    LongToByteArray(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkByteArrayToBigInt(input: Value[SByteArray]): Value[SBigInt.type] =
-    ByteArrayToBigInt(input)
+    ByteArrayToBigInt(input).withSrcCtx(currentSrcCtx.value)
 
 
   override def mkUpcast[T <: SNumericType, R <: SNumericType](input: Value[T],
                                                               tpe: R): Value[R] =
-    Upcast(input, tpe)
+    Upcast(input, tpe).withSrcCtx(currentSrcCtx.value)
 
 
   override def mkDowncast[T <: SNumericType, R <: SNumericType](input: Value[T], tpe: R): Value[R] =
-    Downcast(input, tpe)
+    Downcast(input, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkCalcBlake2b256(input: Value[SByteArray]): Value[SByteArray] =
-    CalcBlake2b256(input)
+    CalcBlake2b256(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkCalcSha256(input: Value[SByteArray]): Value[SByteArray] =
-    CalcSha256(input)
+    CalcSha256(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkDecodePoint(input: Value[SByteArray]): GroupElementValue =
-    DecodePoint(input)
+    DecodePoint(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkMapCollection[IV <: SType, OV <: SType](input: Value[SCollection[IV]],
                                                          mapper: Value[SFunc]): Value[SCollection[OV]] =
-    MapCollection(input, mapper)
+    MapCollection(input, mapper).withSrcCtx(currentSrcCtx.value)
 
   override def mkAppend[IV <: SType](input: Value[SCollection[IV]],
                                      col2: Value[SCollection[IV]]): Value[SCollection[IV]] =
-    Append(input, col2)
+    Append(input, col2).withSrcCtx(currentSrcCtx.value)
 
   override def mkSlice[IV <: SType](input: Value[SCollection[IV]],
                                     from: Value[SInt.type],
                                     until: Value[SInt.type]): Value[SCollection[IV]] =
-    Slice(input, from, until)
+    Slice(input, from, until).withSrcCtx(currentSrcCtx.value)
 
   override def mkFilter[IV <: SType](input: Value[SCollection[IV]],
                                      id: Byte,
                                      condition: Value[SBoolean.type]): Value[SCollection[IV]] =
-    Filter(input, id, condition)
+    Filter(input, id, condition).withSrcCtx(currentSrcCtx.value)
 
   override def mkExists[IV <: SType](input: Value[SCollection[IV]],
                                      condition: Value[SFunc]): Value[SBoolean.type] =
-    Exists(input, condition)
+    Exists(input, condition).withSrcCtx(currentSrcCtx.value)
 
   override def mkForAll[IV <: SType](input: Value[SCollection[IV]],
                                      condition: Value[SFunc]): Value[SBoolean.type] =
-    ForAll(input, condition)
+    ForAll(input, condition).withSrcCtx(currentSrcCtx.value)
 
   def mkFuncValue(args: IndexedSeq[(Int,SType)], body: Value[SType]): Value[SFunc] =
-    FuncValue(args, body)
+    FuncValue(args, body).withSrcCtx(currentSrcCtx.value)
 
   override def mkFold[IV <: SType, OV <: SType](input: Value[SCollection[IV]],
                                    zero: Value[OV],
                                    foldOp: Value[SFunc]): Value[OV] =
-    Fold(input, zero, foldOp)
+    Fold(input, zero, foldOp).withSrcCtx(currentSrcCtx.value)
 
   override def mkByIndex[IV <: SType](input: Value[SCollection[IV]],
                                       index: Value[SInt.type],
                                       default: Option[Value[IV]] = None): Value[IV] =
-    ByIndex(input, index, default)
+    ByIndex(input, index, default).withSrcCtx(currentSrcCtx.value)
 
   override def mkSelectField(input: Value[STuple], fieldIndex: Byte): Value[SType] =
-    SelectField(input, fieldIndex)
+    SelectField(input, fieldIndex).withSrcCtx(currentSrcCtx.value)
 
   override def mkSizeOf[V <: SType](input: Value[SCollection[V]]): Value[SInt.type] =
-    SizeOf(input)
+    SizeOf(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractAmount(input: Value[SBox.type]): Value[SLong.type] =
-    ExtractAmount(input)
+    ExtractAmount(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractScriptBytes(input: Value[SBox.type]): Value[SByteArray] =
-    ExtractScriptBytes(input)
+    ExtractScriptBytes(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractBytes(input: Value[SBox.type]): Value[SByteArray] =
-    ExtractBytes(input)
+    ExtractBytes(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractBytesWithNoRef(input: Value[SBox.type]): Value[SByteArray] =
-    ExtractBytesWithNoRef(input)
+    ExtractBytesWithNoRef(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractId(input: Value[SBox.type]): Value[SByteArray] =
-    ExtractId(input)
+    ExtractId(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractCreationInfo(input: Value[SBox.type]): Value[STuple] =
-    ExtractCreationInfo(input)
+    ExtractCreationInfo(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkExtractRegisterAs[IV <: SType](input: Value[SBox.type],
                                                 registerId: RegisterId,
                                                 tpe: SOption[IV]): Value[SType] =
-    ExtractRegisterAs(input, registerId, tpe)
+    ExtractRegisterAs(input, registerId, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkDeserializeContext[T <: SType](id: Byte, tpe: T): Value[T] =
-    DeserializeContext(id, tpe)
+    DeserializeContext(id, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkDeserializeRegister[T <: SType](reg: RegisterId,
                                                  tpe: T,
                                                  default: Option[Value[T]] = None): Value[T] =
-    DeserializeRegister(reg, tpe, default)
+    DeserializeRegister(reg, tpe, default).withSrcCtx(currentSrcCtx.value)
 
   override def mkTuple(items: Seq[Value[SType]]): Value[SType] =
-    Tuple(items.toIndexedSeq)
+    Tuple(items.toIndexedSeq).withSrcCtx(currentSrcCtx.value)
 
   override def mkProveDiffieHellmanTuple(gv: Value[SGroupElement.type],
                                          hv: Value[SGroupElement.type],
                                          uv: Value[SGroupElement.type],
                                          vv: Value[SGroupElement.type]): SigmaBoolean =
-    ProveDHTuple(gv, hv, uv, vv)
+    ProveDHTuple(gv, hv, uv, vv).withSrcCtx(currentSrcCtx.value).asInstanceOf[ProveDHTuple]
 
   override def mkProveDlog(value: Value[SGroupElement.type]): SigmaBoolean =
-    ProveDlog(value)
+    ProveDlog(value).withSrcCtx(currentSrcCtx.value).asInstanceOf[ProveDlog]
 
-  override def mkBoolToSigmaProp(value: BoolValue) = BoolToSigmaProp(value)
+  override def mkBoolToSigmaProp(value: BoolValue): SigmaPropValue =
+    BoolToSigmaProp(value).withSrcCtx(currentSrcCtx.value)
 
-  override def mkSigmaPropIsProven(value: Value[SSigmaProp.type]) = SigmaPropIsProven(value)
+  override def mkSigmaPropIsProven(value: Value[SSigmaProp.type]): BoolValue =
+    SigmaPropIsProven(value).withSrcCtx(currentSrcCtx.value)
 
-  override def mkSigmaPropBytes(value: Value[SSigmaProp.type]) = SigmaPropBytes(value)
+  override def mkSigmaPropBytes(value: Value[SSigmaProp.type]): Value[SByteArray] =
+    SigmaPropBytes(value).withSrcCtx(currentSrcCtx.value)
 
-  override def mkSigmaAnd(items: Seq[SigmaPropValue]): SigmaPropValue = SigmaAnd(items)
+  override def mkSigmaAnd(items: Seq[SigmaPropValue]): SigmaPropValue =
+    SigmaAnd(items).withSrcCtx(currentSrcCtx.value)
 
-  override def mkSigmaOr(items: Seq[SigmaPropValue]): SigmaPropValue = SigmaOr(items)
+  override def mkSigmaOr(items: Seq[SigmaPropValue]): SigmaPropValue =
+    SigmaOr(items).withSrcCtx(currentSrcCtx.value)
 
   override def mkConcreteCollection[T <: SType](items: IndexedSeq[Value[T]],
                                                 elementType: T): Value[SCollection[T]] =
-    ConcreteCollection(items, elementType)
+    ConcreteCollection(items, elementType).withSrcCtx(currentSrcCtx.value)
 
   override def mkTaggedVariable[T <: SType](varId: Byte, tpe: T): TaggedVariable[T] =
-    TaggedVariableNode(varId, tpe)
+    TaggedVariableNode(varId, tpe).withSrcCtx(currentSrcCtx.value).asInstanceOf[TaggedVariable[T]]
 
-  override def mkSomeValue[T <: SType](x: Value[T]): Value[SOption[T]] = SomeValue(x)
-  override def mkNoneValue[T <: SType](elemType: T): Value[SOption[T]] = NoneValue(elemType)
+  override def mkSomeValue[T <: SType](x: Value[T]): Value[SOption[T]] =
+    SomeValue(x).withSrcCtx(currentSrcCtx.value)
+  override def mkNoneValue[T <: SType](elemType: T): Value[SOption[T]] =
+    NoneValue(elemType).withSrcCtx(currentSrcCtx.value)
 
   override def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType] =
-    Block(bindings, result)
+    Block(bindings, result).withSrcCtx(currentSrcCtx.value)
 
   override def mkBlockValue(items: IndexedSeq[BlockItem], result: Value[SType]): Value[SType] =
-    BlockValue(items, result)
+    BlockValue(items, result).withSrcCtx(currentSrcCtx.value)
 
   override def mkValUse(valId: Int, tpe: SType): Value[SType] =
-    ValUse(valId, tpe)
+    ValUse(valId, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkZKProofBlock(body: Value[SSigmaProp.type]): BoolValue =
-    ZKProofBlock(body)
+    ZKProofBlock(body).withSrcCtx(currentSrcCtx.value)
 
   override def mkVal(name: String,
                      givenType: SType,
                      body: Value[SType]): Val = {
-    val v = ValNode(name, givenType, body)
-    v.sourceContext = currentSrcCtx.value
-    v
+    ValNode(name, givenType, body).withSrcCtx(currentSrcCtx.value).asInstanceOf[Val]
   }
 
   override def mkSelect(obj: Value[SType],
                         field: String,
                         resType: Option[SType] = None): Value[SType] =
-    Select(obj, field, resType)
+    Select(obj, field, resType).withSrcCtx(currentSrcCtx.value)
 
   override def mkIdent(name: String, tpe: SType): Value[SType] = Ident(name, tpe)
 
   override def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType] =
-    Apply(func, args)
+    Apply(func, args).withSrcCtx(currentSrcCtx.value)
 
   override def mkApplyTypes(input: Value[SType], tpeArgs: Seq[SType]): Value[SType] =
-    ApplyTypes(input, tpeArgs)
+    ApplyTypes(input, tpeArgs).withSrcCtx(currentSrcCtx.value)
 
   override def mkMethodCallLike(obj: Value[SType],
                             name: String,
                             args: IndexedSeq[Value[SType]],
                             tpe: SType): Value[SType] =
-    MethodCallLike(obj, name, args, tpe)
+    MethodCallLike(obj, name, args, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkMethodCall(obj: Value[SType],
                             method: SMethod,
                             args: IndexedSeq[Value[SType]]): Value[SType] =
-    MethodCall(obj, method, args)
+    MethodCall(obj, method, args).withSrcCtx(currentSrcCtx.value)
 
   override def mkLambda(args: IndexedSeq[(String, SType)],
                         givenResType: SType,
                         body: Option[Value[SType]]): Value[SFunc] =
-    Lambda(Nil, args, givenResType, body)
+    Lambda(Nil, args, givenResType, body).withSrcCtx(currentSrcCtx.value)
 
   def mkGenLambda(tpeParams: Seq[STypeParam],
                   args: IndexedSeq[(String, SType)],
                   givenResType: SType,
                   body: Option[Value[SType]]) =
-    Lambda(tpeParams, args, givenResType, body)
+    Lambda(tpeParams, args, givenResType, body).withSrcCtx(currentSrcCtx.value)
 
   override def mkConstant[T <: SType](value: T#WrappedType, tpe: T): Constant[T] =
-    ConstantNode[T](value, tpe)
+    ConstantNode[T](value, tpe).withSrcCtx(currentSrcCtx.value).asInstanceOf[Constant[T]]
 
 
   override def mkConstantPlaceholder[T <: SType](id: Int, tpe: T): Value[SType] =
-    ConstantPlaceholder[T](id, tpe)
+    ConstantPlaceholder[T](id, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkCollectionConstant[T <: SType](values: Array[T#WrappedType],
                                                 elementType: T): Constant[SCollection[T]] =
     ConstantNode[SCollection[T]](values, SCollection(elementType))
+      .withSrcCtx(currentSrcCtx.value).asInstanceOf[ConstantNode[SCollection[T]]]
 
   override def mkStringConcat(left: Constant[SString.type], right: Constant[SString.type]): Value[SString.type] =
-    StringConstant(left.value + right.value)
+    StringConstant(left.value + right.value).withSrcCtx(currentSrcCtx.value)
 
   override def mkGetVar[T <: SType](varId: Byte, tpe: T): Value[SOption[T]] =
-    GetVar(varId, tpe)
+    GetVar(varId, tpe).withSrcCtx(currentSrcCtx.value)
 
   override def mkOptionGet[T <: SType](input: Value[SOption[T]]): Value[T] =
-    OptionGet(input)
+    OptionGet(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkOptionGetOrElse[T <: SType](input: Value[SOption[T]], default: Value[T]): Value[T] =
-    OptionGetOrElse(input, default)
+    OptionGetOrElse(input, default).withSrcCtx(currentSrcCtx.value)
 
   override def mkOptionIsDefined[T <: SType](input: Value[SOption[T]]): Value[SBoolean.type] =
-    OptionIsDefined(input)
+    OptionIsDefined(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkModQ(input: Value[SBigInt.type]): Value[SBigInt.type] =
-    ModQ(input)
+    ModQ(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkPlusModQ(left: Value[SBigInt.type], right: Value[SBigInt.type]): Value[SBigInt.type] =
-    ModQArithOp(left, right, OpCodes.PlusModQCode)
+    ModQArithOp(left, right, OpCodes.PlusModQCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkMinusModQ(left: Value[SBigInt.type], right: Value[SBigInt.type]): Value[SBigInt.type] =
-    ModQArithOp(left, right, OpCodes.MinusModQCode)
+    ModQArithOp(left, right, OpCodes.MinusModQCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkLogicalNot(input: Value[SBoolean.type]): Value[SBoolean.type] =
-    LogicalNot(input)
+    LogicalNot(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkNegation[T <: SNumericType](input: Value[T]): Value[T] =
-    Negation(input)
+    Negation(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitInversion[T <: SNumericType](input: Value[T]): Value[T] =
-    BitInversion(input)
+    BitInversion(input).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitOr[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    BitOp(left, right, OpCodes.BitOrCode)
+    BitOp(left, right, OpCodes.BitOrCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitAnd[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    BitOp(left, right, OpCodes.BitAndCode)
+    BitOp(left, right, OpCodes.BitAndCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitXor[T <: SNumericType](left: Value[T], right: Value[T]): Value[T] =
-    BitOp(left, right, OpCodes.BitXorCode)
+    BitOp(left, right, OpCodes.BitXorCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitShiftRight[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T] =
-    BitOp(bits, shift, OpCodes.BitShiftRightCode)
+    BitOp(bits, shift, OpCodes.BitShiftRightCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitShiftLeft[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T] =
-    BitOp(bits, shift, OpCodes.BitShiftLeftCode)
+    BitOp(bits, shift, OpCodes.BitShiftLeftCode).withSrcCtx(currentSrcCtx.value)
 
   override def mkBitShiftRightZeroed[T <: SNumericType](bits: Value[T], shift: Value[T]): Value[T] =
-    BitOp(bits, shift, OpCodes.BitShiftRightZeroedCode)
+    BitOp(bits, shift, OpCodes.BitShiftRightZeroedCode).withSrcCtx(currentSrcCtx.value)
 }
 
 trait TypeConstraintCheck {

--- a/src/main/scala/sigmastate/lang/SigmaBuilder.scala
+++ b/src/main/scala/sigmastate/lang/SigmaBuilder.scala
@@ -159,7 +159,7 @@ trait SigmaBuilder {
   def mkBlockValue(items: IndexedSeq[BlockItem], result: Value[SType]): Value[SType]
   def mkValUse(valId: Int, tpe: SType): Value[SType]
   def mkZKProofBlock(body: Value[SSigmaProp.type]): Value[SBoolean.type]
-  def mkVal(name: String, givenType: SType, body: Value[SType]): Val
+  def mkVal(name: String, givenType: SType, body: Value[SType], srcCtx: SourceContext): Val
   def mkSelect(obj: Value[SType], field: String, resType: Option[SType] = None): Value[SType]
   def mkIdent(name: String, tpe: SType): Value[SType]
   def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType]
@@ -488,8 +488,10 @@ class StdSigmaBuilder extends SigmaBuilder {
   override def mkZKProofBlock(body: Value[SSigmaProp.type]): BoolValue =
     ZKProofBlock(body)
 
-  override def mkVal(name: String, givenType: SType, body: Value[SType]): Val =
-    ValNode(name, givenType, body)
+  override def mkVal(name: String,
+                     givenType: SType,
+                     body: Value[SType], srcCtx: SourceContext): Val =
+    ValNode(name, givenType, body, Nullable(srcCtx))
 
   override def mkSelect(obj: Value[SType],
                         field: String,

--- a/src/main/scala/sigmastate/lang/SigmaCompiler.scala
+++ b/src/main/scala/sigmastate/lang/SigmaCompiler.scala
@@ -20,7 +20,7 @@ import sigmastate.lang.syntax.ParserException
 class SigmaCompiler(networkPrefix: NetworkPrefix, builder: SigmaBuilder) {
 
   def parse(x: String): SValue = {
-    SigmaParser(x, builder) match {
+    SigmaParser(x, builder).parse match {
       case Success(v, i) => v
       case f: Parsed.Failure[_,_] =>
         throw new ParserException(s"Syntax error: $f", Some(f))

--- a/src/main/scala/sigmastate/lang/SigmaCompiler.scala
+++ b/src/main/scala/sigmastate/lang/SigmaCompiler.scala
@@ -20,7 +20,7 @@ import sigmastate.lang.syntax.ParserException
 class SigmaCompiler(networkPrefix: NetworkPrefix, builder: SigmaBuilder) {
 
   def parse(x: String): SValue = {
-    SigmaParser(x, builder).parse match {
+    SigmaParser(x, builder) match {
       case Success(v, i) => v
       case f: Parsed.Failure[_,_] =>
         throw new ParserException(s"Syntax error: $f", Some(f))

--- a/src/main/scala/sigmastate/lang/SigmaCompiler.scala
+++ b/src/main/scala/sigmastate/lang/SigmaCompiler.scala
@@ -22,8 +22,8 @@ class SigmaCompiler(networkPrefix: NetworkPrefix, builder: SigmaBuilder) {
   def parse(x: String): SValue = {
     SigmaParser(x, builder) match {
       case Success(v, i) => v
-      case f: Parsed.Failure[_,_] =>
-        throw new ParserException(s"Syntax error: $f", Some(f))
+      case f: Parsed.Failure[_,String] =>
+        throw new ParserException(s"Syntax error: $f", Some(SourceContext.fromParserFailure(f)))
     }
   }
 

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -4,6 +4,7 @@ import fastparse.core.Logger
 import fastparse.core
 import sigmastate._
 import Values._
+import scalan.Nullable
 import sigmastate.lang.Terms._
 import sigmastate.SCollection.SByteArray
 import sigmastate.lang.syntax.Basic._
@@ -29,7 +30,10 @@ class SigmaParser(str: String,
 //  }
 
   val ValVarDef = P( Index ~ BindPattern/*.rep(1, ",".~/)*/ ~ (`:` ~/ Type).? ~ (`=` ~/ FreeCtx.Expr) ).map {
-    case (index, Ident(n,_), t, body) => builder.mkVal(n, t.getOrElse(NoType), body, srcCtx(index))
+    case (index, Ident(n,_), t, body) =>
+      builder.currentSrcCtx.withValue(Nullable(srcCtx(index))) {
+        builder.mkVal(n, t.getOrElse(NoType), body)
+      }
     case (_, pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -19,11 +19,11 @@ object SigmaParser extends Exprs with Types with Core {
 
   val currentInput = new DynamicVariable[String]("")
 
-  override def atSourcePos[A](parserIndex: Int)(thunk: => A): A = {
-    builder.currentSrcCtx.withValue(Nullable(SourceContext.fromParserIndex(parserIndex, currentInput.value))) {
-      thunk
-    }
-  }
+  override def atSourcePos[A](parserIndex: Int)(thunk: => A): A =
+    builder.currentSrcCtx.withValue(Nullable(srcCtx(parserIndex))) { thunk }
+
+  override def srcCtx(parserIndex: Int): SourceContext =
+    SourceContext.fromParserIndex(parserIndex, currentInput.value)
 
   val TmplBody = {
     val Prelude = P( (Annot ~ OneNLMax).rep )
@@ -40,7 +40,7 @@ object SigmaParser extends Exprs with Types with Core {
       atSourcePos(index) {
         builder.mkVal(n, t.getOrElse(NoType), body)
       }
-    case (index, pat,_,_) => error(s"Only single name patterns supported but was $pat")
+    case (index, pat,_,_) => error(s"Only single name patterns supported but was $pat", srcCtx(index))
   }
 
   val BlockDef = P( Dcl )

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -11,9 +11,12 @@ import sigmastate.lang.syntax.{Core, Exprs}
 
 import scala.collection.mutable
 
-object SigmaParser extends Exprs with Types with Core {
+class SigmaParser(str: String,
+                  override val builder: SigmaBuilder) extends Exprs with Types with Core {
   import fastparse.noApi._
   import WhitespaceApi._
+
+  override def srcCtx(parserIndex: Int): SourceContext = SourceContext(parserIndex, str)
 
   val TmplBody = {
     val Prelude = P( (Annot ~ OneNLMax).rep )
@@ -25,9 +28,9 @@ object SigmaParser extends Exprs with Types with Core {
 //    P( (Id | `this`).! ~ LambdaDef ).map { case (name, lam) => builder.mkVal(name, NoType, lam) }
 //  }
 
-  val ValVarDef = P( BindPattern/*.rep(1, ",".~/)*/ ~ (`:` ~/ Type).? ~ (`=` ~/ FreeCtx.Expr) ).map {
-    case (Ident(n,_), t, body) => builder.mkVal(n, t.getOrElse(NoType), body)
-    case (pat,_,_) => error(s"Only single name patterns supported but was $pat")
+  val ValVarDef = P( Index ~ BindPattern/*.rep(1, ",".~/)*/ ~ (`:` ~/ Type).? ~ (`=` ~/ FreeCtx.Expr) ).map {
+    case (index, Ident(n,_), t, body) => builder.mkVal(n, t.getOrElse(NoType), body, srcCtx(index))
+    case (_, pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 
   val BlockDef = P( Dcl )
@@ -78,16 +81,24 @@ object SigmaParser extends Exprs with Types with Core {
     case _ => error(s"Unknown binary operation $opName")
   }
 
-  def apply(str: String, sigmaBuilder: SigmaBuilder): core.Parsed[Value[_ <: SType], Char, String] = {
-    builder = sigmaBuilder
-    (StatCtx.Expr ~ End).parse(str)
-  }
+  def parse: core.Parsed[Value[_ <: SType], Char, String] = (StatCtx.Expr ~ End).parse(str)
 
-  def parsedType(str: String): core.Parsed[SType, Char, String] = (Type ~ End).parse(str)
+  def parsedType: core.Parsed[SType, Char, String] = (Type ~ End).parse(str)
 
-  def parseType(x: String): SType = {
-    val res = parsedType(x).get.value
+  def parseType: SType = {
+    val res = parsedType.get.value
     res
   }
 
+}
+
+object SigmaParser {
+
+  def apply(str: String, sigmaBuilder: SigmaBuilder): SigmaParser =
+    new SigmaParser(str, sigmaBuilder)
+
+  def parsedType(str: String): core.Parsed[SType, Char, String] =
+    new SigmaParser(str, StdSigmaBuilder).parsedType
+
+  def parseType(x: String): SType = new SigmaParser(x, StdSigmaBuilder).parseType
 }

--- a/src/main/scala/sigmastate/lang/SigmaParser.scala
+++ b/src/main/scala/sigmastate/lang/SigmaParser.scala
@@ -20,7 +20,7 @@ object SigmaParser extends Exprs with Types with Core {
   val currentInput = new DynamicVariable[String]("")
 
   override def atSourcePos[A](parserIndex: Int)(thunk: => A): A = {
-    builder.currentSrcCtx.withValue(Nullable(SourceContext(parserIndex, currentInput.value))) {
+    builder.currentSrcCtx.withValue(Nullable(SourceContext.fromParserIndex(parserIndex, currentInput.value))) {
       thunk
     }
   }
@@ -40,7 +40,7 @@ object SigmaParser extends Exprs with Types with Core {
       atSourcePos(index) {
         builder.mkVal(n, t.getOrElse(NoType), body)
       }
-    case (_, pat,_,_) => error(s"Only single name patterns supported but was $pat")
+    case (index, pat,_,_) => error(s"Only single name patterns supported but was $pat")
   }
 
   val BlockDef = P( Dcl )

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -3,6 +3,7 @@ package sigmastate.lang
 import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{reduce, rewrite, strategy}
 import org.ergoplatform.ErgoAddressEncoder.{NetworkPrefix, TestnetNetworkPrefix}
 import org.ergoplatform._
+import scalan.Nullable
 import scorex.util.encode.{Base58, Base64}
 import sigmastate.SCollection._
 import sigmastate.Values.Value.Typed
@@ -33,8 +34,8 @@ class SigmaSpecializer(val builder: SigmaBuilder) {
 
     case _ @ Block(binds, res) =>
       var curEnv = env
-      for (Val(n, _, b) <- binds) {
-        if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
+      for (Val(n, _, b, Nullable(srcCtx)) <- binds) {
+        if (curEnv.contains(n)) error(s"$srcCtx Variable $n already defined ($n = ${curEnv(n)}")
         val b1 = eval(curEnv, b)
         curEnv = curEnv + (n -> b1)
       }
@@ -175,4 +176,5 @@ class SigmaSpecializer(val builder: SigmaBuilder) {
 object SigmaSpecializer {
 
   def error(msg: String) = throw new SpecializerException(msg, None)
+  def error(msg: String, srcCtx: SourceContext) = throw new SpecializerException(msg, Some(srcCtx))
 }

--- a/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -34,8 +34,8 @@ class SigmaSpecializer(val builder: SigmaBuilder) {
 
     case _ @ Block(binds, res) =>
       var curEnv = env
-      for (Val(n, _, b, Nullable(srcCtx)) <- binds) {
-        if (curEnv.contains(n)) error(s"$srcCtx Variable $n already defined ($n = ${curEnv(n)}")
+      for (v @ Val(n, _, b) <- binds) {
+        if (curEnv.contains(n)) error(s"${v.sourceContext} Variable $n already defined ($n = ${curEnv(n)}")
         val b1 = eval(curEnv, b)
         curEnv = curEnv + (n -> b1)
       }

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -12,7 +12,7 @@ import sigmastate.lang.exceptions._
 import sigmastate.lang.SigmaPredef._
 import sigmastate.serialization.OpCodes
 import sigmastate.utxo._
-import sigmastate.utils.Extensions._
+import sigma.util.Extensions._
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -84,7 +84,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
           val tRes = if (iField != -1) {
             s.methods(iField).stype
           } else
-            throw new MethodNotFound(s"Cannot find method '$n' in in the object $obj of Product type with methods ${s.methods}", obj.sourceContext)
+            throw new MethodNotFound(s"Cannot find method '$n' in in the object $obj of Product type with methods ${s.methods}", obj.sourceContext.toOption)
           mkSelect(newObj, n, Some(tRes))
         case t =>
           error(s"Cannot get field '$n' in in the object $obj of non-product type $t", sel.sourceContext)
@@ -198,7 +198,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
             else
               error(s"Invalid argument type for $m, expected $tColl but was ${r.tpe}", r.sourceContext)
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as operation with arguments $newObj and $newArgs", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as operation with arguments $newObj and $newArgs", mc.sourceContext.toOption)
         }
         case SGroupElement => (m, newArgs) match {
           case ("*", Seq(r)) =>
@@ -207,7 +207,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
             else
               error(s"Invalid argument type for $m, expected $SGroupElement but was ${r.tpe}", r.sourceContext)
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext.toOption)
         }
         case _: SNumericType => (m, newArgs) match {
           case("+" | "*" | "^" | ">>" | "<<" | ">>>", Seq(r)) => r.tpe match {
@@ -220,10 +220,10 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
               case ">>>" => bimap(env, ">>>", newObj.asNumValue, r.asNumValue)(mkBitShiftRightZeroed)(tT, tT)
             }
             case _ =>
-              throw new InvalidBinaryOperationParameters(s"Invalid argument type for $m, expected ${newObj.tpe} but was ${r.tpe}", r.sourceContext)
+              throw new InvalidBinaryOperationParameters(s"Invalid argument type for $m, expected ${newObj.tpe} but was ${r.tpe}", r.sourceContext.toOption)
           }
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext.toOption)
         }
 
         case SSigmaProp => (m, newArgs) match {
@@ -240,7 +240,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
               error(s"Invalid argument type for $m, expected $SSigmaProp but was ${r.tpe}", r.sourceContext)
           }
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext.toOption)
         }
         case SBoolean => (m, newArgs) match {
           case ("||" | "&&" | "^", Seq(r)) => r.tpe match {
@@ -258,17 +258,17 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
               error(s"Invalid argument type for $m, expected ${newObj.tpe} but was ${r.tpe}", r.sourceContext)
           }
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext.toOption)
         }
         case _: SString.type => (m, newArgs) match {
           case ("+", Seq(r)) => (newObj, r) match {
             case (cl : Constant[SString.type]@unchecked, cr : Constant[SString.type]@unchecked) =>
               mkStringConcat(cl, cr)
             case _ =>
-              throw new InvalidBinaryOperationParameters(s"Invalid argument type for $m, expected ${newObj.tpe} but was ${r.tpe}", r.sourceContext)
+              throw new InvalidBinaryOperationParameters(s"Invalid argument type for $m, expected ${newObj.tpe} but was ${r.tpe}", r.sourceContext.toOption)
           }
           case _ =>
-            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext)
+            throw new NonApplicableMethod(s"Unknown symbol $m, which is used as ($newObj) $m ($newArgs)", mc.sourceContext.toOption)
         }
         case t =>
           error(s"Invalid operation $mc on type $t", mc.sourceContext)
@@ -441,7 +441,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
         node
       } catch {
         case e: Throwable =>
-          throw new InvalidBinaryOperationParameters(s"operation: $op: $e", l.sourceContext)
+          throw new InvalidBinaryOperationParameters(s"operation: $op: $e", l.sourceContext.toOption)
       }
     }
     (l1.tpe, r1.tpe) match {
@@ -452,7 +452,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
         if (substOpt.isDefined)
           safeMkNode(l1, r1)
         else
-          throw new InvalidBinaryOperationParameters(s"Invalid binary operation $op: expected argument types ($tArg, $tArg); actual: (${l1.tpe }, ${r1.tpe })", l.sourceContext)
+          throw new InvalidBinaryOperationParameters(s"Invalid binary operation $op: expected argument types ($tArg, $tArg); actual: (${l1.tpe }, ${r1.tpe })", l.sourceContext.toOption)
     }
 
   }
@@ -466,7 +466,7 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
       newNode(l1, r1)
     } catch {
       case e: Throwable =>
-        throw new InvalidBinaryOperationParameters(s"operation $op: $e", l.sourceContext)
+        throw new InvalidBinaryOperationParameters(s"operation $op: $e", l.sourceContext.toOption)
     }
   }
 
@@ -475,12 +475,12 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
                        (tArg: SType): SValue = {
     val i1 = assignType(env, i).asValue[T]
     if (!i1.tpe.isNumType && i1.tpe != tArg)
-      throw new InvalidUnaryOperationParameters(s"Invalid unary op $op: expected argument type $tArg, actual: ${i1.tpe}", i.sourceContext)
+      throw new InvalidUnaryOperationParameters(s"Invalid unary op $op: expected argument type $tArg, actual: ${i1.tpe}", i.sourceContext.toOption)
     try {
       newNode(i1)
     } catch {
       case e: Throwable =>
-        throw new InvalidUnaryOperationParameters(s"operation $op error: $e", i.sourceContext)
+        throw new InvalidUnaryOperationParameters(s"operation $op error: $e", i.sourceContext.toOption)
     }
   }
 
@@ -592,5 +592,5 @@ object SigmaTyper {
     }
   }
 
-  def error(msg: String, srcCtx: Option[SourceContext]) = throw new TyperException(msg, srcCtx)
+  def error(msg: String, srcCtx: Nullable[SourceContext]) = throw new TyperException(msg, srcCtx.toOption)
 }

--- a/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -6,6 +6,7 @@ import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate._
 import SCollection.SBooleanArray
+import scalan.Nullable
 import sigmastate.lang.Terms._
 import sigmastate.lang.exceptions._
 import sigmastate.lang.SigmaPredef._
@@ -39,11 +40,11 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
     case Block(bs, res) =>
       var curEnv = env
       val bs1 = ArrayBuffer[Val]()
-      for (Val(n, _, b) <- bs) {
-        if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}")
+      for (Val(n, _, b, Nullable(srcCtx)) <- bs) {
+        if (curEnv.contains(n)) error(s"Variable $n already defined ($n = ${curEnv(n)}", srcCtx)
         val b1 = assignType(curEnv, b)
         curEnv = curEnv + (n -> b1.tpe)
-        bs1 += mkVal(n, b1.tpe, b1)
+        bs1 += mkVal(n, b1.tpe, b1, srcCtx)
       }
       val res1 = assignType(curEnv, res)
       mkBlock(bs1, res1)
@@ -586,4 +587,5 @@ object SigmaTyper {
   }
 
   def error(msg: String) = throw new TyperException(msg, None)
+  def error(msg: String, srcCtx: SourceContext) = throw new TyperException(msg, Some(srcCtx))
 }

--- a/src/main/scala/sigmastate/lang/SourceContext.scala
+++ b/src/main/scala/sigmastate/lang/SourceContext.scala
@@ -7,16 +7,17 @@ case class SourceContext(line: Int, column: Int, sourceLine: String) {
 }
 
 object SourceContext {
-  def apply(parserIndex: Int, input: String): SourceContext = {
+
+  def fromParserIndex(index: Int, input: String): SourceContext = {
     val lines = Source.fromString(input).getLines.toSeq
     lines.tail
       .scanLeft((0, lines.head.length)) { case ((_, end), line) => (end + 1, end + line.length) }
       .zip(lines)
       .zipWithIndex
-      .find { case (((start, end), _), _) =>  parserIndex >= start && parserIndex <= end }
+      .find { case (((start, end), _), _) =>  index >= start && index <= end }
       .map {
         case (((start, _), line), lineIndex) =>
-          SourceContext(lineIndex + 1, parserIndex - start + 1, line)
+          SourceContext(lineIndex + 1, index - start + 1, line)
       }.get
   }
 

--- a/src/main/scala/sigmastate/lang/SourceContext.scala
+++ b/src/main/scala/sigmastate/lang/SourceContext.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang
 
+import fastparse.core.Parsed.Failure
+
 import scala.io.Source
 
 case class SourceContext(line: Int, column: Int, sourceLine: String) {
@@ -21,4 +23,6 @@ object SourceContext {
       }.get
   }
 
+  def fromParserFailure(e: Failure[_, String]): SourceContext =
+    fromParserIndex(e.index , e.extra.input.slice(0, e.extra.input.length))
 }

--- a/src/main/scala/sigmastate/lang/SourceContext.scala
+++ b/src/main/scala/sigmastate/lang/SourceContext.scala
@@ -1,0 +1,9 @@
+package sigmastate.lang
+
+case class SourceContext(line: Int, column: Int, sourceLine: String) {
+
+}
+
+object SourceContext {
+  def apply(parserIndex: Int, input: String): SourceContext = SourceContext(parserIndex, 0, input)
+}

--- a/src/main/scala/sigmastate/lang/SourceContext.scala
+++ b/src/main/scala/sigmastate/lang/SourceContext.scala
@@ -1,9 +1,23 @@
 package sigmastate.lang
 
+import scala.io.Source
+
 case class SourceContext(line: Int, column: Int, sourceLine: String) {
 
 }
 
 object SourceContext {
-  def apply(parserIndex: Int, input: String): SourceContext = SourceContext(parserIndex, 0, input)
+  def apply(parserIndex: Int, input: String): SourceContext = {
+    val lines = Source.fromString(input).getLines.toSeq
+    lines.tail
+      .scanLeft((0, lines.head.length)) { case ((_, end), line) => (end + 1, end + line.length) }
+      .zip(lines)
+      .zipWithIndex
+      .find { case (((start, end), _), _) =>  parserIndex >= start && parserIndex <= end }
+      .map {
+        case (((start, _), line), lineIndex) =>
+          SourceContext(lineIndex + 1, parserIndex - start + 1, line)
+      }.get
+  }
+
 }

--- a/src/main/scala/sigmastate/lang/SourceContext.scala
+++ b/src/main/scala/sigmastate/lang/SourceContext.scala
@@ -12,15 +12,18 @@ object SourceContext {
 
   def fromParserIndex(index: Int, input: String): SourceContext = {
     val lines = Source.fromString(input).getLines.toSeq
-    lines.tail
-      .scanLeft((0, lines.head.length)) { case ((_, end), line) => (end + 1, end + line.length) }
-      .zip(lines)
-      .zipWithIndex
-      .find { case (((start, end), _), _) =>  index >= start && index <= end }
-      .map {
-        case (((start, _), line), lineIndex) =>
-          SourceContext(lineIndex + 1, index - start + 1, line)
-      }.get
+    if (lines.isEmpty)
+      SourceContext(0, 0, "")
+    else
+      lines.tail
+        .scanLeft((0, lines.head.length)) { case ((_, end), line) => (end + 1, end + 1 + line.length) }
+        .zip(lines)
+        .zipWithIndex
+        .find { case (((start, end), _), _) =>  index >= start && index <= end }
+        .map {
+          case (((start, _), line), lineIndex) =>
+            SourceContext(lineIndex + 1, index - start + 1, line)
+        }.get
   }
 
   def fromParserFailure(e: Failure[_, String]): SourceContext =

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -57,8 +57,7 @@ object Terms {
 
   case class ValNode(name: String,
                      givenType: SType,
-                     body: SValue,
-                     override val sourceContext: Nullable[SourceContext] = Nullable.None) extends Val {
+                     body: SValue) extends Val {
     override val opCode: OpCode = OpCodes.Undefined
     override def tpe: SType = givenType ?: body.tpe
     /** This is not used as operation, but rather to form a program structure */
@@ -67,8 +66,8 @@ object Terms {
   object Val {
     def apply(name: String, body: SValue): Val = ValNode(name, NoType, body)
     def apply(name: String, givenType: SType, body: SValue): Val = ValNode(name, givenType, body)
-    def unapply(v: SValue): Option[(String, SType, SValue, Nullable[SourceContext])] = v match {
-      case ValNode(name, givenType, body, srcCtx) => Some((name, givenType, body, srcCtx))
+    def unapply(v: SValue): Option[(String, SType, SValue)] = v match {
+      case ValNode(name, givenType, body) => Some((name, givenType, body))
       case _ => None
     }
   }

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -110,7 +110,6 @@ object Terms {
     override val opCode: OpCode = OpCodes.Undefined
     override lazy val tpe: SType = input.tpe match {
       case funcType: SFunc =>
-        require(funcType.tpeParams.length == tpeArgs.length, s"Invalid number of type parameters in $node")
         val subst = funcType.tpeParams.map(_.ident).zip(tpeArgs).toMap
         SigmaTyper.applySubst(input.tpe, subst)
       case _ => input.tpe

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -1,6 +1,7 @@
 package sigmastate.lang
 
 import org.ergoplatform.Self
+import scalan.Nullable
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate.utils.Overloading.Overload1
@@ -54,7 +55,10 @@ object Terms {
     val body: SValue
   }
 
-  case class ValNode(name: String, givenType: SType, body: SValue) extends Val {
+  case class ValNode(name: String,
+                     givenType: SType,
+                     body: SValue,
+                     override val sourceContext: Nullable[SourceContext] = Nullable.None) extends Val {
     override val opCode: OpCode = OpCodes.Undefined
     override def tpe: SType = givenType ?: body.tpe
     /** This is not used as operation, but rather to form a program structure */
@@ -63,8 +67,8 @@ object Terms {
   object Val {
     def apply(name: String, body: SValue): Val = ValNode(name, NoType, body)
     def apply(name: String, givenType: SType, body: SValue): Val = ValNode(name, givenType, body)
-    def unapply(v: SValue): Option[(String, SType, SValue)] = v match {
-      case ValNode(name, givenType, body) => Some((name, givenType, body))
+    def unapply(v: SValue): Option[(String, SType, SValue, Nullable[SourceContext])] = v match {
+      case ValNode(name, givenType, body, srcCtx) => Some((name, givenType, body, srcCtx))
       case _ => None
     }
   }

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -203,5 +203,9 @@ object Terms {
       else
         mkUpcast(tV, targetType)
     }
+    def withSrcCtx[T <: SType](sourceContext: Nullable[SourceContext]): Value[T] = {
+      v.sourceContext = sourceContext
+      v.asValue[T]
+    }
   }
 }

--- a/src/main/scala/sigmastate/lang/exceptions/Exceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/Exceptions.scala
@@ -3,7 +3,14 @@ package sigmastate.lang.exceptions
 import sigmastate.lang.SourceContext
 
 class SigmaException(val message: String, val source: Option[SourceContext] = None)
-    extends Exception(message)
+    extends Exception(message) {
+
+  override def getMessage: String = source.map { srcCtx =>
+    val lineNumberStrPrefix = s"line ${srcCtx.line}: "
+    "\n" + lineNumberStrPrefix +
+      s"${srcCtx.sourceLine}\n${" " * (lineNumberStrPrefix.length + srcCtx.column - 1)}^\n" + message
+  }.getOrElse(message)
+}
 
 class BinderException(message: String, source: Option[SourceContext] = None)
     extends SigmaException(message, source)

--- a/src/main/scala/sigmastate/lang/exceptions/Exceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/Exceptions.scala
@@ -1,6 +1,6 @@
 package sigmastate.lang.exceptions
 
-case class SourceContext(index: Int)
+import sigmastate.lang.SourceContext
 
 class SigmaException(val message: String, val source: Option[SourceContext] = None)
     extends Exception(message)

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaBinderExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaBinderExceptions.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang.exceptions
 
+import sigmastate.lang.SourceContext
+
 final class InvalidArguments(message: String, source: Option[SourceContext] = None)
   extends BinderException(message, source)
 

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaBuilderExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaBuilderExceptions.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang.exceptions
 
+import sigmastate.lang.SourceContext
+
 final class ConstraintFailed(message: String, source: Option[SourceContext] = None)
   extends BuilderException(message, source)
 

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaInterpreterExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaInterpreterExceptions.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang.exceptions
 
+import sigmastate.lang.SourceContext
+
 final class OptionUnwrapNone(message: String, source: Option[SourceContext] = None)
   extends InterpreterException(message, source)
 

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang.exceptions
 
+import sigmastate.lang.SourceContext
+
 final class InvalidTypePrefix(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
 

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaTyperExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaTyperExceptions.scala
@@ -1,5 +1,7 @@
 package sigmastate.lang.exceptions
 
+import sigmastate.lang.SourceContext
+
 final class InvalidBinaryOperationParameters(message: String, source: Option[SourceContext] = None)
   extends TyperException(message, source)
 

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -45,7 +45,7 @@ object Basic {
 
 class ParserException(message: String, val parseError: Option[Failure[_,String]])
   extends SigmaException(message,
-    parseError.map(e => SourceContext(e.index, e.extra.input.slice(0, e.extra.input.length))))
+    parseError.map(e => SourceContext.fromParserIndex(e.index, e.extra.input.slice(0, e.extra.input.length))))
 
 /**
   * Most keywords don't just require the correct characters to match,

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -5,7 +5,7 @@ import fastparse.CharPredicates._
 import scalan.Nullable
 import sigmastate.lang.SourceContext
 import sigmastate.lang.exceptions.SigmaException
-import sigma.util.Extensions.nullableToOption
+import sigma.util.Extensions._
 
 object Basic {
   val digits = "0123456789"
@@ -40,7 +40,7 @@ object Basic {
   val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
   def error(msg: String, srcCtx: Option[SourceContext]) = throw new ParserException(msg, srcCtx)
-  def error(msg: String, srcCtx: Nullable[SourceContext]) = throw new ParserException(msg, srcCtx)
+  def error(msg: String, srcCtx: Nullable[SourceContext]) = throw new ParserException(msg, srcCtx.toOption)
 }
 
 class ParserException(message: String, source: Option[SourceContext])

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -39,8 +39,8 @@ object Basic {
   val Lower: Parser[Unit] = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
   val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
-  def error(msg: String, srcCtx: Option[SourceContext] = None) =
-    throw new ParserException(msg, srcCtx)
+  def error(msg: String) = throw new ParserException(msg, None)
+  def error(msg: String, srcCtx: SourceContext) = throw new ParserException(msg, Some(srcCtx))
 }
 
 class ParserException(message: String, source: Option[SourceContext])

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -4,8 +4,10 @@ import fastparse.all._
 import fastparse.CharPredicates._
 import fastparse.all
 import fastparse.core.Parsed.Failure
+import scalan.Nullable
 import sigmastate.lang.SourceContext
 import sigmastate.lang.exceptions.SigmaException
+import sigmastate.utils.Extensions.nullableToOption
 
 object Basic {
   val digits = "0123456789"
@@ -39,8 +41,8 @@ object Basic {
   val Lower: Parser[Unit] = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
   val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
-  def error(msg: String) = throw new ParserException(msg, None)
-  def error(msg: String, srcCtx: SourceContext) = throw new ParserException(msg, Some(srcCtx))
+  def error(msg: String, srcCtx: Option[SourceContext]) = throw new ParserException(msg, srcCtx)
+  def error(msg: String, srcCtx: Nullable[SourceContext]) = throw new ParserException(msg, srcCtx)
 }
 
 class ParserException(message: String, source: Option[SourceContext])

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -2,12 +2,10 @@ package sigmastate.lang.syntax
 
 import fastparse.all._
 import fastparse.CharPredicates._
-import fastparse.all
-import fastparse.core.Parsed.Failure
 import scalan.Nullable
 import sigmastate.lang.SourceContext
 import sigmastate.lang.exceptions.SigmaException
-import sigmastate.utils.Extensions.nullableToOption
+import sigma.util.Extensions.nullableToOption
 
 object Basic {
   val digits = "0123456789"

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -39,13 +39,12 @@ object Basic {
   val Lower: Parser[Unit] = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
   val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
-  def error(msg: String, parseError: Option[Failure[_, String]] = None) =
-    throw new ParserException(msg, parseError)
+  def error(msg: String, srcCtx: Option[SourceContext] = None) =
+    throw new ParserException(msg, srcCtx)
 }
 
-class ParserException(message: String, val parseError: Option[Failure[_,String]])
-  extends SigmaException(message,
-    parseError.map(e => SourceContext.fromParserIndex(e.index, e.extra.input.slice(0, e.extra.input.length))))
+class ParserException(message: String, source: Option[SourceContext])
+  extends SigmaException(message, source)
 
 /**
   * Most keywords don't just require the correct characters to match,

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -39,12 +39,13 @@ object Basic {
   val Lower: Parser[Unit] = P( CharPred(c => isLower(c) || c == '$' | c == '_') )
   val Upper: Parser[Unit] = P( CharPred(isUpper) )
 
-  def error(msg: String, parseError: Option[Failure[_,_]] = None) =
+  def error(msg: String, parseError: Option[Failure[_, String]] = None) =
     throw new ParserException(msg, parseError)
 }
 
-class ParserException(message: String, val parseError: Option[Failure[_,_]])
-  extends SigmaException(message, parseError.map(e => SourceContext(e.index, e.extra.input.toString)))
+class ParserException(message: String, val parseError: Option[Failure[_,String]])
+  extends SigmaException(message,
+    parseError.map(e => SourceContext(e.index, e.extra.input.slice(0, e.extra.input.length))))
 
 /**
   * Most keywords don't just require the correct characters to match,

--- a/src/main/scala/sigmastate/lang/syntax/Basic.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Basic.scala
@@ -4,7 +4,8 @@ import fastparse.all._
 import fastparse.CharPredicates._
 import fastparse.all
 import fastparse.core.Parsed.Failure
-import sigmastate.lang.exceptions.{SigmaException, SourceContext}
+import sigmastate.lang.SourceContext
+import sigmastate.lang.exceptions.SigmaException
 
 object Basic {
   val digits = "0123456789"
@@ -43,7 +44,7 @@ object Basic {
 }
 
 class ParserException(message: String, val parseError: Option[Failure[_,_]])
-  extends SigmaException(message, parseError.map(e => SourceContext(e.index)))
+  extends SigmaException(message, parseError.map(e => SourceContext(e.index, e.extra.input.toString)))
 
 /**
   * Most keywords don't just require the correct characters to match,

--- a/src/main/scala/sigmastate/lang/syntax/Core.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Core.scala
@@ -107,8 +107,10 @@ trait Core extends syntax.Literals {
 //    val ClassQualifier = P( "[" ~ Id ~ "]" )
 //    val ThisSuper = P( `this` | `super` ~ ClassQualifier.? )
 //    val ThisPath: P0 = P( ThisSuper ~ ("." ~ PostDotCheck ~/ Id).rep )
-    val IdPath = P( Id.! ~ ("." ~ PostDotCheck ~/ (`this`.! | Id.!)).rep /*~ ("." ~ ThisPath).?*/ ).map {
-      case (h, t) => t.foldLeft[SValue](Ident(h))(builder.mkSelect(_, _))
+    val IdPath = P( Index ~ Id.! ~ ("." ~ PostDotCheck ~/ Index ~ (`this`.! | Id.!)).rep /*~ ("." ~ ThisPath).?*/ ).map {
+      case (hi, hs, t) => t.foldLeft[SValue](atSrcPos(hi){builder.mkIdent(hs, NoType)}){
+        case (obj, (i, s)) => atSrcPos(i) { builder.mkSelect(obj, s) }
+      }
     }
     P( /*ThisPath |*/ IdPath )
   }

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -3,7 +3,7 @@ package sigmastate.lang.syntax
 import fastparse.noApi._
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.lang.Terms.{Lambda, ApplyTypes, MethodCallLike, Apply, Val, ValueOps, Select, Ident}
+import sigmastate.lang.Terms.{Apply, ApplyTypes, Ident, Lambda, MethodCallLike, Select, Val, ValueOps}
 import sigmastate.lang._
 import sigmastate.lang.SigmaPredef._
 import sigmastate.lang.syntax.Basic._
@@ -207,15 +207,15 @@ trait Exprs extends Core with Types {
 
   val FunDef = {
     val Body = P( WL ~ `=` ~/ FreeCtx.Expr )
-    P(DottyExtMethodSubj.? ~ Id.! ~ FunSig ~ (`:` ~/ Type).? ~~ Body ).map {
-      case (None, n, args, resType, body) =>
+    P(Index ~ DottyExtMethodSubj.? ~ Id.! ~ FunSig ~ (`:` ~/ Type).? ~~ Body ).map {
+      case (index, None, n, args, resType, body) =>
         val lambda = builder.mkLambda(args.headOption.getOrElse(Seq()).toIndexedSeq, resType.getOrElse(NoType), Some(body))
-        builder.mkVal(n, resType.getOrElse(NoType), lambda)
-      case (Some(dottyExtSubj), n, args, resType, body) if args.length <= 1 =>
+        builder.mkVal(n, resType.getOrElse(NoType), lambda, srcCtx(index))
+      case (index, Some(dottyExtSubj), n, args, resType, body) if args.length <= 1 =>
         val combinedArgs = Seq(dottyExtSubj) ++ args.headOption.getOrElse(Seq())
         val lambda = builder.mkLambda(combinedArgs.toIndexedSeq, resType.getOrElse(NoType), Some(body))
-        builder.mkVal(n, resType.getOrElse(NoType), lambda)
-      case (dottyExt, n, secs, resType, body) =>
+        builder.mkVal(n, resType.getOrElse(NoType), lambda, srcCtx(index))
+      case (index, dottyExt, n, secs, resType, body) =>
         error(s"Function can only have single argument list: def ${dottyExt.getOrElse("")} $n($secs): ${resType.getOrElse(NoType)} = $body")
     }
   }

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -211,13 +211,13 @@ trait Exprs extends Core with Types {
     P(Index ~ DottyExtMethodSubj.? ~ Id.! ~ FunSig ~ (`:` ~/ Type).? ~~ Body ).map {
       case (index, None, n, args, resType, body) =>
         val lambda = builder.mkLambda(args.headOption.getOrElse(Seq()).toIndexedSeq, resType.getOrElse(NoType), Some(body))
-        builder.currentSrcCtx.withValue(Nullable(srcCtx(index))) {
+        atSourcePos(index) {
           builder.mkVal(n, resType.getOrElse(NoType), lambda)
         }
       case (index, Some(dottyExtSubj), n, args, resType, body) if args.length <= 1 =>
         val combinedArgs = Seq(dottyExtSubj) ++ args.headOption.getOrElse(Seq())
         val lambda = builder.mkLambda(combinedArgs.toIndexedSeq, resType.getOrElse(NoType), Some(body))
-        builder.currentSrcCtx.withValue(Nullable(srcCtx(index))) {
+        atSourcePos(index) {
           builder.mkVal(n, resType.getOrElse(NoType), lambda)
         }
       case (index, dottyExt, n, secs, resType, body) =>

--- a/src/main/scala/sigmastate/lang/syntax/Exprs.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Exprs.scala
@@ -4,7 +4,7 @@ import fastparse.noApi._
 import scalan.Nullable
 import sigmastate._
 import sigmastate.Values._
-import sigmastate.lang.Terms.{Apply, ApplyTypes, Ident, Lambda, MethodCallLike, Select, Val, ValueOps}
+import sigmastate.lang.Terms.{Ident, Val, ValueOps}
 import sigmastate.lang._
 import sigmastate.lang.SigmaPredef._
 import sigmastate.lang.syntax.Basic._
@@ -15,6 +15,7 @@ import scala.annotation.tailrec
 trait Exprs extends Core with Types {
 
   import WhitespaceApi._
+  import builder._
   def AnonTmpl: P0
   def BlockDef: P[Value[SType]]
 
@@ -44,13 +45,13 @@ trait Exprs extends Core with Types {
       val If = {
         val Else = P( Semi.? ~ `else` ~/ Expr )
         P( Index ~ `if` ~/ "(" ~ ExprCtx.Expr ~ ")" ~ Expr ~ Else ).map {
-          case (i, c, t, e) => atSrcPos(i) { builder.mkIf(c.asValue[SBoolean.type], t, e) }
+          case (i, c, t, e) => atSrcPos(i) { mkIf(c.asValue[SBoolean.type], t, e) }
         }
       }
       val Fun = P(`def` ~ FunDef)
 
-      val LambdaRhs = if (semiInference) P( BlockChunk.map {
-        case (_ , b)  => mkBlock(b)
+      val LambdaRhs = if (semiInference) P( (Index ~ BlockChunk).map {
+        case (index, (_ , b))  => atSrcPos(index) { block(b) }
       } )
       else P( Expr )
 //      val ParenedLambda = P( Parened ~~ (WL ~ `=>` ~ LambdaRhs.? /*| ExprSuffix ~~ PostfixSuffix ~ SuperPostfixSuffix*/) ).map {
@@ -60,11 +61,11 @@ trait Exprs extends Core with Types {
       val PostfixLambda = P( Index ~ PostfixExpr ~ (`=>` ~ LambdaRhs.? | SuperPostfixSuffix).? ).map {
         case (_, e, None) => e
         case (_, e, Some(None)) => e
-        case (i, Tuple(args), Some(Some(body))) => atSrcPos(i) { mkLambda(args, body) }
+        case (i, Tuple(args), Some(Some(body))) => atSrcPos(i) { lambda(args, body) }
         case (i, e, Some(body)) => error(s"Invalid declaration of lambda $e => $body", Some(srcCtx(i)))
       }
       val SmallerExprOrLambda = P( /*ParenedLambda |*/ PostfixLambda )
-//      val Arg = (Id.! ~ `:` ~/ Type).map { case (n, t) => Ident(IndexedSeq(n), t)}
+//      val Arg = (Id.! ~ `:` ~/ Type).map { case (n, t) => mkIdent(IndexedSeq(n), t)}
       P( If | Fun | SmallerExprOrLambda )
     }
 
@@ -74,7 +75,7 @@ trait Exprs extends Core with Types {
     val MatchAscriptionSuffix = P(`match` ~/ "{" ~ CaseClauses | Ascription)
     val ExprPrefix = P( WL ~ CharIn("-+!~").! ~~ !syntax.Basic.OpChar ~ WS)
     val ExprSuffix = P(
-      (WL ~ "." ~/ (Index ~ Id.!).map{ case (i, s) => atSrcPos(i) { builder.mkIdent(s, NoType)} }
+      (WL ~ "." ~/ (Index ~ Id.!).map{ case (i, s) => atSrcPos(i) { mkIdent(s, NoType)} }
       | WL ~ TypeArgs.map(items => STypeApply("", items.toIndexedSeq))
       | NoSemis ~ ArgList ).repX /* ~~ (NoSemis  ~ `_`).? */
     )
@@ -92,7 +93,7 @@ trait Exprs extends Core with Types {
         (op, rhs)
     }
     val PostFix = P( NoSemis ~~ WL ~~ (Index ~ Id.!) ~ Newline.? )
-      .map{ case (i, s) => atSrcPos(i) { builder.mkIdent(s, NoType)} }
+      .map{ case (i, s) => atSrcPos(i) { mkIdent(s, NoType)} }
 
     val PostfixSuffix = P( InfixSuffix.repX ~~ PostFix.?)
 
@@ -102,7 +103,9 @@ trait Exprs extends Core with Types {
         val obj = mkInfixTree(lhs, infixOps)
         postfix.fold(obj) {
           case Ident(name, _) =>
-            builder.mkMethodCallLike(obj, name, IndexedSeq.empty)
+            builder.currentSrcCtx.withValue(obj.sourceContext) {
+              mkMethodCallLike(obj, name, IndexedSeq.empty)
+            }
         }
     }
 
@@ -112,32 +115,21 @@ trait Exprs extends Core with Types {
 
       P( /*New | */ BlockExpr
         | ExprLiteral
-        | StableId //.map { case Ident(ps, t) => mkIdent(ps, t) }
-        | `_`.!.map(Ident(_))
-        | Parened.map(items =>
-            if (items.isEmpty) UnitConstant
-            else if (items.lengthCompare(1) == 0) items.head
-            else builder.mkTuple(items)) )
+        | StableId //.map { case Ident(ps, t) => Ident(ps, t) }
+        | (Index ~ `_`.!).map { case (i, lit) => atSrcPos(i) { mkIdent(lit, NoType) } }
+        | (Index ~ Parened).map {
+        case (index, Seq()) => atSrcPos(index) { mkUnitConstant }
+        case (_, Seq(item)) => item
+        case (index, items) => atSrcPos(index) { mkTuple(items) }
+      }
+      )
     }
     val Guard : P0 = P( `if` ~/ PostfixExpr ).ignore
   }
 
-  protected def mkIdent(nameParts: String, tpe: SType = NoType): SValue = {
-    builder.mkIdent(nameParts, tpe)
-  }
-
-  protected def mkLambda(args: Seq[Value[SType]], body: Value[SType]): Value[SType] = {
+  protected def lambda(args: Seq[Value[SType]], body: Value[SType]): Value[SType] = {
     val names = args.map { case Ident(n, t) => (n, t) }
-    builder.mkLambda(names.toIndexedSeq, NoType, Some(body))
-  }
-
-  protected def mkApply(func: Value[SType], args: IndexedSeq[Value[SType]]): Value[SType] = (func, args) match {
-    case _ => builder.mkApply(func, args)
-  }
-
-  def mkApplyTypes(input: Value[SType], targs: IndexedSeq[SType]): Value[SType] = {
-//    val subst = targs.zipWithIndex.map { case (t, i) => (STypeIdent(s"_${i + 1}") -> t) }.toMap
-    builder.mkApplyTypes(input, targs)
+    mkLambda(names.toIndexedSeq, NoType, Some(body))
   }
 
   /** The precedence of an infix operator is determined by the operator's first character.
@@ -190,36 +182,38 @@ trait Exprs extends Core with Types {
 
 
   protected def applySuffix(f: Value[SType], args: Seq[SigmaNode]): Value[SType] = {
-    val rhs = args.foldLeft(f)((acc, arg) => arg match {
-      case Ident(name, _) => builder.mkSelect(acc, name)
-      case UnitConstant => mkApply(acc, IndexedSeq.empty)
-      case Tuple(xs) => mkApply(acc, xs)
-      case STypeApply("", targs) => mkApplyTypes(acc, targs)
-      case arg: SValue => acc match {
-        case Ident(name, _) if name == "ZKProof" => arg match {
-          case Terms.Block(_, body) => Apply(ZKProofFunc.sym, IndexedSeq(body))
-          case nonBlock => error(s"expected block parameter for ZKProof, got $nonBlock", nonBlock.sourceContext)
+    builder.currentSrcCtx.withValue(f.sourceContext) {
+      val rhs = args.foldLeft(f)((acc, arg) => arg match {
+        case Ident(name, _) => mkSelect(acc, name)
+        case UnitConstant() => mkApply(acc, IndexedSeq.empty)
+        case Tuple(xs) => mkApply(acc, xs)
+        case STypeApply("", targs) => mkApplyTypes(acc, targs)
+        case arg: SValue => acc match {
+          case Ident(name, _) if name == "ZKProof" => arg match {
+            case Terms.Block(_, body) => mkApply(ZKProofFunc.sym, IndexedSeq(body))
+            case nonBlock => error(s"expected block parameter for ZKProof, got $nonBlock", nonBlock.sourceContext)
+          }
+          case _ => mkApply(acc, IndexedSeq(arg))
         }
-        case _ => mkApply(acc, IndexedSeq(arg))
-      }
-      case _ => error(s"Error after expression $f: invalid suffixes $args", f.sourceContext)
-    })
-    rhs
+        case _ => error(s"Error after expression $f: invalid suffixes $args", f.sourceContext)
+      })
+      rhs
+    }
   }
 
   val FunDef = {
     val Body = P( WL ~ `=` ~/ FreeCtx.Expr )
     P(Index ~ DottyExtMethodSubj.? ~ Id.! ~ FunSig ~ (`:` ~/ Type).? ~~ Body ).map {
       case (index, None, n, args, resType, body) =>
-        val lambda = builder.mkLambda(args.headOption.getOrElse(Seq()).toIndexedSeq, resType.getOrElse(NoType), Some(body))
+        val lambda = mkLambda(args.headOption.getOrElse(Seq()).toIndexedSeq, resType.getOrElse(NoType), Some(body))
         atSrcPos(index) {
-          builder.mkVal(n, resType.getOrElse(NoType), lambda)
+          mkVal(n, resType.getOrElse(NoType), lambda)
         }
       case (index, Some(dottyExtSubj), n, args, resType, body) if args.length <= 1 =>
         val combinedArgs = Seq(dottyExtSubj) ++ args.headOption.getOrElse(Seq())
-        val lambda = builder.mkLambda(combinedArgs.toIndexedSeq, resType.getOrElse(NoType), Some(body))
+        val lambda = mkLambda(combinedArgs.toIndexedSeq, resType.getOrElse(NoType), Some(body))
         atSrcPos(index) {
-          builder.mkVal(n, resType.getOrElse(NoType), lambda)
+          mkVal(n, resType.getOrElse(NoType), lambda)
         }
       case (index, dottyExt, n, secs, resType, body) =>
         error(s"Function can only have single argument list: def ${dottyExt.getOrElse("")} $n($secs): ${resType.getOrElse(NoType)} = $body", Some(srcCtx(index)))
@@ -230,7 +224,8 @@ trait Exprs extends Core with Types {
     val TupleEx = P( "(" ~/ Pattern.repTC() ~ ")" )
     val Extractor = P( StableId /* ~ TypeArgs.?*/ ~ TupleEx.? )
 //    val Thingy = P( `_` ~ (`:` ~/ TypePat).? ~ !("*" ~~ !syntax.Basic.OpChar) )
-    P( /*Thingy | PatLiteral |*/ TupleEx | Extractor | VarId.!.map(Ident(_)))
+    P( /*Thingy | PatLiteral |*/ TupleEx | Extractor
+      | (Index ~ VarId.!).map { case (i, lit) => atSrcPos(i) { mkIdent(lit, NoType) } })
   }
 
   val BlockExpr = P( "{" ~/ (/*CaseClauses |*/ Block ~ "}") )
@@ -262,12 +257,12 @@ trait Exprs extends Core with Types {
       (lets.toList, stats.last)
     }
     else
-      (Seq(), UnitConstant)
+      (Seq(), mkUnitConstant)
   }
 
-  protected def mkBlock(stats: Seq[SValue]): SValue = {
+  protected def block(stats: Seq[SValue]): SValue = {
     val (lets, body) = extractBlockStats(stats)
-    builder.mkBlock(lets, body)
+    mkBlock(lets, body)
   }
 
   def BaseBlock(end: P0)(implicit name: sourcecode.Name): P[Value[SType]] = {
@@ -275,18 +270,20 @@ trait Exprs extends Core with Types {
     val Body = P( BlockChunk.repX(sep = Semis) )
     P( Index ~ Semis.? ~ BlockLambda.? ~ Body ~/ BlockEnd ).map {
       case (index, Some(args), Seq((Seq(), Seq(b)))) =>
-        atSrcPos(index) { builder.mkLambda(args.toIndexedSeq, NoType, Some(b)) }
+        atSrcPos(index) { mkLambda(args.toIndexedSeq, NoType, Some(b)) }
       case (index, Some(args), bodyItems) =>
-          val block = mkBlock(bodyItems.flatMap {
+        atSrcPos(index) {
+          val b = block(bodyItems.flatMap {
             case (Seq(), exprs) => exprs
           })
-        atSrcPos(index) {
-          builder.mkLambda(args.toIndexedSeq, NoType, Some(block))
+          mkLambda(args.toIndexedSeq, NoType, Some(b))
         }
-      case (_, None, bodyItems) =>
-        mkBlock(bodyItems.flatMap {
-          case (Seq(), exprs) => exprs
-        })
+      case (index, None, bodyItems) =>
+        atSrcPos(index) {
+          block(bodyItems.flatMap {
+            case (Seq(), exprs) => exprs
+          })
+        }
     }
   }
   val Block = BaseBlock("}")
@@ -303,9 +300,9 @@ trait Exprs extends Core with Types {
   }
 
   val TypePat = P( CompoundType )
-  val ParenArgList = P( "(" ~/ Exprs /*~ (`:` ~/ `_*`).?*/.? ~ TrailingComma ~ ")" ).map {
-    case Some(exprs) => builder.mkTuple(exprs)
-    case None => UnitConstant
+  val ParenArgList = P( "(" ~/ Index ~ Exprs /*~ (`:` ~/ `_*`).?*/.? ~ TrailingComma ~ ")" ).map {
+    case (index, Some(exprs)) => atSrcPos(index) { mkTuple(exprs) }
+    case (index, None) => atSrcPos(index) { mkUnitConstant }
   }
   val ArgList = P( ParenArgList | OneNLMax ~ BlockExpr )
 

--- a/src/main/scala/sigmastate/lang/syntax/Literals.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Literals.scala
@@ -8,10 +8,11 @@ import fastparse.{all, core}
 import java.lang.Long.parseLong
 import java.lang.Integer.parseInt
 
-import sigmastate.lang.{SigmaBuilder, StdSigmaBuilder}
+import sigmastate.lang.{SigmaBuilder, SourceContext, StdSigmaBuilder}
 
 trait Literals { l =>
-  var builder: SigmaBuilder = StdSigmaBuilder
+  val builder: SigmaBuilder = StdSigmaBuilder
+  def srcCtx(parserIndex: Int): SourceContext
   def Block: P[Value[SType]]
   def Pattern: P0
 

--- a/src/main/scala/sigmastate/lang/syntax/Literals.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Literals.scala
@@ -12,7 +12,7 @@ import sigmastate.lang.{SigmaBuilder, SourceContext, StdSigmaBuilder}
 
 trait Literals { l =>
   val builder: SigmaBuilder = StdSigmaBuilder
-  def srcCtx(parserIndex: Int): SourceContext
+  def atSourcePos[A](parserIndex: Int)(thunk: => A): A
   def Block: P[Value[SType]]
   def Pattern: P0
 

--- a/src/main/scala/sigmastate/lang/syntax/Literals.scala
+++ b/src/main/scala/sigmastate/lang/syntax/Literals.scala
@@ -13,6 +13,7 @@ import sigmastate.lang.{SigmaBuilder, SourceContext, StdSigmaBuilder}
 trait Literals { l =>
   val builder: SigmaBuilder = StdSigmaBuilder
   def atSourcePos[A](parserIndex: Int)(thunk: => A): A
+  def srcCtx(parserIndex: Int): SourceContext
   def Block: P[Value[SType]]
   def Pattern: P0
 

--- a/src/test/scala/sigmastate/lang/LangTests.scala
+++ b/src/test/scala/sigmastate/lang/LangTests.scala
@@ -6,6 +6,7 @@ import sigmastate._
 import java.math.BigInteger
 
 import org.bouncycastle.math.ec.ECPoint
+import org.scalatest.Matchers
 import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.SCollection.SByteArray
 import sigmastate.basics.ProveDHTuple
@@ -13,7 +14,7 @@ import sigmastate.eval.CostingSigmaDslBuilder
 import sigmastate.interpreter.CryptoConstants
 import sigmastate.interpreter.Interpreter.ScriptEnv
 
-trait LangTests {
+trait LangTests extends Matchers {
 
   def BoolIdent(name: String): Value[SBoolean.type] = Ident(name).asValue[SBoolean.type]
   def IntIdent(name: String): Value[SLong.type] = Ident(name).asValue[SLong.type]
@@ -70,4 +71,13 @@ trait LangTests {
 
   /** Parses string to SType tree */
   def ty(s: String): SType = SigmaParser.parseType(s)
+
+  def assertSrcCtxForAllNodes(tree: SValue): Unit = {
+    import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
+    rewrite(everywherebu(rule[SValue] {
+      case node =>
+        withClue(s"Missing sourceContext for $node") { node.sourceContext.isDefined shouldBe true }
+        node
+    }))(tree)
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -179,8 +179,12 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("val fails (already defined in env)") {
-    val script= "{val x = 10; x > 2}"
+    val script= """{
+        |val x = 10
+        |x > 2
+        |
+        |}""".stripMargin
     val e = the[BinderException] thrownBy bind(env, script)
-    e.source shouldBe Some(SourceContext(1, 6, script))
+    e.source shouldBe Some(SourceContext(2, 5, "val x = 10"))
   }
 }

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -91,7 +91,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("tuple constructor") {
-    bind(env, "()") shouldBe UnitConstant
+    bind(env, "()") shouldBe UnitConstant()
     bind(env, "(1)") shouldBe IntConstant(1)
     bind(env, "(1, 2)") shouldBe Tuple(IntConstant(1), IntConstant(2))
     bind(env, "(1, x - 1)") shouldBe Tuple(IntConstant(1), Minus(10, 1))

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -24,6 +24,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
       new PredefinedFuncRegistry(builder))
     val res = binder.bind(ast)
     res.sourceContext.isDefined shouldBe true
+    assertSrcCtxForAllNodes(res)
     res
   }
 
@@ -66,6 +67,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "min(1, 2)") shouldBe Min(IntConstant(1), IntConstant(2))
     bind(env, "max(1, 2)") shouldBe Max(IntConstant(1), IntConstant(2))
     bind(env, "min(1, 2L)") shouldBe Min(Upcast(IntConstant(1), SLong), LongConstant(2))
+    bind(env, "max(1, 2L)") shouldBe Max(Upcast(IntConstant(1), SLong), LongConstant(2))
   }
 
   property("min/max fail (invalid arguments)") {

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -19,7 +19,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
 
   def bind(env: ScriptEnv, x: String): SValue = {
     val builder = TransformingSigmaBuilder
-    val ast = SigmaParser(x, builder).get.value
+    val ast = SigmaParser(x, builder).parse.get.value
     val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix,
       new PredefinedFuncRegistry(builder))
     binder.bind(ast)
@@ -178,4 +178,9 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     bind(env, "Coll[Int]()") shouldBe ConcreteCollection()(SInt)
   }
 
+  property("val fails (already defined in env)") {
+    val script= "{val x = 10; x > 2}"
+    val e = the[BinderException] thrownBy bind(env, script)
+    e.source shouldBe Some(SourceContext(1, 6, script))
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -19,7 +19,7 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
 
   def bind(env: ScriptEnv, x: String): SValue = {
     val builder = TransformingSigmaBuilder
-    val ast = SigmaParser(x, builder).parse.get.value
+    val ast = SigmaParser(x, builder).get.value
     val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix,
       new PredefinedFuncRegistry(builder))
     binder.bind(ast)

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -179,11 +179,17 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("val fails (already defined in env)") {
+    val script= "{ val x = 10; x > 2 }"
+    (the[BinderException] thrownBy bind(env, script)).source shouldBe
+      Some(SourceContext(1, 7, script))
+  }
+
+  property("val fails (already defined in env) multiline") {
     val script= """{
-        |val x = 10
-        |x > 2
-        |
-        |}""".stripMargin
+                  |val x = 10
+                  |x > 2
+                  |
+                  |}""".stripMargin
     val e = the[BinderException] thrownBy bind(env, script)
     e.source shouldBe Some(SourceContext(2, 5, "val x = 10"))
   }

--- a/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -22,7 +22,9 @@ class SigmaBinderTest extends PropSpec with PropertyChecks with Matchers with La
     val ast = SigmaParser(x, builder).get.value
     val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix,
       new PredefinedFuncRegistry(builder))
-    binder.bind(ast)
+    val res = binder.bind(ast)
+    res.sourceContext.isDefined shouldBe true
+    res
   }
 
   property("simple expressions") {

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -32,6 +32,17 @@ class SigmaCompilerTest extends SigmaTestingCommons with LangTests with ValueGen
     an [CosterException] should be thrownBy comp(env, script)
   }
 
+  private def costerFail(env: ScriptEnv, x: String, expectedLine: Int, expectedCol: Int): Unit = {
+    val exception = the[CosterException] thrownBy comp(env, x)
+    withClue(s"Exception: $exception, is missing source context:") { exception.source shouldBe defined }
+    val sourceContext = exception.source.get
+    sourceContext.line shouldBe expectedLine
+    sourceContext.column shouldBe expectedCol
+  }
+
+  private def costerFail(x: String, expectedLine: Int, expectedCol: Int): Unit =
+    costerFail(env, x, expectedLine, expectedCol)
+
   property("array indexed access") {
     comp(env, "Coll(1)(0)") shouldBe
       ByIndex(ConcreteCollection(IndexedSeq(IntConstant(1)))(SInt), 0)
@@ -190,6 +201,11 @@ class SigmaCompilerTest extends SigmaTestingCommons with LangTests with ValueGen
 
   property("BitShiftRightZeroed") {
     testMissingCosting("1 >>> 2", mkBitShiftRightZeroed(IntConstant(1), IntConstant(2)))
+  }
+
+  property("failed option constructors (not supported)") {
+    costerFail("None", 1, 1)
+    costerFail("Some(10)", 1, 1)
   }
 
 }

--- a/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -26,22 +26,6 @@ class SigmaCompilerTest extends SigmaTestingCommons with LangTests with ValueGen
   private def compWOCosting(x: String): Value[SType] = compile(env, x)
   private def compWOCosting(env: ScriptEnv, x: String): Value[SType] = compile(env, x)
 
-  private def fail(env: ScriptEnv, x: String, index: Int, expected: Any): Unit = {
-    try {
-      val res = compiler.compile(env, x)
-      assert(false, s"Error expected")
-    } catch {
-      case e: TestFailedException =>
-        throw e
-      case pe: ParserException if pe.parseError.isDefined =>
-        val p = pe
-        val i = pe.parseError.get.index
-        val l = pe.parseError.get.lastParser
-        i shouldBe index
-        l.toString shouldBe expected.toString
-    }
-  }
-
   private def testMissingCosting(script: String, expected: SValue): Unit = {
     compWOCosting(script) shouldBe expected
     // when implemented in coster this should be changed to a positive expectation
@@ -86,15 +70,6 @@ class SigmaCompilerTest extends SigmaTestingCommons with LangTests with ValueGen
     comp("{ def f(i: Int) = { i + 1 }; f(2) }") shouldBe Apply(
       FuncValue(Vector((1,SInt)),Plus(ValUse(1,SInt), IntConstant(1))),
       Vector(IntConstant(2)))
-  }
-
-  property("negative tests") {
-    fail(env, "(10", 3, "\")\"")
-    fail(env, "10)", 2, "End")
-    fail(env, "X)", 1, "End")
-    fail(env, "(X", 2, "\")\"")
-    fail(env, "{ X", 3, "\"}\"")
-    fail(env, "{ val X", 7, "\"=\"")
   }
 
   property("allOf") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -19,7 +19,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   import predefFuncRegistry._
 
   def parse(x: String): SValue = {
-    SigmaParser(x, TransformingSigmaBuilder) match {
+    SigmaParser(x, TransformingSigmaBuilder).parse match {
       case Parsed.Success(v, _) => v
       case f@Parsed.Failure(_, _, extra) =>
         val traced = extra.traced
@@ -34,7 +34,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   def fail(x: String, index: Int): Unit = {
     try {
-      val res = SigmaParser(x, TransformingSigmaBuilder).get.value
+      val res = SigmaParser(x, TransformingSigmaBuilder).parse.get.value
       assert(false, s"Error expected")
     } catch {
       case e: TestFailedException =>

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -21,7 +21,9 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   def parse(x: String): SValue = {
     SigmaParser(x, TransformingSigmaBuilder) match {
-      case Parsed.Success(v, _) => v
+      case Parsed.Success(v, _) =>
+        v.sourceContext.isDefined shouldBe true
+        v
       case f@Parsed.Failure(_, _, extra) =>
         val traced = extra.traced
         println(s"\nTRACE: ${traced.trace}")
@@ -116,7 +118,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("tuple operations") {
-    parse("()") shouldBe UnitConstant
+    parse("()") shouldBe UnitConstant()
     parse("(1)") shouldBe IntConstant(1)
     parse("(1, 2)") shouldBe Tuple(IntConstant(1), IntConstant(2))
     parse("(1, X - 1)") shouldBe Tuple(IntConstant(1), mkMinus(IntIdent("X"), 1))

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -869,4 +869,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     )
   }
 
+  property("single name pattern fail") {
+    fail("{val (a,b) = (1,2)}", 1, 6)
+  }
 }

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -23,6 +23,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     SigmaParser(x, TransformingSigmaBuilder) match {
       case Parsed.Success(v, _) =>
         v.sourceContext.isDefined shouldBe true
+        assertSrcCtxForAllNodes(v)
         v
       case f@Parsed.Failure(_, _, extra) =>
         val traced = extra.traced

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -19,7 +19,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   import predefFuncRegistry._
 
   def parse(x: String): SValue = {
-    SigmaParser(x, TransformingSigmaBuilder).parse match {
+    SigmaParser(x, TransformingSigmaBuilder) match {
       case Parsed.Success(v, _) => v
       case f@Parsed.Failure(_, _, extra) =>
         val traced = extra.traced
@@ -34,7 +34,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   def fail(x: String, index: Int): Unit = {
     try {
-      val res = SigmaParser(x, TransformingSigmaBuilder).parse.get.value
+      val res = SigmaParser(x, TransformingSigmaBuilder).get.value
       assert(false, s"Error expected")
     } catch {
       case e: TestFailedException =>

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -33,19 +33,6 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
     SigmaParser.parseType(x)
   }
 
-  def fail(x: String, index: Int): Unit = {
-    try {
-      val res = SigmaParser(x, TransformingSigmaBuilder).get.value
-      assert(false, s"Error expected")
-    } catch {
-      case e: TestFailedException =>
-        throw e
-      case pe: ParseError[_,_] =>
-        val l = pe.failure.index
-        l shouldBe index
-    }
-  }
-
   def fail(x: String, expectedLine: Int, expectedCol: Int): Unit = {
     val compiler = SigmaCompiler(ErgoAddressEncoder.TestnetNetworkPrefix)
     val sourceContext = (the[ParserException] thrownBy compiler.parse(x)).source.get
@@ -565,13 +552,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
   }
 
   property("negative tests") {
-    fail("(10", 3)
-    fail("10)", 2)
-    fail("X)", 1)
-    fail("(X", 2)
-    fail("{ X", 3)
-    fail("{ val X", 7)
-    fail("\"str", 4)
+    fail("(10", 1, 4)
+    fail("10)", 1, 3)
+    fail("X)", 1, 2)
+    fail("(X", 1, 3)
+    fail("{ X", 1, 4)
+    fail("{ val X", 1, 8)
+    fail("\"str", 1, 5)
   }
 
   property("not(yet) supported lambda syntax") {

--- a/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -1,6 +1,7 @@
 package sigmastate.lang
 
 import fastparse.core.{ParseError, Parsed}
+import org.ergoplatform.ErgoAddressEncoder
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
@@ -43,6 +44,13 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
         val l = pe.failure.index
         l shouldBe index
     }
+  }
+
+  def fail(x: String, expectedLine: Int, expectedCol: Int): Unit = {
+    val compiler = SigmaCompiler(ErgoAddressEncoder.TestnetNetworkPrefix)
+    val sourceContext = (the[ParserException] thrownBy compiler.parse(x)).source.get
+    sourceContext.line shouldBe expectedLine
+    sourceContext.column shouldBe expectedCol
   }
 
   def and(l: SValue, r: SValue) = MethodCallLike(l, "&&", IndexedSeq(r))
@@ -568,7 +576,7 @@ class SigmaParserTest extends PropSpec with PropertyChecks with Matchers with La
 
   property("not(yet) supported lambda syntax") {
     // passing a lambda without curly braces is not supported yet :)
-    fail("arr.exists ( (a: Int) => a >= 1 )", 15)
+    fail("arr.exists ( (a: Int) => a >= 1 )", 1, 16)
     // no argument type
     an[ParserException] should be thrownBy parse("arr.exists ( a => a >= 1 )")
     an[ParserException] should be thrownBy parse("arr.exists { a => a >= 1 }")

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -33,7 +33,7 @@ class SigmaSpecializerTest extends PropSpec
 
   def typed(env: Map[String, SValue], x: String): SValue = {
     val builder = TransformingSigmaBuilder
-    val parsed = SigmaParser(x, builder).parse.get.value
+    val parsed = SigmaParser(x, builder).get.value
     val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
     val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
     val bound = binder.bind(parsed)

--- a/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaSpecializerTest.scala
@@ -33,7 +33,7 @@ class SigmaSpecializerTest extends PropSpec
 
   def typed(env: Map[String, SValue], x: String): SValue = {
     val builder = TransformingSigmaBuilder
-    val parsed = SigmaParser(x, builder).get.value
+    val parsed = SigmaParser(x, builder).parse.get.value
     val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
     val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
     val bound = binder.bind(parsed)

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -37,24 +37,19 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     }
   }
 
-  def typefail(env: ScriptEnv, x: String, messageSubstr: String = ""): Unit = {
-    try {
-      val builder = TransformingSigmaBuilder
-      val parsed = SigmaParser(x, builder).get.value
-      val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
-      val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
-      val bound = binder.bind(parsed)
-      val st = new SigmaTree(bound)
-      val typer = new SigmaTyper(builder, predefinedFuncRegistry)
-      val typed = typer.typecheck(bound)
-      assert(false, s"Should not typecheck: $x")
-    } catch {
-      case e: TyperException =>
-        if (messageSubstr.nonEmpty)
-          if (!e.getMessage.contains(messageSubstr)) {
-            throw new AssertionError(s"Error message '${e.getMessage}' doesn't contain '$messageSubstr'.", e)
-          }
-    }
+  def typefail(env: ScriptEnv, x: String, expectedLine: Int, expectedCol: Int): Unit = {
+    val builder = TransformingSigmaBuilder
+    val parsed = SigmaParser(x, builder).get.value
+    val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
+    val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
+    val bound = binder.bind(parsed)
+    val st = new SigmaTree(bound)
+    val typer = new SigmaTyper(builder, predefinedFuncRegistry)
+    val exception = the[TyperException] thrownBy typer.typecheck(bound)
+    withClue(s"Exception: $exception, is missing source context:") { exception.source shouldBe defined }
+    val sourceContext = exception.source.get
+    sourceContext.line shouldBe expectedLine
+    sourceContext.column shouldBe expectedCol
   }
 
   property("simple expressions") {
@@ -72,12 +67,12 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "INPUTS.size") shouldBe SInt
     typecheck(env, "INPUTS.size > 1", GT(Select(Inputs, "size", Some(SInt)), 1)) shouldBe SBoolean
     // todo: restore in https://github.com/ScorexFoundation/sigmastate-interpreter/issues/324
-//    typecheck(env, "arr1 | arr2", Xor(ByteArrayConstant(arr1), ByteArrayConstant(arr2))) shouldBe SByteArray
+    //    typecheck(env, "arr1 | arr2", Xor(ByteArrayConstant(arr1), ByteArrayConstant(arr2))) shouldBe SByteArray
     typecheck(env, "arr1 ++ arr2", Append(ByteArrayConstant(arr1), ByteArrayConstant(arr2))) shouldBe SByteArray
     typecheck(env, "col1 ++ col2") shouldBe SCollection(SLong)
     // todo should be g1.exp(n1)
     // ( see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/324 )
-//    typecheck(env, "g1 ^ n1") shouldBe SGroupElement
+    //    typecheck(env, "g1 ^ n1") shouldBe SGroupElement
     typecheck(env, "g1 * g2") shouldBe SGroupElement
     typecheck(env, "p1 || p2") shouldBe SSigmaProp
     typecheck(env, "p1 && p2") shouldBe SSigmaProp
@@ -121,8 +116,8 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, """{val X = 10 + 1; X >= X}""".stripMargin) shouldBe SBoolean
     typecheck(env,
       """{val X = 10
-       |val Y = X + 1
-       |X < Y}
+        |val Y = X + 1
+        |X < Y}
       """.stripMargin) shouldBe SBoolean
     typecheck(env, "{val X = (10, true); X._1 > 2 && X._2}") shouldBe SBoolean
     typecheck(env, "{val X = (Coll(1,2,3), 1); X}") shouldBe STuple(SCollection(SInt), SInt)
@@ -153,7 +148,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "(1, 2L)._2") shouldBe SLong
     typecheck(env, "(1, 2L, 3)._3") shouldBe SInt
 
-    an[MethodNotFound] should be thrownBy typecheck(env, "(1, 2L)._3")
+    typefail(env, "(1, 2L)._3", 1, 1)
 
     // tuple as collection
     typecheck(env, "(1, 2L).size") shouldBe SInt
@@ -185,16 +180,16 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("array literals") {
-    typefail(env, "Coll()", "Undefined type of empty collection")
-    typefail(env, "Coll(Coll())", "Undefined type of empty collection")
-    typefail(env, "Coll(Coll(Coll()))", "Undefined type of empty collection")
+    typefail(env, "Coll()", 1, 1)
+    typefail(env, "Coll(Coll())", 1, 6)
+    typefail(env, "Coll(Coll(Coll()))", 1, 11)
 
     typecheck(env, "Coll(1)") shouldBe SCollection(SInt)
     typecheck(env, "Coll(1, x)") shouldBe SCollection(SInt)
     typecheck(env, "Coll(Coll(x + 1))") shouldBe SCollection(SCollection(SInt))
 
-    typefail(env, "Coll(1, x + 1, Coll())")
-    typefail(env, "Coll(1, false)")
+    typefail(env, "Coll(1, x + 1, Coll())", 1, 16)
+    typefail(env, "Coll(1, false)", 1, 1)
   }
 
   property("Option constructors") {
@@ -210,23 +205,23 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("array indexed access") {
-    typefail(env, "Coll()(0)", "Undefined type of empty collection")
+    typefail(env, "Coll()(0)", 1, 1)
     typecheck(env, "Coll(0)(0)") shouldBe SInt
-    typefail(env, "Coll(0)(0)(0)", "array type is expected")
+    typefail(env, "Coll(0)(0)(0)", 1, 1)
   }
 
   property("array indexed access with evaluation") {
     typecheck(env, "Coll(0)(1 - 1)") shouldBe SInt
     typecheck(env, "Coll(0)((1 - 1) + 0)") shouldBe SInt
-    typefail(env, "Coll(0)(0 == 0)", "Invalid argument type of array application")
-    typefail(env, "Coll(0)(1,1,1)", "Invalid argument of array application")
+    typefail(env, "Coll(0)(0 == 0)", 1, 9)
+    typefail(env, "Coll(0)(1,1,1)", 1, 1)
   }
 
   property("array indexed access with default value") {
     typecheck(env, "Coll(0).getOrElse(0, 1)") shouldBe SInt
-    typefail(env, "Coll(0).getOrElse(true, 1)", "Invalid argument type of application")
-    typefail(env, "Coll(true).getOrElse(0, 1)", "Invalid argument type of application")
-    typefail(env, "Coll(0).getOrElse(0, Coll(1))", "Invalid argument type of application")
+    typefail(env, "Coll(0).getOrElse(true, 1)", 1, 1)
+    typefail(env, "Coll(true).getOrElse(0, 1)", 1, 1)
+    typefail(env, "Coll(0).getOrElse(0, Coll(1))", 1, 1)
   }
 
   property("array indexed access with default value with evaluation") {
@@ -245,7 +240,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "{ (p: (Int, SigmaProp), box: Box) => p._1 > box.value && p._2.isProven }") shouldBe
       SFunc(IndexedSeq(STuple(SInt, SSigmaProp), SBox), SBoolean)
 
-    typefail(env, "{ (a) => a + 1 }", "undefined type of argument")
+    typefail(env, "{ (a) => a + 1 }", 1, 3)
   }
 
   property("function definitions via val") {
@@ -270,14 +265,13 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "SELF.R1[Int].isDefined") shouldBe SBoolean
     typecheck(env, "SELF.R1[Int].isEmpty") shouldBe SBoolean
     typecheck(env, "SELF.R1[Int].get") shouldBe SInt
-    typefail(env, "x[Int]", "doesn't have type parameters")
-    typefail(env, "arr1[Int]", "doesn't have type parameters")
+    typefail(env, "x[Int]", 1, 1)
+    typefail(env, "arr1[Int]", 1, 1)
     typecheck(env, "SELF.R1[(Int,Boolean)]") shouldBe SOption(STuple(SInt, SBoolean))
     typecheck(env, "SELF.R1[(Int,Boolean)].get") shouldBe STuple(SInt, SBoolean)
-    an[IllegalArgumentException] should be thrownBy typecheck(env, "SELF.R1[Int,Boolean].get")
+    typefail(env, "SELF.R1[Int,Boolean].get", 1, 6)
     typecheck(env, "Coll[Int]()") shouldBe SCollection(SInt)
   }
-
 
   property("compute unifying type substitution: prim types") {
     import SigmaTyper._
@@ -438,25 +432,23 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("invalid binary operations type check") {
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 == false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 != false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 > false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 >= false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 < false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 <= false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 + false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 - false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 / false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 % false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "min(1, false)")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "max(1, false)")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 * false")
-    an[InvalidBinaryOperationParameters] should be thrownBy typecheck(env, "1 + \"a\"")
-    an[NonApplicableMethod] should be thrownBy typecheck(env, "1 || 1")
-    an[NonApplicableMethod] should be thrownBy typecheck(env, "col1 || col2")
-    an[NonApplicableMethod] should be thrownBy typecheck(env, "g1 || g2")
-    an[NonApplicableMethod] should be thrownBy typecheck(env, "true ++ false")
-    an[NonApplicableMethod] should be thrownBy typecheck(env, "\"a\" ++ \"a\"")
+    typefail(env, "1 == false", 1, 1)
+    typefail(env, "1 != false", 1, 1)
+    typefail(env, "1 > false", 1, 1)
+    typefail(env, "1 < false", 1, 1)
+    typefail(env, "1 + false", 1, 5)
+    typefail(env, "1 - false", 1, 1)
+    typefail(env, "1 / false", 1, 1)
+    typefail(env, "1 % false", 1, 1)
+    typefail(env, "min(1, false)", 1, 5)
+    typefail(env, "max(1, false)", 1, 5)
+    typefail(env, "1 * false", 1, 5)
+    typefail(env, "1 + \"a\"", 1, 5)
+    typefail(env, "1 || 1", 1, 1)
+    typefail(env, "col1 || col2", 1, 1)
+    typefail(env, "g1 || g2", 1, 1)
+    typefail(env, "true ++ false", 1, 1)
+    typefail(env, "\"a\" ++ \"a\"", 1, 1)
   }
 
   property("upcast for binary operations with numeric types") {
@@ -483,7 +475,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("invalid cast method for numeric types") {
-    an[MethodNotFound] should be thrownBy typecheck(env, "1.toSuperBigInteger")
+    typefail(env, "1.toSuperBigInteger", 1, 1)
   }
 
   property("string concat") {
@@ -494,24 +486,24 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     typecheck(env, "10.toBigInt.modQ") shouldBe SBigInt
     typecheck(env, "10.toBigInt.plusModQ(2.toBigInt)") shouldBe SBigInt
     typecheck(env, "10.toBigInt.minusModQ(2.toBigInt)") shouldBe SBigInt
-    an[MethodNotFound] should be thrownBy typecheck(env, "10.modQ")
-    an[TyperException] should be thrownBy typecheck(env, "10.toBigInt.plusModQ(1)")
-    an[TyperException] should be thrownBy typecheck(env, "10.toBigInt.minusModQ(1)")
+    typefail(env, "10.modQ", 1, 1)
+    typefail(env, "10.toBigInt.plusModQ(1)", 1, 1)
+    typefail(env, "10.toBigInt.minusModQ(1)", 1, 1)
   }
 
   property("byteArrayToLong") {
     typecheck(env, "byteArrayToLong(Coll[Byte](1.toByte))") shouldBe SLong
-    an[TyperException] should be thrownBy typecheck(env, "byteArrayToLong(Coll[Int](1))")
+    typefail(env, "byteArrayToLong(Coll[Int](1))", 1, 1)
   }
 
   property("decodePoint") {
     typecheck(env, "decodePoint(Coll[Byte](1.toByte))") shouldBe SGroupElement
-    an[TyperException] should be thrownBy typecheck(env, "decodePoint(Coll[Int](1))")
+    typefail(env, "decodePoint(Coll[Int](1))", 1, 1)
   }
 
   property("xorOf") {
     typecheck(env, "xorOf(Coll[Boolean](true, false))") shouldBe SBoolean
-    an[TyperException] should be thrownBy typecheck(env, "xorOf(Coll[Int](1))")
+    typefail(env, "xorOf(Coll[Int](1))", 1, 1)
   }
 
   property("outerJoin") {
@@ -526,7 +518,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   }
 
   property("AtLeast (invalid parameters)") {
-    an [TyperException] should be thrownBy typecheck(env, "atLeast(2, 2)")
+    typefail(env, "atLeast(2, 2)", 1, 1)
   }
 
   property("substConstants") {
@@ -539,17 +531,17 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("LogicalNot") {
     typecheck(env, "!true") shouldBe SBoolean
-    an [TyperException] should be thrownBy typecheck(env, "!getVar[SigmaProp](1).get")
+    typefail(env, "!getVar[SigmaProp](1).get", 1, 2)
   }
 
   property("Negation") {
     typecheck(env, "-HEIGHT") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "-true")
+    typefail(env, "-true", 1, 2)
   }
 
   property("BitInversion") {
     typecheck(env, "~1") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "~true")
+    typefail(env, "~true", 1, 2)
   }
 
   property("LogicalXor") {
@@ -558,12 +550,12 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("BitwiseOr") {
     typecheck(env, "1 | 2") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "true | false")
+    typefail(env, "true | false", 1, 1)
   }
 
   property("BitwiseAnd") {
     typecheck(env, "1 & 2") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "true & false")
+    typefail(env, "true & false", 1, 1)
   }
 
   property("BitwiseXor") {
@@ -572,17 +564,17 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
 
   property("BitShiftRight") {
     typecheck(env, "1 >> 2") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "true >> false")
+    typefail(env, "true >> false", 1, 1)
   }
 
   property("BitShiftLeft") {
     typecheck(env, "1 << 2") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "true << false")
+    typefail(env, "true << false", 1, 1)
   }
 
   property("BitShiftRightZeroed") {
     typecheck(env, "1 >>> 2") shouldBe SInt
-    an [TyperException] should be thrownBy typecheck(env, "true >>> false")
+    typefail(env, "true >>> false", 1, 1)
   }
 
 }

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -22,7 +22,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   def typecheck(env: ScriptEnv, x: String, expected: SValue = null): SType = {
     try {
       val builder = TransformingSigmaBuilder
-      val parsed = SigmaParser(x, builder).parse.get.value
+      val parsed = SigmaParser(x, builder).get.value
       val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
       val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
       val bound = binder.bind(parsed)
@@ -39,7 +39,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   def typefail(env: ScriptEnv, x: String, messageSubstr: String = ""): Unit = {
     try {
       val builder = TransformingSigmaBuilder
-      val parsed = SigmaParser(x, builder).parse.get.value
+      val parsed = SigmaParser(x, builder).get.value
       val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
       val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
       val bound = binder.bind(parsed)

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -22,7 +22,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   def typecheck(env: ScriptEnv, x: String, expected: SValue = null): SType = {
     try {
       val builder = TransformingSigmaBuilder
-      val parsed = SigmaParser(x, builder).get.value
+      val parsed = SigmaParser(x, builder).parse.get.value
       val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
       val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
       val bound = binder.bind(parsed)
@@ -39,7 +39,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
   def typefail(env: ScriptEnv, x: String, messageSubstr: String = ""): Unit = {
     try {
       val builder = TransformingSigmaBuilder
-      val parsed = SigmaParser(x, builder).get.value
+      val parsed = SigmaParser(x, builder).parse.get.value
       val predefinedFuncRegistry = new PredefinedFuncRegistry(builder)
       val binder = new SigmaBinder(env, builder, TestnetNetworkPrefix, predefinedFuncRegistry)
       val bound = binder.bind(parsed)

--- a/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -29,6 +29,7 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
       val st = new SigmaTree(bound)
       val typer = new SigmaTyper(builder, predefinedFuncRegistry)
       val typed = typer.typecheck(bound)
+      assertSrcCtxForAllNodes(typed)
       if (expected != null) typed shouldBe expected
       typed.tpe
     } catch {

--- a/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/TransformerGenerators.scala
@@ -276,6 +276,6 @@ trait TransformerGenerators {
 
   val boolToSigmaPropGen: Gen[BoolToSigmaProp] = for {
     b <- booleanConstGen
-  } yield mkBoolToSigmaProp(b)
+  } yield mkBoolToSigmaProp(b).asInstanceOf[BoolToSigmaProp]
 
 }


### PR DESCRIPTION
Ref #389, #161  

- [x] lightweight type parsing;
- [x] fix test (build SourceContext from index and input);
- [x] add SourceContext to SigmaParser's `error` method;
- [x] add SourceContext to all nodes created in parser;
- [x] in tests traverse AST after parser and check all nodes have SourceContext defined;
- [x] add SourceContext to all nodes created in binder;
- [x] in tests traverse AST after binder and check all nodes have SourceContext defined;
- [x] add SourceContext to all errors generated in binder;
- [x] add SourceContext to all nodes created in typer;
- [x] add SourceContext to all errors generated in typer;
- [x] in tests traverse AST after typer and check all nodes have SourceContext defined;
- [x] pretty print error message (source line text with a column);
- [x] add SourceContext to the generated errors in costing;