### PR TITLE
Add dataInputs to ErgoLikeTransaction

### DIFF
--- a/src/main/scala/org/ergoplatform/ErgoBox.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBox.scala
@@ -36,13 +36,15 @@ import scala.runtime.ScalaRunTime
   * A transaction is unsealing a box. As a box can not be open twice, any further valid transaction can not be linked
   * to the same box.
   *
-  * @param value         - amount of money associated with the box
-  * @param ergoTree   guarding script, which should be evaluated to true in order to open this box
-  * @param additionalTokens - secondary tokens the box contains
+  * @param value               - amount of money associated with the box
+  * @param ergoTree            - guarding script, which should be evaluated to true in order to open this box
+  * @param additionalTokens    - secondary tokens the box contains
   * @param additionalRegisters - additional registers the box can carry over
-  * @param transactionId - id of transaction which created the box
-  * @param index         - number of box (from 0 to total number of boxes the transaction with transactionId created - 1)
-  * @param creationHeight - height when a transaction containing the box was included into the blockchain
+  * @param transactionId       - id of transaction which created the box
+  * @param index               - number of box (from 0 to total number of boxes the transaction with transactionId created - 1)
+  * @param creationHeight      - height when a transaction containing the box was created.
+  *                            This height is declared by user and should not exceed height of the block,
+  *                            containing the transaction with this box.
   */
 class ErgoBox private(
                        override val value: Long,

--- a/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -17,6 +17,20 @@ import sigmastate.utxo.CostTable.Cost
 import scala.collection.mutable.WrappedArray.ofByte
 import scala.runtime.ScalaRunTime
 
+/**
+  * Contains the same fields as `org.ergoplatform.ErgoBox`, except if transaction id and index,
+  * that will be calculated after full transaction formation.
+  *
+  * @see org.ergoplatform.ErgoBox for more details
+  *
+  * @param value               - amount of money associated with the box
+  * @param ergoTree            - guarding script, which should be evaluated to true in order to open this box
+  * @param creationHeight      - height when a transaction containing the box was created.
+  *                            This height is declared by user and should not exceed height of the block,
+  *                            containing the transaction with this box.
+  * @param additionalTokens    - secondary tokens the box contains
+  * @param additionalRegisters - additional registers the box can carry over
+  */
 class ErgoBoxCandidate(val value: Long,
                        val ergoTree: ErgoTree,
                        val creationHeight: Int,
@@ -64,7 +78,7 @@ class ErgoBoxCandidate(val value: Long,
     ScalaRunTime._hashCode((value, ergoTree, additionalTokens, additionalRegisters, creationHeight))
 
   override def toString: Idn = s"ErgoBoxCandidate($value, $ergoTree," +
-    s"tokens: (${additionalTokens.map(t => Base16.encode(t._1)+":"+t._2).mkString(", ")}), " +
+    s"tokens: (${additionalTokens.map(t => Base16.encode(t._1) + ":" + t._2).mkString(", ")}), " +
     s"$additionalRegisters, creationHeight: $creationHeight)"
 }
 
@@ -143,4 +157,5 @@ object ErgoBoxCandidate {
       parseBodyWithIndexedDigests(None, r)
     }
   }
+
 }

--- a/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
+++ b/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
@@ -157,22 +157,23 @@ object ErgoLikeTransaction {
 
   /**
     * Bytes that should be signed by provers.
-    * Contains all the transaction bytes except of signatures itself
+    * Contains all the transaction bytes except of signatures
     */
   def bytesToSign[IT <: UnsignedInput](tx: ErgoLikeTransactionTemplate[IT]): Array[Byte] = {
     val emptyProofInputs = tx.inputs.map(_.inputToSign)
     val w = SigmaSerializer.startWriter()
-    val txWithoutProofs = ErgoLikeTransaction(emptyProofInputs, tx.dataInputs, tx.outputCandidates)
+    val txWithoutProofs = new ErgoLikeTransaction(emptyProofInputs, tx.dataInputs, tx.outputCandidates)
     ErgoLikeTransactionSerializer.serialize(txWithoutProofs, w)
     w.toBytes
   }
 
+  /**
+    * Creates ErgoLikeTransaction without data inputs
+    */
   def apply(inputs: IndexedSeq[Input], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
     new ErgoLikeTransaction(inputs, IndexedSeq(), outputCandidates)
 
-  def apply(inputs: IndexedSeq[Input], dataInputs: IndexedSeq[DataInput], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
-    new ErgoLikeTransaction(inputs, dataInputs, outputCandidates)
-
+  // TODO unify serialization approach in Ergo/sigma with BytesSerializable
   val serializer: SigmaSerializer[ErgoLikeTransaction, ErgoLikeTransaction] = ErgoLikeTransactionSerializer
 
 }

--- a/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
+++ b/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
@@ -23,7 +23,7 @@ trait ErgoBoxReader {
   * Consists of:
   *
   * @param inputs           - inputs, that will be spent by this transaction.
-  * TODO @param dataInputs       - inputs, that are not going to be spent by transaction, but will be
+  * @param dataInputs       - inputs, that are not going to be spent by transaction, but will be
   *                         reachable from inputs scripts. `dataInputs` scripts will not be executed,
   *                         thus their scripts costs are not included in transaction cost and
   *                         they do not contain spending proofs.
@@ -31,6 +31,7 @@ trait ErgoBoxReader {
   *                         Differ from ordinary ones in that they do not include transaction id and index
   */
 trait ErgoLikeTransactionTemplate[IT <: UnsignedInput] {
+  val dataInputs: IndexedSeq[DataInput]
   val inputs: IndexedSeq[IT]
   val outputCandidates: IndexedSeq[ErgoBoxCandidate]
 
@@ -51,6 +52,7 @@ trait ErgoLikeTransactionTemplate[IT <: UnsignedInput] {
   * Unsigned version of `ErgoLikeTransactionTemplate`
   */
 class UnsignedErgoLikeTransaction(override val inputs: IndexedSeq[UnsignedInput],
+                                  override val dataInputs: IndexedSeq[DataInput],
                                   override val outputCandidates: IndexedSeq[ErgoBoxCandidate])
   extends ErgoLikeTransactionTemplate[UnsignedInput] {
 
@@ -59,19 +61,23 @@ class UnsignedErgoLikeTransaction(override val inputs: IndexedSeq[UnsignedInput]
   def toSigned(proofs: IndexedSeq[ProverResult]): ErgoLikeTransaction = {
     require(proofs.size == inputs.size)
     val ins = inputs.zip(proofs).map { case (ui, proof) => Input(ui.boxId, proof) }
-    new ErgoLikeTransaction(ins, outputCandidates)
+    new ErgoLikeTransaction(ins, dataInputs, outputCandidates)
   }
 }
 
 object UnsignedErgoLikeTransaction {
+  def apply(inputs: IndexedSeq[UnsignedInput], dataInputs: IndexedSeq[DataInput], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
+    new UnsignedErgoLikeTransaction(inputs, dataInputs, outputCandidates)
+
   def apply(inputs: IndexedSeq[UnsignedInput], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
-    new UnsignedErgoLikeTransaction(inputs, outputCandidates)
+    new UnsignedErgoLikeTransaction(inputs, IndexedSeq(), outputCandidates)
 }
 
 /**
   * Signed version of `ErgoLikeTransactionTemplate`
   */
 class ErgoLikeTransaction(override val inputs: IndexedSeq[Input],
+                          override val dataInputs: IndexedSeq[DataInput],
                           override val outputCandidates: IndexedSeq[ErgoBoxCandidate])
   extends ErgoLikeTransactionTemplate[Input] {
 
@@ -96,6 +102,11 @@ object ErgoLikeTransactionSerializer extends SigmaSerializer[ErgoLikeTransaction
     for (input <- tx.inputs) {
       Input.serializer.serialize(input, w)
     }
+    // serialize transaction data inputs
+    w.putUShort(tx.dataInputs.length)
+    for (input <- tx.dataInputs) {
+      w.putBytes(input.boxId)
+    }
     // serialize distinct ids of tokens in transaction outputs
     val distinctTokenIds = tx.outputCandidates
       .flatMap(_.additionalTokens.map(t => new mutable.WrappedArray.ofByte(t._1)))
@@ -118,7 +129,11 @@ object ErgoLikeTransactionSerializer extends SigmaSerializer[ErgoLikeTransaction
     for (_ <- 0 until inputsCount) {
       inputsBuilder += Input.serializer.parse(r)
     }
-
+    val dataInputsCount = r.getUShort()
+    val dataInputsBuilder = mutable.ArrayBuilder.make[DataInput]()
+    for (_ <- 0 until dataInputsCount) {
+      dataInputsBuilder += DataInput(ADKey @@ r.getBytes(ErgoBox.BoxId.size))
+    }
     val digestsCount = r.getUInt().toInt
     val digestsBuilder = mutable.ArrayBuilder.make[Digest32]()
     for (_ <- 0 until digestsCount) {
@@ -130,7 +145,7 @@ object ErgoLikeTransactionSerializer extends SigmaSerializer[ErgoLikeTransaction
     for (_ <- 0 until outsCount) {
       outputCandidatesBuilder += ErgoBoxCandidate.serializer.parseBodyWithIndexedDigests(Some(digests), r)
     }
-    ErgoLikeTransaction(inputsBuilder.result(), outputCandidatesBuilder.result())
+    new ErgoLikeTransaction(inputsBuilder.result(), dataInputsBuilder.result(), outputCandidatesBuilder.result())
   }
 
 }
@@ -147,13 +162,16 @@ object ErgoLikeTransaction {
   def bytesToSign[IT <: UnsignedInput](tx: ErgoLikeTransactionTemplate[IT]): Array[Byte] = {
     val emptyProofInputs = tx.inputs.map(_.inputToSign)
     val w = SigmaSerializer.startWriter()
-    val txWithoutProofs = ErgoLikeTransaction(emptyProofInputs, tx.outputCandidates)
+    val txWithoutProofs = ErgoLikeTransaction(emptyProofInputs, tx.dataInputs, tx.outputCandidates)
     ErgoLikeTransactionSerializer.serialize(txWithoutProofs, w)
     w.toBytes
   }
 
   def apply(inputs: IndexedSeq[Input], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
-    new ErgoLikeTransaction(inputs, outputCandidates)
+    new ErgoLikeTransaction(inputs, IndexedSeq(), outputCandidates)
+
+  def apply(inputs: IndexedSeq[Input], dataInputs: IndexedSeq[DataInput], outputCandidates: IndexedSeq[ErgoBoxCandidate]) =
+    new ErgoLikeTransaction(inputs, dataInputs, outputCandidates)
 
   val serializer: SigmaSerializer[ErgoLikeTransaction, ErgoLikeTransaction] = ErgoLikeTransactionSerializer
 

--- a/src/main/scala/org/ergoplatform/Input.scala
+++ b/src/main/scala/org/ergoplatform/Input.scala
@@ -10,6 +10,13 @@ import sigmastate.serialization.SigmaSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 
 /**
+  * Inputs, that are used to enrich script context, but won't be spent by the transaction
+  *
+  * @param boxId - id of a box to add into context (should be in UTXO)
+  */
+case class DataInput(boxId: BoxId)
+
+/**
   * Inputs of formed, but unsigned transaction
   *
   * @param boxId     - id of a box to spent

--- a/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
@@ -99,6 +99,33 @@ class ErgoLikeTransactionSpec extends PropSpec
         (itx8.messageToSign sameElements initialMessage) shouldBe true
 
         /**
+          * Check inputs modifications
+          */
+        // transaction with decreased number of data inputs
+        if (di.nonEmpty) {
+          val dtx3 = new ErgoLikeTransaction(txIn.inputs, di.tail, txIn.outputCandidates)
+          (dtx3.messageToSign sameElements initialMessage) shouldBe false
+        }
+
+        // transaction with increased number of data inputs
+        val di4 = DataInput(txIn.outputs.head.id)
+        val dtx4 = new ErgoLikeTransaction(txIn.inputs, di4 +: di, txIn.outputCandidates)
+        (dtx4.messageToSign sameElements initialMessage) shouldBe false
+
+        // transaction with shuffled data inputs
+        if (di.size > 1) {
+          val dtx5 = new ErgoLikeTransaction(txIn.inputs, di.tail ++ Seq(di.head), txIn.outputCandidates)
+          (dtx5.messageToSign sameElements initialMessage) shouldBe false
+        }
+
+        // transaction with modified data input boxId
+        if (di.nonEmpty) {
+          val di6 = DataInput(txIn.outputs.head.id)
+          val dtx6 = new ErgoLikeTransaction(txIn.inputs, di6 +: di.tail, txIn.outputCandidates)
+          (dtx6.messageToSign sameElements initialMessage) shouldBe false
+        }
+
+        /**
           * Check outputs modifications
           */
         // transaction with decreased number of outputs

--- a/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
@@ -52,75 +52,76 @@ class ErgoLikeTransactionSpec extends PropSpec
         val outputs = (0 until 10).map { i =>
           new ErgoBoxCandidate(headOut.value, headOut.ergoTree, i, headOut.additionalTokens, headOut.additionalRegisters)
         }
-        val txIn = ErgoLikeTransaction(tx0.inputs, tx0.outputCandidates ++ outputs)
+        val di = tx0.dataInputs
+        val txIn = new ErgoLikeTransaction(tx0.inputs, di, tx0.outputCandidates ++ outputs)
         val tailOuts = txIn.outputCandidates.tail
         val headInput = txIn.inputs.head
         val tailInputs = txIn.inputs.tail
         val initialMessage = txIn.messageToSign
 
         // transaction with the same fields should have the same message to sign
-        val otx2 = ErgoLikeTransaction(headInput +: tailInputs, headOut +: tailOuts)
+        val otx2 = new ErgoLikeTransaction(headInput +: tailInputs, di, headOut +: tailOuts)
         (otx2.messageToSign sameElements initialMessage) shouldBe true
 
         /**
           * Check inputs modifications
           */
         // transaction with decreased number of inputs
-        val itx3 = ErgoLikeTransaction(tailInputs, txIn.outputCandidates)
+        val itx3 = new ErgoLikeTransaction(tailInputs, di, txIn.outputCandidates)
         (itx3.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with increased number of inputs
-        val itx4 = ErgoLikeTransaction(headInput +: txIn.inputs, txIn.outputCandidates)
+        val itx4 = new ErgoLikeTransaction(headInput +: txIn.inputs, di, txIn.outputCandidates)
         (itx4.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with shuffled inputs
         if (tailInputs.nonEmpty) {
-          val itx5 = ErgoLikeTransaction(tailInputs ++ Seq(headInput), txIn.outputCandidates)
+          val itx5 = new ErgoLikeTransaction(tailInputs ++ Seq(headInput), di, txIn.outputCandidates)
           (itx5.messageToSign sameElements initialMessage) shouldBe false
         }
 
         // transaction with modified input boxId
         val headInput6 = headInput.copy(boxId = txIn.outputs.head.id)
-        val itx6 = ErgoLikeTransaction(headInput6 +: tailInputs, txIn.outputCandidates)
+        val itx6 = new ErgoLikeTransaction(headInput6 +: tailInputs, di, txIn.outputCandidates)
         (itx6.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with modified input extension
         val newExtension7 = ContextExtension(headInput.spendingProof.extension.values ++ Map(Byte.MinValue -> ByteArrayConstant(Random.randomBytes(32))))
         val newProof7 = new ProverResult(headInput.spendingProof.proof, newExtension7)
         val headInput7 = headInput.copy(spendingProof = newProof7)
-        val itx7 = ErgoLikeTransaction(headInput7 +: tailInputs, txIn.outputCandidates)
+        val itx7 = new ErgoLikeTransaction(headInput7 +: tailInputs, di, txIn.outputCandidates)
         (itx7.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with modified input proof should not affect messageToSign
         val newProof8 = new ProverResult(headInput.spendingProof.proof, headInput.spendingProof.extension)
         val headInput8 = headInput.copy(spendingProof = newProof8)
-        val itx8 = ErgoLikeTransaction(headInput8 +: tailInputs, txIn.outputCandidates)
+        val itx8 = new ErgoLikeTransaction(headInput8 +: tailInputs, di, txIn.outputCandidates)
         (itx8.messageToSign sameElements initialMessage) shouldBe true
 
         /**
           * Check outputs modifications
           */
         // transaction with decreased number of outputs
-        val otx3 = ErgoLikeTransaction(txIn.inputs, tailOuts)
+        val otx3 = new ErgoLikeTransaction(txIn.inputs, di, tailOuts)
         (otx3.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with increased number of outputs
-        val otx4 = ErgoLikeTransaction(txIn.inputs, headOut +: txIn.outputCandidates)
+        val otx4 = new ErgoLikeTransaction(txIn.inputs, di, headOut +: txIn.outputCandidates)
         (otx4.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with shuffled outputs
-        val otx5 = ErgoLikeTransaction(txIn.inputs, tailOuts ++ Seq(txIn.outputCandidates.head))
+        val otx5 = new ErgoLikeTransaction(txIn.inputs, di, tailOuts ++ Seq(txIn.outputCandidates.head))
         (otx5.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with modified output value
         val headOut6 = new ErgoBoxCandidate(headOut.value - 1, headOut.ergoTree, headOut.creationHeight, headOut.additionalTokens, headOut.additionalRegisters)
-        val otx6 = ErgoLikeTransaction(txIn.inputs, headOut6 +: tailOuts)
+        val otx6 = new ErgoLikeTransaction(txIn.inputs, di, headOut6 +: tailOuts)
         (otx6.messageToSign sameElements initialMessage) shouldBe false
 
         // transaction with modified output tokens
         val newTokens = headOut.additionalTokens.map(t => t._1 -> (t._2 - 1))
         val headOut7 = new ErgoBoxCandidate(headOut.value, headOut.ergoTree, headOut.creationHeight, newTokens, headOut.additionalRegisters)
-        val otx7 = ErgoLikeTransaction(txIn.inputs, headOut7 +: tailOuts)
+        val otx7 = new ErgoLikeTransaction(txIn.inputs, di, headOut7 +: tailOuts)
         (otx7.messageToSign sameElements initialMessage) shouldBe false
 
       }

--- a/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
@@ -27,7 +27,7 @@ class ErgoLikeTransactionSpec extends PropSpec
         val outputs = (0 until 10).map { i =>
           new ErgoBoxCandidate(out.value, out.ergoTree, i, out.additionalTokens, out.additionalRegisters)
         }
-        val tx = ErgoLikeTransaction(txIn.inputs, txIn.outputCandidates ++ outputs)
+        val tx = new ErgoLikeTransaction(txIn.inputs, txIn.dataInputs, txIn.outputCandidates ++ outputs)
         roundTripTestWithPos(tx)(ErgoLikeTransaction.serializer)
 
         // check that token id is written only once

--- a/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
@@ -99,7 +99,7 @@ class ErgoLikeTransactionSpec extends PropSpec
         (itx8.messageToSign sameElements initialMessage) shouldBe true
 
         /**
-          * Check inputs modifications
+          * Check data inputs modifications
           */
         // transaction with decreased number of data inputs
         if (di.nonEmpty) {

--- a/src/test/scala/org/ergoplatform/dsl/TestContractSpec.scala
+++ b/src/test/scala/org/ergoplatform/dsl/TestContractSpec.scala
@@ -83,7 +83,7 @@ case class TestContractSpec(testSuite: SigmaTestingCommons)(implicit val IR: IRC
         lastBlockUtxoRoot = AvlTreeData.dummy,
         minerPubkey = ErgoLikeContext.dummyPubkey,
         boxesToSpend = tx.inputs.map(_.utxoBox.ergoBox).toIndexedSeq,
-        spendingTransaction = ErgoLikeTransaction(IndexedSeq(), tx.outputs.map(_.ergoBox).toIndexedSeq),
+        spendingTransaction = testSuite.createTransaction(tx.outputs.map(_.ergoBox).toIndexedSeq),
         self = utxoBox.ergoBox)
       ctx
     }

--- a/src/test/scala/sigmastate/FailingToProveSpec.scala
+++ b/src/test/scala/sigmastate/FailingToProveSpec.scala
@@ -35,7 +35,7 @@ class FailingToProveSpec extends SigmaTestingCommons {
     val selfBox = ErgoBox(200L, compiledScript, 0)
     val o1 = ErgoBox(101L, TrueProp, 5001)
     val o2 = ErgoBox(99L, TrueProp, 5001)
-    val tx =  ErgoLikeTransaction(IndexedSeq(), IndexedSeq(o1, o2))
+    val tx =  createTransaction(IndexedSeq(o1, o2))
     val ctx = ErgoLikeContext(
       currentHeight = 5001,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -69,7 +69,7 @@ class FailingToProveSpec extends SigmaTestingCommons {
     val o1 = ErgoBox(102L, TrueProp, 5001)
     val o2 = ErgoBox(98L, TrueProp, 5001)
     val o3 = ErgoBox(100L, TrueProp, 5001)
-    val tx =  ErgoLikeTransaction(IndexedSeq(), IndexedSeq(o1, o2, o3))
+    val tx =  createTransaction(IndexedSeq(o1, o2, o3))
     val ctx = ErgoLikeContext(
       currentHeight = 5001,
       lastBlockUtxoRoot = AvlTreeData.dummy,

--- a/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
+++ b/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
@@ -32,7 +32,7 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests { self: BaseCtxT
   lazy val compiler = new SigmaCompiler(TestnetNetworkPrefix, IR.builder)
 
   def newErgoContext(height: Int, boxToSpend: ErgoBox, extension: Map[Byte, EvaluatedValue[SType]] = Map()): ErgoLikeContext = {
-    val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq())
+    val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), IndexedSeq(boxToSpend))
     val ergoCtx = ErgoLikeContext(
       currentHeight = height,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -73,7 +73,7 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests { self: BaseCtxT
     additionalRegisters = Map(ErgoBox.R4 -> BigIntArrayConstant(bigIntegerArr1)))
   lazy val tx1Output1 = ErgoBox(minToRaise, projectPubKey, 0)
   lazy val tx1Output2 = ErgoBox(1, projectPubKey, 0)
-  lazy val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(tx1Output1, tx1Output2))
+  lazy val tx1 = new ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), IndexedSeq(tx1Output1, tx1Output2))
   lazy val ergoCtx = ErgoLikeContext(
     currentHeight = timeout - 1,
     lastBlockUtxoRoot = AvlTreeData.dummy,

--- a/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
+++ b/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
@@ -32,7 +32,7 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests { self: BaseCtxT
   lazy val compiler = new SigmaCompiler(TestnetNetworkPrefix, IR.builder)
 
   def newErgoContext(height: Int, boxToSpend: ErgoBox, extension: Map[Byte, EvaluatedValue[SType]] = Map()): ErgoLikeContext = {
-    val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), IndexedSeq(boxToSpend))
+    val tx1 = new ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), IndexedSeq(boxToSpend))
     val ergoCtx = ErgoLikeContext(
       currentHeight = height,
       lastBlockUtxoRoot = AvlTreeData.dummy,

--- a/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -112,7 +112,7 @@ class EvaluationTest extends BaseCtxTests
 //    val boxToSpend = ErgoBox(10, TrueLeaf)
 //    val tx1Output1 = ErgoBox(minToRaise, projectPubKey)
 //    val tx1Output2 = ErgoBox(1, projectPubKey)
-//    val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(tx1Output1, tx1Output2))
+//    val tx1 = createTransaction(IndexedSeq(tx1Output1, tx1Output2))
 //    val ergoCtx = ErgoLikeContext(
 //      currentHeight = timeout - 1,
 //      lastBlockUtxoRoot = AvlTreeData.dummy,

--- a/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -29,11 +29,11 @@ class EvaluationTest extends BaseCtxTests
     reduce(emptyEnv, "one_gt_one", "1 > 1", ctx, false)
     reduce(emptyEnv, "or", "1 > 1 || 2 < 1", ctx, false)
     reduce(emptyEnv, "or2", "1 > 1 || 2 < 1 || 2 > 1", ctx, true)
-    reduce(emptyEnv, "or3", "OUTPUTS.size > 1 || OUTPUTS.size < 1", ctx, true)
+    reduce(emptyEnv, "or3", "OUTPUTS.size > 1 || OUTPUTS.size <= 1", ctx, true)
     reduce(emptyEnv, "and", "1 > 1 && 2 < 1", ctx, false)
     reduce(emptyEnv, "and2", "1 > 1 && 2 < 1 && 2 > 1", ctx, false)
     reduce(emptyEnv, "and3", "1 == 1 && (2 < 1 || 2 > 1)", ctx, true)
-    reduce(emptyEnv, "and4", "OUTPUTS.size > 1 && OUTPUTS.size < 1", ctx, false)
+    reduce(emptyEnv, "and4", "OUTPUTS.size > 1 && OUTPUTS.size <= 1", ctx, false)
   }
 
   test("lazy logical ops") {

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -3,7 +3,7 @@ package sigmastate.helpers
 import org.ergoplatform.ErgoAddressEncoder.TestnetNetworkPrefix
 import org.ergoplatform.ErgoBox.{NonMandatoryRegisterId, TokenId}
 import org.ergoplatform.ErgoScriptPredef.TrueProp
-import org.ergoplatform.{ErgoBox, ErgoLikeContext}
+import org.ergoplatform.{ErgoBox, ErgoBoxCandidate, ErgoLikeContext, ErgoLikeTransaction}
 import org.scalacheck.Arbitrary.arbByte
 import org.scalacheck.Gen
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
@@ -63,6 +63,12 @@ trait SigmaTestingCommons extends PropSpec
                 proposition: ErgoTree,
                 creationHeight: Int)
   = ErgoBox(value, proposition, creationHeight, Seq(), Map(), ErgoBox.allZerosModifierId)
+
+  def createTransaction(outputCandidates: IndexedSeq[ErgoBoxCandidate]): ErgoLikeTransaction = {
+    new ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), outputCandidates)
+  }
+
+  def createTransaction(box: ErgoBoxCandidate): ErgoLikeTransaction = createTransaction(IndexedSeq(box))
 
   class TestingIRContext extends TestContext with IRContext with CompiletimeCosting {
     override def onCostingResult[T](env: ScriptEnv, tree: SValue, res: CostingResult[T]): Unit = {

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -64,6 +64,12 @@ trait SigmaTestingCommons extends PropSpec
                 creationHeight: Int)
   = ErgoBox(value, proposition, creationHeight, Seq(), Map(), ErgoBox.allZerosModifierId)
 
+  /**
+    * Create fake transaction with provided outputCandidates, but without inputs and data inputs.
+    * Normally, this transaction will be invalid as far as it will break rule that sum of
+    * coins in inputs should not be less then sum of coins in outputs, but we're not checking it
+    * in our test cases
+    */
   def createTransaction(outputCandidates: IndexedSeq[ErgoBoxCandidate]): ErgoLikeTransaction = {
     new ErgoLikeTransaction(IndexedSeq(), IndexedSeq(), outputCandidates)
   }

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -156,6 +156,10 @@ trait ValueGenerators extends TypeGenerators {
     contextExt <- contextExtensionGen
   } yield new UnsignedInput(boxId, contextExt)
 
+  val dataInputGen: Gen[DataInput] = for {
+    boxId <- boxIdGen
+  } yield DataInput(boxId)
+
   val inputGen: Gen[Input] = for {
     boxId <- boxIdGen
     proof <- serializedProverResultGen
@@ -260,9 +264,10 @@ trait ValueGenerators extends TypeGenerators {
   val ergoTransactionGen: Gen[ErgoLikeTransaction] = for {
     inputs <- Gen.nonEmptyListOf(inputGen)
     tokens <- tokensGen
+    dataInputs <- Gen.listOf(dataInputGen)
     outputsCount <- Gen.chooseNum(50, 200)
     outputCandidates <- Gen.listOfN(outputsCount, ergoBoxCandidateGen(tokens))
-  } yield ErgoLikeTransaction(inputs.toIndexedSeq, outputCandidates.toIndexedSeq)
+  } yield new ErgoLikeTransaction(inputs.toIndexedSeq, dataInputs.toIndexedSeq, outputCandidates.toIndexedSeq)
 
   // distinct list of elements from a given generator
   // with a maximum number of elements to discard

--- a/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/AVLTreeScriptsSpecification.scala
@@ -53,7 +53,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> AvlTreeConstant(treeData)))
 
@@ -102,7 +102,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> AvlTreeConstant(treeData)))
 
@@ -148,7 +148,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> AvlTreeConstant(treeData)))
 
@@ -199,7 +199,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      new ErgoLikeTransaction(IndexedSeq(), IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(ErgoBox(1, recipientProposition, 0)),
       self = selfBox)
 
     avlProver.performOneOperation(Lookup(treeElements.head._1))
@@ -259,7 +259,7 @@ class AVLTreeScriptsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> AvlTreeConstant(treeData), reg2 -> ByteArrayConstant(key)))
 

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -73,7 +73,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, prop, creationHeight = 0, boxIndex = 0, additionalRegisters = Map(
       reg1 -> IntConstant(1),
       reg2 -> IntConstant(10)))
-    val tx = createTransaction(IndexedSeq(newBox1))
+    val tx = createTransaction(newBox1)
 
     val ctx = ErgoLikeContext(currentHeight = 0,
       lastBlockUtxoRoot = AvlTreeData.dummy, dummyPubkey, boxesToSpend = IndexedSeq(boxToSpend),

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -73,7 +73,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, prop, creationHeight = 0, boxIndex = 0, additionalRegisters = Map(
       reg1 -> IntConstant(1),
       reg2 -> IntConstant(10)))
-    val tx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(newBox1))
+    val tx = createTransaction(IndexedSeq(newBox1))
 
     val ctx = ErgoLikeContext(currentHeight = 0,
       lastBlockUtxoRoot = AvlTreeData.dummy, dummyPubkey, boxesToSpend = IndexedSeq(boxToSpend),

--- a/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -21,7 +21,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = boxesToSpend,
-      spendingTransaction = ErgoLikeTransaction(IndexedSeq(), outputs),
+      spendingTransaction = createTransaction(outputs),
       self = null)
 
   private def assertProof(code: String,
@@ -75,7 +75,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(15, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -106,7 +106,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -137,7 +137,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(11, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -175,7 +175,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0, Seq(), Map(reg1 -> LongConstant(6)))
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> LongConstant(5)))
 
@@ -218,7 +218,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0, Seq(), Map(reg1 -> LongConstant(6)))
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, TrueProp, 0, Seq(), Map(reg1 -> LongConstant(5)))
 
@@ -249,7 +249,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(21, pubkey, 0)
 

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -156,7 +156,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val properHash = Blake2b256(properBytes)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     def mixingRequestProp(sender: ProveDlog, timeout: Int) = {
       val env = Map("sender" -> sender, "timeout" -> timeout, "properHash" -> properHash)
@@ -233,7 +233,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -263,7 +263,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val newBox2 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1, newBox2)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -306,7 +306,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
       self = selfBox)
 
     val proof = prover.prove(prop, ctx, fakeMessage).get
@@ -339,7 +339,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val newBox1 = ErgoBox(10, pubkey3, 0)
     val newBoxes = IndexedSeq(newBox1)
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s1 = ErgoBox(20, ErgoScriptPredef.TrueProp, 0, Seq(),
       Map(regPubkey1 -> GroupElementConstant(pubkey1.value),
@@ -400,7 +400,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
       self = selfBox)
 
     val proof = prover.prove(prop, ctx, fakeMessage).get
@@ -426,7 +426,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val newBox = ErgoBox(20, pubkey2, 0)
 
     val newBoxes = IndexedSeq(newBox)
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val env = Map("brother" -> brother)
     val prop = compileWithCosting(env,
@@ -500,7 +500,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
     val newBox = ErgoBox(20, pubkey2, 0)
 
     val newBoxes = IndexedSeq(newBox)
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val env = Map("friend" -> friend)
     val prop = compileWithCosting(env,
@@ -601,7 +601,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val output = ErgoBox(22, pubkey, 0, Seq(), Map())
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(output))
+    val spendingTransaction = createTransaction(IndexedSeq(output))
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,
@@ -633,7 +633,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(box),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(ErgoBox(10, TrueProp, 0))),
+      createTransaction(IndexedSeq(ErgoBox(10, TrueProp, 0))),
       self = box)
 
     an[RuntimeException] should be thrownBy

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -306,7 +306,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(ErgoBox(1, recipientProposition, 0)),
       self = selfBox)
 
     val proof = prover.prove(prop, ctx, fakeMessage).get
@@ -400,7 +400,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(ErgoBox(1, recipientProposition, 0)),
       self = selfBox)
 
     val proof = prover.prove(prop, ctx, fakeMessage).get
@@ -601,7 +601,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val output = ErgoBox(22, pubkey, 0, Seq(), Map())
 
-    val spendingTransaction = createTransaction(IndexedSeq(output))
+    val spendingTransaction = createTransaction(output)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,

--- a/src/test/scala/sigmastate/utxo/SpamSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SpamSpecification.scala
@@ -153,7 +153,7 @@ class SpamSpecification extends SigmaTestingCommons {
       ).toSigmaProp
 
     val txOutputs = ((1 to outCnt) map (_ => ErgoBox(11, spamProp, 0))) :+ ErgoBox(11, propToCompare, 0)
-    val tx = ErgoLikeTransaction(IndexedSeq(), txOutputs)
+    val tx = createTransaction(txOutputs)
 
     val ctx = ErgoLikeContext.dummy(createBox(0, propToCompare)).withTransaction(tx)
 
@@ -192,7 +192,7 @@ class SpamSpecification extends SigmaTestingCommons {
     val inputs = ((1 to 999) map (_ => ErgoBox(11, inputScript, 0))) :+ ErgoBox(11, outputScript, 0)
     val outputs = (1 to 1000) map (_ => ErgoBox(11, outputScript, 0))
 
-    val tx = ergoplatform.ErgoLikeTransaction(IndexedSeq(), outputs)
+    val tx = createTransaction(outputs)
 
     val ctx = new ErgoLikeContext(currentHeight = 0,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -256,7 +256,7 @@ class SpamSpecification extends SigmaTestingCommons {
     val newBox1 = ErgoBox(10, pubkey, 0)
     val newBoxes = IndexedSeq(newBox1)
 
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val s = ErgoBox(20, ErgoScriptPredef.TrueProp, 0, Seq(), Map(reg1 -> AvlTreeConstant(treeData)))
 

--- a/src/test/scala/sigmastate/utxo/benchmarks/CrowdfundingBenchmark.scala
+++ b/src/test/scala/sigmastate/utxo/benchmarks/CrowdfundingBenchmark.scala
@@ -15,7 +15,7 @@ class CrowdfundingBenchmark extends SigmaTestingCommons {
     val tx1Output1 = ErgoBox(contract.minToRaise, contract.projectPubKey, 0)
     val tx1Output2 = ErgoBox(1, contract.projectPubKey, 0)
     //normally this transaction would invalid, but we're not checking it in this test
-    val tx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(tx1Output1, tx1Output2))
+    val tx = createTransaction(IndexedSeq(tx1Output1, tx1Output2))
     val ctx = ErgoLikeContext(
       currentHeight = contract.timeout - 1, // HEIGHT < timeout,
       lastBlockUtxoRoot = AvlTreeData.dummy,

--- a/src/test/scala/sigmastate/utxo/blockchain/BlockchainSimulationTestingCommons.scala
+++ b/src/test/scala/sigmastate/utxo/blockchain/BlockchainSimulationTestingCommons.scala
@@ -72,7 +72,7 @@ trait BlockchainSimulationTestingCommons extends SigmaTestingCommons {
 
 }
 
-object BlockchainSimulationTestingCommons {
+object BlockchainSimulationTestingCommons extends SigmaTestingCommons {
 
   private val MaxBlockCost = 700000
 
@@ -148,7 +148,7 @@ object BlockchainSimulationTestingCommons {
       (0 until 10).map { i =>
         val txId = Blake2b256.hash(i.toString.getBytes ++ scala.util.Random.nextString(12).getBytes).toModifierId
         val boxes = (1 to 50).map(_ => ErgoBox(10, Values.TrueLeaf.toSigmaProp, i, Seq(), Map(), txId))
-        ergoplatform.ErgoLikeTransaction(IndexedSeq(), boxes)
+        createTransaction(boxes)
       },
       ErgoLikeContext.dummyPubkey
     )

--- a/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoinEmissionSpecification.scala
@@ -110,15 +110,7 @@ class CoinEmissionSpecification extends SigmaTestingCommons with ScorexLogging {
     val minerProp = minerImage
 
     val initialBoxCandidate: ErgoBox = ErgoBox(coinsTotal / 4, prop, 0, Seq(), Map(register -> IntConstant(-1)))
-    val initBlock = FullBlock(
-      IndexedSeq(
-        ErgoLikeTransaction(
-          IndexedSeq(),
-          IndexedSeq(initialBoxCandidate)
-        )
-      ),
-      minerPubkey
-    )
+    val initBlock = FullBlock(IndexedSeq(createTransaction(initialBoxCandidate)), minerPubkey)
     val genesisState = ValidationState.initialState(initBlock)
     val fromState = genesisState.boxesReader.byId(genesisState.boxesReader.allIds.head).get
     val initialBox = ErgoBox(initialBoxCandidate.value, initialBoxCandidate.ergoTree, 0,

--- a/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
@@ -14,7 +14,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
   implicit lazy val IR = new TestingIRContext
   
   def mkTxFromOutputs(ergoBox: ErgoBox*): ErgoLikeTransaction = {
-    ErgoLikeTransaction(IndexedSeq(), ergoBox.toIndexedSeq)
+    createTransaction(ergoBox.toIndexedSeq)
   }
 
   def mkCtx(height: Int,

--- a/src/test/scala/sigmastate/utxo/examples/DHTupleExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DHTupleExampleSpecification.scala
@@ -76,7 +76,7 @@ class DHTupleExampleSpecification extends SigmaTestingCommons {
       )
     )
 
-    val tx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(outBox))
+    val tx = createTransaction(IndexedSeq(outBox))
 
     val context = ErgoLikeContext(
       currentHeight = 70,

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -174,8 +174,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     verifier.verify(prop, ctx4, NoProof, fakeMessage).get._1 shouldBe false
 
     //miner can spend less
-    val tx5 = ErgoLikeTransaction(IndexedSeq(),
-      IndexedSeq(createBox(outValue + 1, prop, currentHeight2)))
+    val tx5 = createTransaction(createBox(outValue + 1, prop, currentHeight2))
 
     val ctx5 = ErgoLikeContext(
       currentHeight = currentHeight2,

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -106,7 +106,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     //case 1: demurrage time hasn't come yet
     val currentHeight1 = inHeight + demurragePeriod - 1
 
-    val tx1 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(createBox(outValue, prop, currentHeight1)))
+    val tx1 = createTransaction(IndexedSeq(createBox(outValue, prop, currentHeight1)))
     val selfBox = createBox(inValue, prop, inHeight)
     val ctx1 = ErgoLikeContext(
       currentHeight1,
@@ -127,7 +127,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //case 2: demurrage time has come
     val currentHeight2 = inHeight + demurragePeriod
-    val tx2 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(createBox(outValue, prop, currentHeight2)))
+    val tx2 = createTransaction(IndexedSeq(createBox(outValue, prop, currentHeight2)))
     val ctx2 = ErgoLikeContext(
       currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -143,7 +143,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //miner can spend "demurrageCoeff * demurragePeriod" tokens
     val b = createBox(outValue, prop, currentHeight2)
-    val tx3 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(b))
+    val tx3 = createTransaction(IndexedSeq(b))
     val ctx3 = ErgoLikeContext(
       currentHeight = currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -160,7 +160,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //miner can't spend more
     val b2 = createBox(outValue - 1, prop, currentHeight2)
-    val tx4 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(b2))
+    val tx4 = createTransaction(IndexedSeq(b2))
     val ctx4 = ErgoLikeContext(
       currentHeight = currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -192,7 +192,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     //miner can destroy a box if it contains less than the storage fee
     val iv = inValue - outValue
     val b3 = createBox(iv, ErgoScriptPredef.FalseProp, currentHeight2)
-    val tx6 = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(b3))
+    val tx6 = createTransaction(IndexedSeq(b3))
     val selfBox6 = createBox(iv, prop, inHeight)
     val ctx6 = ErgoLikeContext(
       currentHeight = currentHeight2,

--- a/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/DemurrageExampleSpecification.scala
@@ -106,7 +106,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     //case 1: demurrage time hasn't come yet
     val currentHeight1 = inHeight + demurragePeriod - 1
 
-    val tx1 = createTransaction(IndexedSeq(createBox(outValue, prop, currentHeight1)))
+    val tx1 = createTransaction(createBox(outValue, prop, currentHeight1))
     val selfBox = createBox(inValue, prop, inHeight)
     val ctx1 = ErgoLikeContext(
       currentHeight1,
@@ -127,7 +127,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //case 2: demurrage time has come
     val currentHeight2 = inHeight + demurragePeriod
-    val tx2 = createTransaction(IndexedSeq(createBox(outValue, prop, currentHeight2)))
+    val tx2 = createTransaction(createBox(outValue, prop, currentHeight2))
     val ctx2 = ErgoLikeContext(
       currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -143,7 +143,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //miner can spend "demurrageCoeff * demurragePeriod" tokens
     val b = createBox(outValue, prop, currentHeight2)
-    val tx3 = createTransaction(IndexedSeq(b))
+    val tx3 = createTransaction(b)
     val ctx3 = ErgoLikeContext(
       currentHeight = currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -160,7 +160,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
 
     //miner can't spend more
     val b2 = createBox(outValue - 1, prop, currentHeight2)
-    val tx4 = createTransaction(IndexedSeq(b2))
+    val tx4 = createTransaction(b2)
     val ctx4 = ErgoLikeContext(
       currentHeight = currentHeight2,
       lastBlockUtxoRoot = AvlTreeData.dummy,
@@ -191,7 +191,7 @@ class DemurrageExampleSpecification extends SigmaTestingCommons {
     //miner can destroy a box if it contains less than the storage fee
     val iv = inValue - outValue
     val b3 = createBox(iv, ErgoScriptPredef.FalseProp, currentHeight2)
-    val tx6 = createTransaction(IndexedSeq(b3))
+    val tx6 = createTransaction(b3)
     val selfBox6 = createBox(iv, prop, inHeight)
     val ctx6 = ErgoLikeContext(
       currentHeight = currentHeight2,

--- a/src/test/scala/sigmastate/utxo/examples/FsmExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/FsmExampleSpecification.scala
@@ -139,7 +139,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox1),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fsmBox2)),
+      createTransaction(fsmBox2),
       self = fsmBox1)
 
     val spendingProof = prover
@@ -159,7 +159,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox2),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fsmBox1)),
+      createTransaction(fsmBox1),
       self = fsmBox2)
 
     val spendingProof2 = prover
@@ -187,7 +187,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox1),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fsmBox3)),
+      createTransaction(fsmBox3),
       self = fsmBox1)
 
     //honest prover fails
@@ -214,7 +214,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox2),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fsmBox3)),
+      createTransaction(fsmBox3),
       self = fsmBox2)
 
     val spendingProof23 = prover
@@ -236,7 +236,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox3),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(freeBox)),
+      createTransaction(freeBox),
       self = fsmBox3)
 
     val spendingProof30 = prover
@@ -252,7 +252,7 @@ class FsmExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(fsmBox2),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(freeBox)),
+      createTransaction(freeBox),
       self = fsmBox2)
 
     //honest prover fails

--- a/src/test/scala/sigmastate/utxo/examples/MASTExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/MASTExampleSpecification.scala
@@ -100,7 +100,7 @@ class MASTExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(ErgoBox(1, recipientProposition, 0)),
       self = selfBox)
 
     avlProver.performOneOperation(Lookup(knownSecretTreeKey))

--- a/src/test/scala/sigmastate/utxo/examples/MASTExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/MASTExampleSpecification.scala
@@ -100,7 +100,7 @@ class MASTExampleSpecification extends SigmaTestingCommons {
       lastBlockUtxoRoot = AvlTreeData.dummy,
       minerPubkey = ErgoLikeContext.dummyPubkey,
       boxesToSpend = IndexedSeq(selfBox),
-      ErgoLikeTransaction(IndexedSeq(), IndexedSeq(ErgoBox(1, recipientProposition, 0))),
+      createTransaction(IndexedSeq(ErgoBox(1, recipientProposition, 0))),
       self = selfBox)
 
     avlProver.performOneOperation(Lookup(knownSecretTreeKey))

--- a/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
@@ -155,7 +155,7 @@ class MixExampleSpecification extends SigmaTestingCommons {
     )
 
     // normally this transaction would be invalid, but we're not checking it in this test
-    val fullMixTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fullMixOutput0, fullMixOutput1))
+    val fullMixTx = createTransaction(IndexedSeq(fullMixOutput0, fullMixOutput1))
 
     val fullMixContext = ErgoLikeContext(
       currentHeight = fullMixCreationHeight,
@@ -188,7 +188,7 @@ class MixExampleSpecification extends SigmaTestingCommons {
     val carolOutput = ErgoBox(mixAmount, carolPubKey, spendHeight)
 
     // normally this transaction would be invalid, but we're not checking it in this test
-    val spendingTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(carolOutput))
+    val spendingTx = createTransaction(IndexedSeq(carolOutput))
 
     //////////////////////////////////////////////
     //// Alice spending her output

--- a/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
@@ -188,7 +188,7 @@ class MixExampleSpecification extends SigmaTestingCommons {
     val carolOutput = ErgoBox(mixAmount, carolPubKey, spendHeight)
 
     // normally this transaction would be invalid, but we're not checking it in this test
-    val spendingTx = createTransaction(IndexedSeq(carolOutput))
+    val spendingTx = createTransaction(carolOutput)
 
     //////////////////////////////////////////////
     //// Alice spending her output

--- a/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/OracleExamplesSpecification.scala
@@ -155,7 +155,7 @@ class OracleExamplesSpecification extends SigmaTestingCommons { suite =>
 
     val newBox1 = ErgoBox(20, alicePubKey, 0, boxIndex = 2)
     val newBoxes = IndexedSeq(newBox1)
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val sinceHeight = 40
     val timeout = 60
@@ -246,7 +246,7 @@ class OracleExamplesSpecification extends SigmaTestingCommons { suite =>
 
     val newBox1 = ErgoBox(20, alicePubKey, 0)
     val newBoxes = IndexedSeq(newBox1)
-    val spendingTransaction = ErgoLikeTransaction(IndexedSeq(), newBoxes)
+    val spendingTransaction = createTransaction(newBoxes)
 
     val ctx = ErgoLikeContext(
       currentHeight = 50,

--- a/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
@@ -153,7 +153,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val fullGameTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fullGameOutput0, fullGameOutput1))
+    val fullGameTx = createTransaction(IndexedSeq(fullGameOutput0, fullGameOutput1))
 
     val fullGameContext = ErgoLikeContext(
       currentHeight = fullGameCreationHeight,
@@ -186,7 +186,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     val gameOverOutput = ErgoBox(playAmount, carolPubKey, gameOverHeight)
 
     // normally this transaction would be invalid, but we're not checking it in this test
-    val gameOverTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(gameOverOutput))
+    val gameOverTx = createTransaction(IndexedSeq(gameOverOutput))
 
     val aliceProver = alice.withContextExtender(0, ByteArrayConstant(s)).withContextExtender(1, ByteConstant(a))
     val bobProver = bob.withContextExtender(0, ByteArrayConstant(s)).withContextExtender(1, ByteConstant(a))
@@ -275,7 +275,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     val defaultWinOutput = ErgoBox(playAmount*2, carolPubKey, defaultWinHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val defaultWinTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(defaultWinOutput))
+    val defaultWinTx = createTransaction(IndexedSeq(defaultWinOutput))
 
     val defaultWinContext0 = ErgoLikeContext(
       currentHeight = defaultWinHeight,

--- a/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
@@ -186,7 +186,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     val gameOverOutput = ErgoBox(playAmount, carolPubKey, gameOverHeight)
 
     // normally this transaction would be invalid, but we're not checking it in this test
-    val gameOverTx = createTransaction(IndexedSeq(gameOverOutput))
+    val gameOverTx = createTransaction(gameOverOutput)
 
     val aliceProver = alice.withContextExtender(0, ByteArrayConstant(s)).withContextExtender(1, ByteConstant(a))
     val bobProver = bob.withContextExtender(0, ByteArrayConstant(s)).withContextExtender(1, ByteConstant(a))
@@ -275,7 +275,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     val defaultWinOutput = ErgoBox(playAmount*2, carolPubKey, defaultWinHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val defaultWinTx = createTransaction(IndexedSeq(defaultWinOutput))
+    val defaultWinTx = createTransaction(defaultWinOutput)
 
     val defaultWinContext0 = ErgoLikeContext(
       currentHeight = defaultWinHeight,

--- a/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
@@ -131,7 +131,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val withdrawTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(reversibleWithdrawOutput))
+    val withdrawTx = createTransaction(IndexedSeq(reversibleWithdrawOutput))
 
     val withdrawContext = ErgoLikeContext(
       currentHeight = withdrawHeight,
@@ -160,7 +160,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     val bobSpendOutput = ErgoBox(bobSpendAmount, davePubKey, bobSpendHeight)
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val bobSpendTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(bobSpendOutput))
+    val bobSpendTx = createTransaction(IndexedSeq(bobSpendOutput))
 
     val bobSpendContext = ErgoLikeContext(
       currentHeight = bobSpendHeight,
@@ -185,7 +185,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     val carolSpendOutput = ErgoBox(carolSpendAmount, davePubKey, carolSpendHeight)
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val carolSpendTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(carolSpendOutput))
+    val carolSpendTx = createTransaction(IndexedSeq(carolSpendOutput))
 
     val carolSpendContext = ErgoLikeContext(
       currentHeight = carolSpendHeight,

--- a/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
@@ -131,7 +131,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val withdrawTx = createTransaction(IndexedSeq(reversibleWithdrawOutput))
+    val withdrawTx = createTransaction(reversibleWithdrawOutput)
 
     val withdrawContext = ErgoLikeContext(
       currentHeight = withdrawHeight,
@@ -160,7 +160,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     val bobSpendOutput = ErgoBox(bobSpendAmount, davePubKey, bobSpendHeight)
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val bobSpendTx = createTransaction(IndexedSeq(bobSpendOutput))
+    val bobSpendTx = createTransaction(bobSpendOutput)
 
     val bobSpendContext = ErgoLikeContext(
       currentHeight = bobSpendHeight,
@@ -185,7 +185,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
     val carolSpendOutput = ErgoBox(carolSpendAmount, davePubKey, carolSpendHeight)
 
     //normally this transaction would be invalid (why?), but we're not checking it in this test
-    val carolSpendTx = createTransaction(IndexedSeq(carolSpendOutput))
+    val carolSpendTx = createTransaction(carolSpendOutput)
 
     val carolSpendContext = ErgoLikeContext(
       currentHeight = carolSpendHeight,

--- a/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/Rule110Specification.scala
@@ -404,7 +404,7 @@ class Rule110Specification extends SigmaTestingCommons {
     }
 
     val initBlock = FullBlock(
-      IndexedSeq(ErgoLikeTransaction(IndexedSeq(), coins)),
+      IndexedSeq(createTransaction(coins)),
       ErgoLikeContext.dummyPubkey
     )
 

--- a/src/test/scala/sigmastate/utxo/examples/TimedPaymentExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/TimedPaymentExampleSpecification.scala
@@ -56,7 +56,7 @@ class TimedPaymentExampleSpecification extends SigmaTestingCommons {
     val timedWithdrawOutput = ErgoBox(withdrawAmount, bobPubKey, withdrawHeight)
 
     //normally this transaction would be invalid, but we're not checking it in this test
-    val withdrawTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(timedWithdrawOutput))
+    val withdrawTx = createTransaction(IndexedSeq(timedWithdrawOutput))
 
     val withdrawContext = ErgoLikeContext(
       currentHeight = 109,

--- a/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
@@ -142,7 +142,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val abortHalfGameTx = createTransaction(IndexedSeq(abortHalfGameOutput))
+    val abortHalfGameTx = createTransaction(abortHalfGameOutput)
 
     val abortHalfGameContext = ErgoLikeContext(
       currentHeight = abortHalfGameHeight,
@@ -178,7 +178,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val fullGameTx = createTransaction(IndexedSeq(fullGameOutput))
+    val fullGameTx = createTransaction(fullGameOutput)
 
     val fullGameContext = ErgoLikeContext(
       currentHeight = fullGameCreationHeight,
@@ -228,7 +228,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     val gameOverOutput = ErgoBox(playAmount*2, carolPubKey, gameOverHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val gameOverTx = createTransaction(IndexedSeq(gameOverOutput))
+    val gameOverTx = createTransaction(gameOverOutput)
 
     val gameOverContext = ErgoLikeContext(
       currentHeight = gameOverHeight,
@@ -255,7 +255,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     val defaultWinOutput = ErgoBox(playAmount*2, carolPubKey, defaultWinHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val defaultWinTx = createTransaction(IndexedSeq(defaultWinOutput))
+    val defaultWinTx = createTransaction(defaultWinOutput)
 
     val defaultWinContext = ErgoLikeContext(
       currentHeight = defaultWinHeight,

--- a/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
@@ -142,7 +142,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val abortHalfGameTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(abortHalfGameOutput))
+    val abortHalfGameTx = createTransaction(IndexedSeq(abortHalfGameOutput))
 
     val abortHalfGameContext = ErgoLikeContext(
       currentHeight = abortHalfGameHeight,
@@ -178,7 +178,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     )
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val fullGameTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(fullGameOutput))
+    val fullGameTx = createTransaction(IndexedSeq(fullGameOutput))
 
     val fullGameContext = ErgoLikeContext(
       currentHeight = fullGameCreationHeight,
@@ -228,7 +228,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     val gameOverOutput = ErgoBox(playAmount*2, carolPubKey, gameOverHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val gameOverTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(gameOverOutput))
+    val gameOverTx = createTransaction(IndexedSeq(gameOverOutput))
 
     val gameOverContext = ErgoLikeContext(
       currentHeight = gameOverHeight,
@@ -255,7 +255,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     val defaultWinOutput = ErgoBox(playAmount*2, carolPubKey, defaultWinHeight)
 
     //normally this transaction would invalid (why?), but we're not checking it in this test
-    val defaultWinTx = ErgoLikeTransaction(IndexedSeq(), IndexedSeq(defaultWinOutput))
+    val defaultWinTx = createTransaction(IndexedSeq(defaultWinOutput))
 
     val defaultWinContext = ErgoLikeContext(
       currentHeight = defaultWinHeight,


### PR DESCRIPTION
- Relies on unmerged https://github.com/ScorexFoundation/sigmastate-interpreter/pull/408 
- Add `dataInputs` to transaction (close #345).
- No operations that use them in the scripting language, they'll be added in separate PR (probably by @aslesarenko)
