### PR TITLE
Add type check for deserialized script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val sigma = (project in file("."))
     .settings(commonSettings: _*)
 
 def runErgoTask(task: String, sigmastateVersion: String, log: Logger): Unit = {
-  val ergoBranch = "new-sigma"
+  val ergoBranch = "sigma454-type-check-on-script-deser"
   log.info(s"Testing current build in Ergo (branch $ergoBranch):")
   val cwd = new File("").absolutePath
   val ergoPath = new File(cwd + "/ergo-tests/")

--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val sigma = (project in file("."))
     .settings(commonSettings: _*)
 
 def runErgoTask(task: String, sigmastateVersion: String, log: Logger): Unit = {
-  val ergoBranch = "sigma454-type-check-on-script-deser"
+  val ergoBranch = "new-sigma"
   log.info(s"Testing current build in Ergo (branch $ergoBranch):")
   val cwd = new File("").absolutePath
   val ergoPath = new File(cwd + "/ergo-tests/")

--- a/src/main/scala/org/ergoplatform/ErgoAddress.scala
+++ b/src/main/scala/org/ergoplatform/ErgoAddress.scala
@@ -233,8 +233,8 @@ case class ErgoAddressEncoder(networkPrefix: NetworkPrefix) {
                  ByteArrayConstant(scriptHash))),
              DeserializeContext(Pay2SHAddress.scriptId, SSigmaProp))) => new Pay2SHAddress(scriptHash.toArray)
       case b: Value[SSigmaProp.type]@unchecked if b.tpe == SSigmaProp => Pay2SAddress(proposition)
-      case other =>
-        throw new RuntimeException(s"Cannot create ErgoAddress form proposition: ${proposition}")
+      case _ =>
+        throw new RuntimeException(s"Cannot create ErgoAddress form proposition: $proposition")
     }
   }
 }

--- a/src/main/scala/org/ergoplatform/ErgoScriptPredef.scala
+++ b/src/main/scala/org/ergoplatform/ErgoScriptPredef.scala
@@ -9,8 +9,8 @@ import sigmastate.eval.IRContext
 import sigmastate.interpreter.CryptoConstants
 import sigmastate.lang.Terms.ValueOps
 import sigmastate.{SLong, _}
-import sigmastate.lang.{TransformingSigmaBuilder, SigmaCompiler}
-import sigmastate.serialization.ErgoTreeSerializer
+import sigmastate.lang.{SigmaCompiler, TransformingSigmaBuilder}
+import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 import sigmastate.utxo._
 
 object ErgoScriptPredef {
@@ -37,7 +37,7 @@ object ErgoScriptPredef {
   def expectedMinerOutScriptBytesVal(delta: Int, minerPkBytesVal: Value[SByteArray]): Value[SByteArray] = {
     val genericPk = ProveDlog(CryptoConstants.dlogGroup.generator)
     val genericMinerProp = rewardOutputScript(delta, genericPk)
-    val genericMinerPropBytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(genericMinerProp)
+    val genericMinerPropBytes = DefaultSerializer.serializeErgoTree(genericMinerProp.treeWithSegregation)
     // first segregated constant is delta, so key is second constant
     val positions = IntArrayConstant(Array[Int](1))
     val minerPubkeySigmaProp = CreateProveDlog(DecodePoint(minerPkBytesVal))

--- a/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
@@ -2,8 +2,7 @@ package org.ergoplatform.settings
 
 import org.ergoplatform.ErgoScriptPredef
 import org.ergoplatform.mining.emission.EmissionRules
-import sigmastate.Values.SigmaPropValue
-import sigmastate.lang.Terms._
+import sigmastate.Values.ErgoTree
 
 /**
   * Configuration file for monetary settings of Ergo chain
@@ -17,9 +16,9 @@ case class MonetarySettings(fixedRatePeriod: Int = 30 * 2 * 24 * 365,
                             minerRewardDelay: Int = 720,
                             foundersInitialReward: Long = 75L * EmissionRules.CoinsInOneErgo / 10) {
 
-  val feeProposition: SigmaPropValue = ErgoScriptPredef.feeProposition(minerRewardDelay)
-  val feePropositionBytes: Array[Byte] = feeProposition.treeWithSegregation.bytes
-  val emissionBoxProposition: SigmaPropValue = ErgoScriptPredef.emissionBoxProp(this)
-  val foundersBoxProposition: SigmaPropValue = ErgoScriptPredef.foundationScript(this)
+  val feeProposition: ErgoTree = ErgoScriptPredef.feeProposition(minerRewardDelay)
+  val feePropositionBytes: Array[Byte] = feeProposition.bytes
+  val emissionBoxProposition: ErgoTree = ErgoScriptPredef.emissionBoxProp(this)
+  val foundersBoxProposition: ErgoTree = ErgoScriptPredef.foundationScript(this)
 
 }

--- a/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
@@ -2,8 +2,8 @@ package org.ergoplatform.settings
 
 import org.ergoplatform.ErgoScriptPredef
 import org.ergoplatform.mining.emission.EmissionRules
-import sigmastate.Values.{Value, SigmaPropValue}
-import sigmastate.{SBoolean, Values}
+import sigmastate.Values.SigmaPropValue
+import sigmastate.lang.Terms._
 
 /**
   * Configuration file for monetary settings of Ergo chain

--- a/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
+++ b/src/main/scala/org/ergoplatform/settings/MonetarySettings.scala
@@ -18,7 +18,7 @@ case class MonetarySettings(fixedRatePeriod: Int = 30 * 2 * 24 * 365,
                             foundersInitialReward: Long = 75L * EmissionRules.CoinsInOneErgo / 10) {
 
   val feeProposition: SigmaPropValue = ErgoScriptPredef.feeProposition(minerRewardDelay)
-  val feePropositionBytes: Array[Byte] = feeProposition.bytes
+  val feePropositionBytes: Array[Byte] = feeProposition.treeWithSegregation.bytes
   val emissionBoxProposition: SigmaPropValue = ErgoScriptPredef.emissionBoxProp(this)
   val foundersBoxProposition: SigmaPropValue = ErgoScriptPredef.foundationScript(this)
 

--- a/src/main/scala/sigmastate/UnprovenTree.scala
+++ b/src/main/scala/sigmastate/UnprovenTree.scala
@@ -8,7 +8,6 @@ import sigmastate.basics.DLogProtocol.{FirstDLogProverMessage, ProveDlog}
 import sigmastate.basics.VerifierMessage.Challenge
 import sigmastate.Values.{ErgoTree, SigmaBoolean, SigmaPropConstant}
 import sigmastate.basics.{FirstDiffieHellmanTupleProverMessage, FirstProverMessage, ProveDHTuple}
-import sigmastate.serialization.ErgoTreeSerializer
 import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 
 import scala.language.existentials

--- a/src/main/scala/sigmastate/UnprovenTree.scala
+++ b/src/main/scala/sigmastate/UnprovenTree.scala
@@ -6,8 +6,8 @@ import com.google.common.primitives.Shorts
 import gf2t.GF2_192_Poly
 import sigmastate.basics.DLogProtocol.{FirstDLogProverMessage, ProveDlog}
 import sigmastate.basics.VerifierMessage.Challenge
-import sigmastate.Values.{SigmaBoolean, SigmaPropConstant}
-import sigmastate.basics.{FirstProverMessage, ProveDHTuple, FirstDiffieHellmanTupleProverMessage}
+import sigmastate.Values.{ErgoTree, SigmaBoolean, SigmaPropConstant}
+import sigmastate.basics.{FirstDiffieHellmanTupleProverMessage, FirstProverMessage, ProveDHTuple}
 import sigmastate.serialization.ErgoTreeSerializer
 import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 
@@ -139,7 +139,8 @@ object FiatShamirTree {
 
     def traverseNode(node: ProofTree): Array[Byte] = node match {
       case l: ProofTreeLeaf =>
-        val propBytes = DefaultSerializer.serializeWithSegregation(SigmaPropConstant(l.proposition))
+        val propTree = ErgoTree.withSegregation(SigmaPropConstant(l.proposition))
+        val propBytes = DefaultSerializer.serializeErgoTree(propTree)
         val commitmentBytes = l.commitmentOpt.get.bytes
         leafPrefix +:
           ((Shorts.toByteArray(propBytes.length.toShort) ++ propBytes) ++

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -949,6 +949,15 @@ object Values {
       withoutSegregation(pk.toSigmaProp)
     }
 
+    /** Build ErgoTree via serialization of the value with ConstantSegregationHeader, constants segregated
+      * from the tree and ConstantPlaceholders referring to the segregated constants.
+      *
+      * This method uses single traverse of the tree to:
+      * 1) find and segregate all constants;
+      * 2) replace constants with ConstantPlaceholders in the `tree`;
+      * 3) write the `tree` to the Writer's buffer obtaining `treeBytes`.
+      * 4) deserialize `tree` with ConstantPlaceholders;
+      **/
     def withSegregation(value: SigmaPropValue): ErgoTree = {
       val constantStore = new ConstantStore()
       val byteWriter = SigmaSerializer.startWriter(constantStore)

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -740,6 +740,7 @@ object Values {
   implicit class SigmaPropValueOps(val p: Value[SSigmaProp.type]) extends AnyVal {
     def isProven: Value[SBoolean.type] = SigmaPropIsProven(p)
     def propBytes: Value[SByteArray] = SigmaPropBytes(p)
+    def bytes: Array[Byte] = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(p)
   }
 
   implicit class SigmaBooleanOps(val sb: SigmaBoolean) extends AnyVal {

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -955,8 +955,8 @@ object Values {
       * This method uses single traverse of the tree to:
       * 1) find and segregate all constants;
       * 2) replace constants with ConstantPlaceholders in the `tree`;
-      * 3) write the `tree` to the Writer's buffer obtaining `treeBytes`.
-      * 4) deserialize `tree` with ConstantPlaceholders;
+      * 3) write the `tree` to the Writer's buffer obtaining `treeBytes`;
+      * 4) deserialize `tree` with ConstantPlaceholders.
       **/
     def withSegregation(value: SigmaPropValue): ErgoTree = {
       val constantStore = new ConstantStore()

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -59,8 +59,6 @@ object Values {
       * the type of operation result. */
     def tpe: S
 
-    lazy val bytes = DefaultSerializer.serializeWithSegregation(this)
-
     /** Every value represents an operation and that operation can be associated with a function type,
       * describing functional meaning of the operation, kind of operation signature.
       * Thus we can obtain global operation identifiers by combining Value.opName with Value.opType,

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -5,22 +5,18 @@ import java.util.{Objects, Arrays}
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
 import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{strategy, everywherebu}
-import org.bouncycastle.math.ec.ECPoint
-import org.ergoplatform.{ErgoLikeContext, ErgoBox}
+import org.ergoplatform.ErgoLikeContext
 import scalan.{Nullable, RType}
 import scorex.crypto.authds.{ADDigest, SerializedAdProof}
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
 import scorex.crypto.hash.{Digest32, Blake2b256}
 import scalan.util.CollectionUtil._
-import scorex.util.serialization.Serializer
 import sigmastate.SCollection.SByteArray
 import sigmastate.interpreter.CryptoConstants.EcPointType
-import sigmastate.interpreter.{CryptoConstants, InterpreterContext, CryptoFunctions}
+import sigmastate.interpreter.CryptoConstants
 import sigmastate.serialization._
-import sigmastate.serialization.{ErgoTreeSerializer, OpCodes, ConstantStore}
+import sigmastate.serialization.{OpCodes, ConstantStore}
 import sigmastate.serialization.OpCodes._
-import sigmastate.utxo.CostTable.Cost
-import sigma.util.Extensions._
 import sigmastate.TrivialProp.{FalseProp, TrueProp}
 import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.basics.ProveDHTuple
@@ -37,7 +33,7 @@ import sigmastate.lang.DefaultSigmaBuilder._
 import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 import sigmastate.serialization.transformers.ProveDHTupleSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
-import special.sigma.{Header, Extensions, AnyValue, AvlTree, TestValue, PreHeader}
+import special.sigma.{Header, AnyValue, AvlTree, PreHeader}
 import sigmastate.lang.SourceContext
 import special.collection.Coll
 

--- a/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -40,7 +40,11 @@ trait Interpreter extends ScorexLogging {
       if (context.extension.values.contains(d.id))
         context.extension.values(d.id) match {
           case eba: EvaluatedValue[SByteArray]@unchecked if eba.tpe == SByteArray =>
-            Some(ValueSerializer.deserialize(eba.value.toArray))
+            val script = ValueSerializer.deserialize(eba.value.toArray)
+            if (d.tpe != script.tpe)
+              throw new InterpreterException(s"Failed context deserialization of $d: expected deserialized script to have type ${d.tpe}; got ${script.tpe}")
+            else
+              Some(script)
           case _ => None
         }
       else

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -7,7 +7,7 @@ import sigmastate.Values._
 import sigmastate.utils.Overloading.Overload1
 import sigmastate._
 import sigmastate.lang.SigmaTyper.STypeSubst
-import sigmastate.serialization.OpCodes
+import sigmastate.serialization.{ErgoTreeSerializer, OpCodes}
 import sigmastate.serialization.OpCodes.OpCode
 import sigmastate.lang.TransformingSigmaBuilder._
 import sigmastate.utxo.CostTable.Cost
@@ -234,5 +234,9 @@ object Terms {
       }))(v).asValue[T]
     }
 
+  }
+
+  implicit class SigmaPropValueOps(val v: SigmaPropValue) extends AnyVal {
+    def bytes: Array[Byte] = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(v)
   }
 }

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -6,13 +6,9 @@ import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate.utils.Overloading.Overload1
 import sigmastate._
-import sigmastate.lang.SigmaTyper.STypeSubst
-import sigmastate.serialization.{ErgoTreeSerializer, OpCodes}
+import sigmastate.serialization.OpCodes
 import sigmastate.serialization.OpCodes.OpCode
 import sigmastate.lang.TransformingSigmaBuilder._
-import sigmastate.utxo.CostTable.Cost
-import sigmastate.utxo.{ExtractRegisterAs, SigmaPropIsProven, Slice}
-import special.sigma.{AnyValue, TestValue}
 
 import scala.language.implicitConversions
 
@@ -223,7 +219,6 @@ object Terms {
     }
     /**
       * Set source context to all nodes missing source context in the given tree.
-      * @param tree AST to traverse
       * @param srcCtx source context to set
       * @return AST where all nodes with missing source context are set to the given srcCtx
       */

--- a/src/main/scala/sigmastate/lang/Terms.scala
+++ b/src/main/scala/sigmastate/lang/Terms.scala
@@ -235,8 +235,4 @@ object Terms {
     }
 
   }
-
-  implicit class SigmaPropValueOps(val v: SigmaPropValue) extends AnyVal {
-    def bytes: Array[Byte] = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(v)
-  }
 }

--- a/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
@@ -127,23 +127,6 @@ class ErgoTreeSerializer {
     tree
   }
 
-  def serializedPubkeyPropValue(pubkey: Value[SByteArray]): Value[SByteArray] =
-    Append(
-      Append(
-        ConcreteCollection(
-          0.toByte, // header
-          1.toByte, // const count
-          SGroupElement.typeCode // const type
-        ),
-        pubkey // const value
-      ),
-      ConcreteCollection(
-        OpCodes.ProveDlogCode,
-        OpCodes.ConstantPlaceholderIndexCode,
-        0.toByte // constant index in the store
-      )
-    )
-
   def substituteConstants(scriptBytes: Array[Byte],
                           positions: Array[Int],
                           newVals: Array[Value[SType]]): Array[Byte] = {

--- a/src/test/scala/org/ergoplatform/ErgoScriptPredefSpec.scala
+++ b/src/test/scala/org/ergoplatform/ErgoScriptPredefSpec.scala
@@ -85,15 +85,15 @@ class ErgoScriptPredefSpec extends SigmaTestingCommons {
 
     def checkAtHeight(height: Int) = {
       // collect correct amount of coins, correct new script, able to satisfy R4 conditions
-      checkSpending(remaining(height), height, prop, R4Prop(true)) shouldBe 'success
+      checkSpending(remaining(height), height, prop.proposition, R4Prop(true)) shouldBe 'success
       // unable to satisfy R4 conditions
-      checkSpending(remaining(height), height, prop, R4Prop(false)) shouldBe 'failure
+      checkSpending(remaining(height), height, prop.proposition, R4Prop(false)) shouldBe 'failure
       // incorrect new script
       checkSpending(remaining(height), height, TrivialProp.TrueProp, R4Prop(true)) shouldBe 'failure
       // collect less coins then possible
-      checkSpending(remaining(height) + 1, height, prop, R4Prop(true)) shouldBe 'success
+      checkSpending(remaining(height) + 1, height, prop.proposition, R4Prop(true)) shouldBe 'success
       // collect more coins then possible
-      checkSpending(remaining(height) - 1, height, prop, R4Prop(true)) shouldBe 'failure
+      checkSpending(remaining(height) - 1, height, prop.proposition, R4Prop(true)) shouldBe 'failure
     }
 
     def checkSpending(remainingAmount: Long,
@@ -162,17 +162,17 @@ class ErgoScriptPredefSpec extends SigmaTestingCommons {
     // collect coins during the fixed rate period
     forAll(Gen.choose(1, settings.fixedRatePeriod)) { height =>
       val currentRate = emission.minersRewardAtHeight(height)
-      createRewardTx(currentRate, height, minerProp) shouldBe 'success
-      createRewardTx(currentRate + 1, height, minerProp) shouldBe 'failure
-      createRewardTx(currentRate - 1, height, minerProp) shouldBe 'failure
+      createRewardTx(currentRate, height, minerProp.proposition) shouldBe 'success
+      createRewardTx(currentRate + 1, height, minerProp.proposition) shouldBe 'failure
+      createRewardTx(currentRate - 1, height, minerProp.proposition) shouldBe 'failure
     }
 
     // collect coins after the fixed rate period
     forAll(Gen.choose(1, emission.blocksTotal - 1)) { height =>
       val currentRate = emission.minersRewardAtHeight(height)
-      createRewardTx(currentRate, height, minerProp) shouldBe 'success
-      createRewardTx(currentRate + 1, height, minerProp) shouldBe 'failure
-      createRewardTx(currentRate - 1, height, minerProp) shouldBe 'failure
+      createRewardTx(currentRate, height, minerProp.proposition) shouldBe 'success
+      createRewardTx(currentRate + 1, height, minerProp.proposition) shouldBe 'failure
+      createRewardTx(currentRate - 1, height, minerProp.proposition) shouldBe 'failure
     }
 
     // collect coins to incorrect proposition
@@ -182,9 +182,9 @@ class ErgoScriptPredefSpec extends SigmaTestingCommons {
       val correctProp = ErgoScriptPredef.rewardOutputScript(settings.minerRewardDelay, minerPk)
       val incorrectDelay = ErgoScriptPredef.rewardOutputScript(settings.minerRewardDelay + 1, minerPk)
       val incorrectPk = ErgoScriptPredef.rewardOutputScript(settings.minerRewardDelay, pk2)
-      createRewardTx(currentRate, height, correctProp) shouldBe 'success
-      createRewardTx(currentRate, height, incorrectDelay) shouldBe 'failure
-      createRewardTx(currentRate, height, incorrectPk) shouldBe 'failure
+      createRewardTx(currentRate, height, correctProp.proposition) shouldBe 'success
+      createRewardTx(currentRate, height, incorrectDelay.proposition) shouldBe 'failure
+      createRewardTx(currentRate, height, incorrectPk.proposition) shouldBe 'failure
       createRewardTx(currentRate, height, minerPk) shouldBe 'failure
     }
 

--- a/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/TestingInterpreterSpecification.scala
@@ -304,7 +304,7 @@ class TestingInterpreterSpecification extends SigmaTestingCommons {
     val prop3 = AND(FalseLeaf, TrueLeaf).toSigmaProp
     verifier.verify(prop3, env, proof, challenge).map(_._1).fold(t => throw t, identity) shouldBe false
 
-    val prop4 = GT(Height, LongConstant(100)).toSigmaProp
+    val prop4 = GT(Height, IntConstant(100)).toSigmaProp
     verifier.verify(prop4, env, proof, challenge).map(_._1).fold(t => throw t, identity) shouldBe false
   }
 

--- a/src/test/scala/sigmastate/crypto/SigningSpecification.scala
+++ b/src/test/scala/sigmastate/crypto/SigningSpecification.scala
@@ -50,11 +50,14 @@ class SigningSpecification extends SigmaTestingCommons {
 
     val sk = proverA.dlogSecrets.head
     val prop = sk.publicImage
-    val prove = proverA.prove(prop, fakeContext, msg).get
+    val tree = prop.toSigmaProp.treeWithSegregation
+    val prove = proverA.prove(tree, fakeContext, msg).get
 
     println(s"Message: ${Base16.encode(msg)}")
     println(s"sk: ${sk.w}")
+    println(s"sk(Base16): ${Base16.encode(sk.w.toByteArray)}")
     println(s"pkBytes: ${Base16.encode(prop.pkBytes)}")
+    println(s"treeBytes: ${Base16.encode(tree.bytes)}")
     println(s"Signature: ${Base16.encode(prove.proof)}")
   }
 

--- a/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -10,6 +10,7 @@ import scalan.util.BenchmarkUtil._
 import sigmastate._
 import sigmastate.basics.DLogProtocol.{DLogProverInput, ProveDlog}
 import sigmastate.serialization.ErgoTreeSerializer
+import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 
 class EvaluationTest extends BaseCtxTests
     with LangTests with ExampleContracts with ErgoScriptTestkit {
@@ -134,12 +135,12 @@ class EvaluationTest extends BaseCtxTests
     val pk2 = DLogProverInput.random().publicImage
     val script1 = script(pk1)
     val script2 = script(pk2)
-    val inputBytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(script1)
+    val inputBytes = DefaultSerializer.serializeErgoTree(script1.treeWithSegregation)
     val positions = IntArrayConstant(Array[Int](2))
     // in ergo we have only byte array of a serialized group element
     val newVals = ConcreteCollection(Vector[SigmaPropValue](CreateProveDlog(DecodePoint(pk2.pkBytes))), SSigmaProp)
 
-    val expectedBytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(script2)
+    val expectedBytes = DefaultSerializer.serializeErgoTree(script2.treeWithSegregation)
     val ctx = newErgoContext(height = 1, boxToSpend)
     reduce(emptyEnv, "SubstConst",
       EQ(SubstConstants(inputBytes, positions, newVals), expectedBytes),

--- a/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -127,7 +127,8 @@ class EvaluationTest extends BaseCtxTests
 //  }
 
   test("SubstConst") {
-    def script(pk: ProveDlog): Value[SType] = AND(EQ(IntConstant(1), IntConstant(1)), SigmaPropConstant(pk).isProven)
+    def script(pk: ProveDlog): SigmaPropValue =
+      AND(EQ(IntConstant(1), IntConstant(1)), SigmaPropConstant(pk).isProven).toSigmaProp
 
     val pk1 = DLogProverInput.random().publicImage
     val pk2 = DLogProverInput.random().publicImage

--- a/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -19,7 +19,7 @@ import sigmastate.eval.{CompiletimeCosting, IRContext, Evaluation}
 import sigmastate.interpreter.Interpreter.{ScriptNameProp, ScriptEnv}
 import sigmastate.interpreter.{CryptoConstants, Interpreter}
 import sigmastate.lang.{TransformingSigmaBuilder, SigmaCompiler}
-import sigmastate.serialization.{ErgoTreeSerializer, SigmaSerializer}
+import sigmastate.serialization.{ErgoTreeSerializer, SigmaSerializer, ValueSerializer}
 import sigmastate.{SGroupElement, SType}
 import special.sigma._
 import spire.util.Opt
@@ -49,9 +49,9 @@ trait SigmaTestingCommons extends PropSpec
   val compiler = SigmaCompiler(TestnetNetworkPrefix, TransformingSigmaBuilder)
 
   def checkSerializationRoundTrip(v: SValue): Unit = {
-    val compiledTreeBytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(v)
+    val compiledTreeBytes = ValueSerializer.serialize(v)
     withClue(s"(De)Serialization roundtrip failed for the tree:") {
-      ErgoTreeSerializer.DefaultSerializer.deserialize(compiledTreeBytes) shouldEqual v
+      ValueSerializer.deserialize(compiledTreeBytes) shouldEqual v
     }
   }
 

--- a/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
@@ -1,15 +1,13 @@
 package sigmastate.serialization
 
-import java.nio.ByteBuffer
-
 import org.ergoplatform.Self
 import sigmastate.Values.ErgoTree.DefaultHeader
-import sigmastate.Values.{BlockValue, Constant, ConstantPlaceholder, ErgoTree, IntConstant, LongConstant, ValDef, ValUse, Value}
+import sigmastate.Values.{ErgoTree, IntConstant, LongConstant, SigmaPropValue}
 import sigmastate._
 import sigmastate.eval.IRContext
 import sigmastate.helpers.SigmaTestingCommons
 import sigmastate.lang.exceptions.SerializerException
-import sigmastate.utils.SigmaByteReader
+import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 import sigmastate.utxo.ExtractAmount
 
 class ErgoTreeSerializerSpecification extends SerializationSpecification with SigmaTestingCommons {
@@ -18,14 +16,14 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
     beginPass(noConstPropagationPass)
   }
 
-  private def passThroughTreeBuilder(tree: Value[SType]): Value[SType] = {
+  private def passThroughTreeBuilder(tree: SigmaPropValue): SigmaPropValue = {
     val env = Map[String, Any]()
     val IR.Pair(calcF, _) = IR.doCosting(env, tree)
     val outTree = IR.buildTree(calcF, None)
     outTree
   }
 
-  private def extractConstants(tree: Value[SType])(implicit IR: IRContext): ErgoTree = {
+  private def extractConstants(tree: SigmaPropValue)(implicit IR: IRContext): ErgoTree = {
     import ErgoTree._
     val env = Map[String, Any]()
     val IR.Pair(calcF, _) = IR.doCosting(env, tree)
@@ -38,10 +36,10 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
   }
 
   property("(de)serialization round trip using treeBytes()") {
-    val tree = Plus(10, 20)
+    val tree = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
     val ergoTree = extractConstants(tree)
-    val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(ergoTree)
-    val (_, deserializedConstants, treeBytes) = ErgoTreeSerializer.DefaultSerializer
+    val bytes = DefaultSerializer.serializeErgoTree(ergoTree)
+    val (_, deserializedConstants, treeBytes) = DefaultSerializer
       .deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes))
     deserializedConstants shouldEqual ergoTree.constants
     val r = SigmaSerializer.startReader(treeBytes, new ConstantStore(deserializedConstants),
@@ -53,35 +51,36 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
   property("Constant extraction via compiler pass: (de)serialization round trip") {
     val prop = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
     val ergoTree = extractConstants(prop)
-    val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(ergoTree)
-    val deserializedTree = ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes)
+    val bytes = DefaultSerializer.serializeErgoTree(ergoTree)
+    val deserializedTree = DefaultSerializer.deserializeErgoTree(bytes)
     deserializedTree shouldEqual ergoTree
   }
 
   property("failed type check on tree deserialization") {
     val prop = IntConstant(1)
-    val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(extractConstants(prop))
-    an[SerializerException] should be thrownBy ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes)
+    val bytes = DefaultSerializer.serializeErgoTree(extractConstants(prop.asInstanceOf[SigmaPropValue]))
+    an[SerializerException] should be thrownBy DefaultSerializer.deserializeErgoTree(bytes)
+    an[SerializerException] should be thrownBy DefaultSerializer.deserialize(bytes)
   }
 
   property("Constant extraction during serialization: (de)serialization round trip") {
-    val tree = Plus(10, 20)
-    val bytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(tree)
-    val (_, deserializedConstants, _) = ErgoTreeSerializer.DefaultSerializer.
+    val tree = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
+    val bytes = DefaultSerializer.serializeWithSegregation(tree)
+    val (_, deserializedConstants, _) = DefaultSerializer.
       deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes))
-    deserializedConstants.length shouldBe 2
-    val deserializedTree = ErgoTreeSerializer.DefaultSerializer.deserialize(bytes)
+    deserializedConstants.length shouldBe 3
+    val deserializedTree = DefaultSerializer.deserialize(bytes)
     deserializedTree shouldEqual tree
   }
 
   property("tree with placeholders bytes should be equal if only constants are different") {
-    val tree1 = Plus(10, 20)
-    val tree2 = Plus(30, 40)
-    val bytes1 = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(tree1)
-    val bytes2 = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(tree2)
-    val (_, _, treeBytes1) = ErgoTreeSerializer.DefaultSerializer
+    val tree1 = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
+    val tree2 = EQ(Plus(30, 40), IntConstant(70)).toSigmaProp
+    val bytes1 = DefaultSerializer.serializeWithSegregation(tree1)
+    val bytes2 = DefaultSerializer.serializeWithSegregation(tree2)
+    val (_, _, treeBytes1) = DefaultSerializer
       .deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes1))
-    val (_, _, treeBytes2) = ErgoTreeSerializer.DefaultSerializer
+    val (_, _, treeBytes2) = DefaultSerializer
       .deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes2))
     treeBytes1 shouldEqual treeBytes2
   }
@@ -89,8 +88,8 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
   property("(de)serialize round trip (without constants)") {
     val prop = EQ(ExtractAmount(Self), LongConstant(0)).toSigmaProp
     val tree = ErgoTree(DefaultHeader, IndexedSeq(), prop, prop)
-    val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(tree)
-    val deserializedProp = ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes).proposition
+    val bytes = DefaultSerializer.serializeErgoTree(tree)
+    val deserializedProp = DefaultSerializer.deserializeErgoTree(bytes).proposition
     deserializedProp shouldEqual prop
   }
 
@@ -98,22 +97,9 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
     forAll(logicalExprTreeNodeGen(Seq(AND.apply))) { tree =>
       val processedTree = passThroughTreeBuilder(tree.toSigmaProp)
       val ergoTree = extractConstants(processedTree)
-      val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(ergoTree)
-      val deserializedTree = ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(bytes)
+      val bytes = DefaultSerializer.serializeErgoTree(ergoTree)
+      val deserializedTree = DefaultSerializer.deserializeErgoTree(bytes)
       deserializedTree shouldEqual ergoTree
-    }
-  }
-
-  property("AND expr gen: deserialization round trip with constant injection") {
-    forAll(logicalExprTreeNodeGen(Seq(AND.apply))) { tree =>
-      val processedTree = passThroughTreeBuilder(tree)
-      val ergoTree = extractConstants(processedTree)
-      val bytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(ergoTree)
-      val (_, deserializedConstants, treeBytes) = ErgoTreeSerializer.DefaultSerializer
-        .deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes))
-      val c = new ConstantStore(deserializedConstants)
-      val deserializedTree = ErgoTreeSerializer.DefaultSerializer.deserializeWithConstantInjection(c, treeBytes)
-      deserializedTree shouldEqual processedTree
     }
   }
 

--- a/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
@@ -60,24 +60,24 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification with Si
     val prop = IntConstant(1)
     val bytes = DefaultSerializer.serializeErgoTree(extractConstants(prop.asInstanceOf[SigmaPropValue]))
     an[SerializerException] should be thrownBy DefaultSerializer.deserializeErgoTree(bytes)
-    an[SerializerException] should be thrownBy DefaultSerializer.deserialize(bytes)
+    an[SerializerException] should be thrownBy DefaultSerializer.deserializeErgoTree(bytes)
   }
 
   property("Constant extraction during serialization: (de)serialization round trip") {
-    val tree = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
-    val bytes = DefaultSerializer.serializeWithSegregation(tree)
+    val tree = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp.treeWithSegregation
+    val bytes = DefaultSerializer.serializeErgoTree(tree)
     val (_, deserializedConstants, _) = DefaultSerializer.
       deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes))
     deserializedConstants.length shouldBe 3
-    val deserializedTree = DefaultSerializer.deserialize(bytes)
+    val deserializedTree = DefaultSerializer.deserializeErgoTree(bytes)
     deserializedTree shouldEqual tree
   }
 
   property("tree with placeholders bytes should be equal if only constants are different") {
-    val tree1 = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp
-    val tree2 = EQ(Plus(30, 40), IntConstant(70)).toSigmaProp
-    val bytes1 = DefaultSerializer.serializeWithSegregation(tree1)
-    val bytes2 = DefaultSerializer.serializeWithSegregation(tree2)
+    val tree1 = EQ(Plus(10, 20), IntConstant(30)).toSigmaProp.treeWithSegregation
+    val tree2 = EQ(Plus(30, 40), IntConstant(70)).toSigmaProp.treeWithSegregation
+    val bytes1 = DefaultSerializer.serializeErgoTree(tree1)
+    val bytes2 = DefaultSerializer.serializeErgoTree(tree2)
     val (_, _, treeBytes1) = DefaultSerializer
       .deserializeHeaderWithTreeBytes(SigmaSerializer.startReader(bytes1))
     val (_, _, treeBytes2) = DefaultSerializer

--- a/src/test/scala/sigmastate/serialization/SubstConstantsSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/SubstConstantsSerializerSpecification.scala
@@ -7,8 +7,9 @@ import sigmastate.{EQ, SInt, SubstConstants}
 class SubstConstantsSerializerSpecification extends SerializationSpecification {
 
   property("SubstConstant deserialization round trip") {
-    forAll(numExprTreeNodeGen) { tree =>
-      val bytes = DefaultSerializer.serializeWithSegregation(EQ(tree, IntConstant(1)).toSigmaProp)
+    forAll(numExprTreeNodeGen) { prop =>
+      val tree = EQ(prop, IntConstant(1)).toSigmaProp.treeWithSegregation
+      val bytes = DefaultSerializer.serializeErgoTree(tree)
       val newVals = ConcreteCollection(Vector[IntValue](1), SInt)
       val expr = SubstConstants(bytes, IntArrayConstant(Array(0)), newVals)
       roundTripTest(expr)

--- a/src/test/scala/sigmastate/serialization/SubstConstantsSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/SubstConstantsSerializerSpecification.scala
@@ -1,13 +1,14 @@
 package sigmastate.serialization
 
-import sigmastate.Values.{ConcreteCollection, IntArrayConstant, IntValue}
-import sigmastate.{SInt, SubstConstants}
+import sigmastate.Values.{ConcreteCollection, IntArrayConstant, IntConstant, IntValue}
+import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
+import sigmastate.{EQ, SInt, SubstConstants}
 
 class SubstConstantsSerializerSpecification extends SerializationSpecification {
 
   property("SubstConstant deserialization round trip") {
     forAll(numExprTreeNodeGen) { tree =>
-      val bytes = ErgoTreeSerializer.DefaultSerializer.serializeWithSegregation(tree)
+      val bytes = DefaultSerializer.serializeWithSegregation(EQ(tree, IntConstant(1)).toSigmaProp)
       val newVals = ConcreteCollection(Vector[IntValue](1), SInt)
       val expr = SubstConstants(bytes, IntArrayConstant(Array(0)), newVals)
       roundTripTest(expr)

--- a/src/test/scala/sigmastate/utxo/BlockchainSimulationSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BlockchainSimulationSpecification.scala
@@ -1,23 +1,21 @@
 package sigmastate.utxo
 
-import java.io.{FileWriter, File}
+import java.io.{File, FileWriter}
 
 import org.ergoplatform
 import org.ergoplatform.ErgoBox.TokenId
 import org.ergoplatform._
 import org.scalacheck.Gen
-import org.scalatest.prop.{PropertyChecks, GeneratorDrivenPropertyChecks}
-import org.scalatest.{PropSpec, Matchers}
-import scorex.crypto.authds.avltree.batch.{Remove, BatchAVLProver, Insert}
+import scorex.crypto.authds.avltree.batch.{BatchAVLProver, Insert, Remove}
 import scorex.crypto.authds.{ADDigest, ADKey, ADValue}
-import scorex.crypto.hash.{Digest32, Blake2b256}
+import scorex.crypto.hash.{Blake2b256, Digest32}
 import scorex.util._
-import sigmastate.Values.LongConstant
-import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, SigmaTestingCommons, ErgoTransactionValidator}
+import sigmastate.Values.{IntConstant, LongConstant}
+import sigmastate.helpers.{ErgoLikeTestProvingInterpreter, ErgoTransactionValidator, SigmaTestingCommons}
 import sigmastate.interpreter.ContextExtension
 import sigmastate.eval._
 import sigmastate.interpreter.Interpreter.{ScriptNameProp, emptyEnv}
-import sigmastate.{GE, AvlTreeData, AvlTreeFlags}
+import sigmastate.{AvlTreeData, AvlTreeFlags, GE}
 
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
@@ -35,7 +33,7 @@ class BlockchainSimulationSpecification extends SigmaTestingCommons {
 
     val txs = boxesToSpend.map { box =>
       val newBoxCandidate =
-        new ErgoBoxCandidate(10, minerPubKey, height, Colls.emptyColl[(TokenId, Long)], Map(heightReg -> LongConstant(height + windowSize)))
+        new ErgoBoxCandidate(10, minerPubKey, height, Colls.emptyColl[(TokenId, Long)], Map(heightReg -> IntConstant(height + windowSize)))
       val unsignedInput = new UnsignedInput(box.id)
       val tx = UnsignedErgoLikeTransaction(IndexedSeq(unsignedInput), IndexedSeq(newBoxCandidate))
       val context = ErgoLikeContext(height + 1,
@@ -159,7 +157,7 @@ object BlockchainSimulationSpecification {
     def byId(boxId: KeyType): Try[ErgoBox] = Try(boxes(boxId))
 
     def byHeightRegValue(i: Int): Iterable[ErgoBox] =
-      boxes.values.filter(_.get(heightReg).getOrElse(LongConstant(i + 1)) == LongConstant(i))
+      boxes.values.filter(_.get(heightReg).getOrElse(IntConstant(i + 1)) == IntConstant(i))
 
     def byTwoInts(r1Id: ErgoBox.RegisterId, int1: Int,
                   r2Id: ErgoBox.RegisterId, int2: Int): Option[ErgoBox] =
@@ -214,7 +212,7 @@ object BlockchainSimulationSpecification {
     val initBlock = Block(
       (0 until windowSize).map { i =>
         val txId = hash.hash(i.toString.getBytes ++ scala.util.Random.nextString(12).getBytes).toModifierId
-        val boxes = (1 to 50).map(_ => ErgoBox(10, GE(Height, LongConstant(i)).toSigmaProp, 0, Seq(), Map(heightReg -> LongConstant(i)), txId))
+        val boxes = (1 to 50).map(_ => ErgoBox(10, GE(Height, IntConstant(i)).toSigmaProp, 0, Seq(), Map(heightReg -> IntConstant(i)), txId))
         ergoplatform.ErgoLikeTransaction(IndexedSeq(), boxes)
       },
       ErgoLikeContext.dummyPubkey

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -33,14 +33,16 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons {
 
     val ctx = ErgoLikeContext.dummy(fakeSelf)
 
-    val e = compile(Map("h1" -> h1.bytes, "h2" -> h2.bytes), "h1 == h1")
+    val e = compile(Map("h1" -> h1.treeWithSegregation.bytes, "h2" -> h2.treeWithSegregation.bytes), "h1 == h1")
     val exp = TrueLeaf
     e shouldBe exp
 
     val res = verifier.reduceToCrypto(ctx, exp).get._1
     res shouldBe TrueProp
 
-    val res2 = verifier.reduceToCrypto(ctx, EQ(ByteArrayConstant(h1.bytes), ByteArrayConstant(h2.bytes))).get._1
+    val res2 = verifier.reduceToCrypto(ctx,
+      EQ(ByteArrayConstant(h1.treeWithSegregation.bytes),
+        ByteArrayConstant(h2.treeWithSegregation.bytes))).get._1
     res2 shouldBe FalseProp
   }
 

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -15,7 +15,6 @@ import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.basics.ProveDHTuple
 import sigmastate.helpers.{ContextEnrichingTestProvingInterpreter, ErgoLikeTestInterpreter, SigmaTestingCommons}
 import sigmastate.lang.Terms._
-import sigmastate.lang.Terms.SigmaPropValueOps
 import sigmastate.lang.exceptions.InterpreterException
 import sigmastate.serialization.ValueSerializer
 

--- a/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -15,6 +15,7 @@ import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.basics.ProveDHTuple
 import sigmastate.helpers.{ContextEnrichingTestProvingInterpreter, ErgoLikeTestInterpreter, SigmaTestingCommons}
 import sigmastate.lang.Terms._
+import sigmastate.lang.Terms.SigmaPropValueOps
 import sigmastate.lang.exceptions.InterpreterException
 import sigmastate.serialization.ValueSerializer
 

--- a/src/test/scala/sigmastate/utxo/SpamSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SpamSpecification.scala
@@ -145,7 +145,9 @@ class SpamSpecification extends SigmaTestingCommons {
         FuncValue(Vector((1, SBox)),
           AND(
             GE(ExtractAmount(ValUse(1, SBox)), LongConstant(10)),
-            EQ(ExtractScriptBytes(ValUse(1, SBox)), ByteArrayConstant(propToCompare.bytes))
+            EQ(
+              ExtractScriptBytes(ValUse(1, SBox)),
+              ByteArrayConstant(propToCompare.treeWithSegregation.bytes))
           )
         )
       ).toSigmaProp

--- a/src/test/scala/sigmastate/utxo/SpamSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SpamSpecification.scala
@@ -10,7 +10,6 @@ import scorex.utils.Random
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate.lang.Terms._
-import sigmastate.lang.Terms.SigmaPropValueOps
 import sigmastate._
 import sigmastate.eval._
 import sigmastate.interpreter.Interpreter._

--- a/src/test/scala/sigmastate/utxo/SpamSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/SpamSpecification.scala
@@ -10,6 +10,7 @@ import scorex.utils.Random
 import sigmastate.SCollection.SByteArray
 import sigmastate.Values._
 import sigmastate.lang.Terms._
+import sigmastate.lang.Terms.SigmaPropValueOps
 import sigmastate._
 import sigmastate.eval._
 import sigmastate.interpreter.Interpreter._

--- a/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingKernelContract.scala
+++ b/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingKernelContract.scala
@@ -58,7 +58,8 @@ class CrowdFundingKernelContract(
     val c2 = Array(
       ctx.currentHeight < timeout,
       ctx.spendingTransaction.outputs.exists(out => {
-        out.value >= minToRaise && util.Arrays.equals(out.propositionBytes, projectPubKey.toSigmaProp.bytes)
+        out.value >= minToRaise &&
+          util.Arrays.equals(out.propositionBytes, projectPubKey.toSigmaProp.treeWithSegregation.bytes)
       })
     ).forall(identity)
     var proof: projectProver.ProofT = null

--- a/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingKernelContract.scala
+++ b/src/test/scala/sigmastate/utxo/benchmarks/CrowdFundingKernelContract.scala
@@ -8,6 +8,7 @@ import sigmastate.basics.DLogProtocol.{DLogInteractiveProver, DLogProverInput, F
 import sigmastate.basics.VerifierMessage.Challenge
 import scorex.crypto.hash.Blake2b256
 import sigmastate._
+import sigmastate.lang.Terms._
 import sigmastate.helpers.ContextEnrichingTestProvingInterpreter
 import sigmastate.interpreter.{CryptoConstants, Interpreter}
 import sigmastate.utils.Helpers

--- a/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/CoopExampleSpecification.scala
@@ -287,8 +287,8 @@ class CoopExampleSpecification extends SigmaTestingCommons {
       "pubkeyB" -> pubkeyB,
       "pubkeyC" -> pubkeyC,
       "pubkeyD" -> pubkeyD,
-      "spendingContract1Hash" -> ByteArrayConstant(Blake2b256(spendingProp1.bytes)),
-      "spendingContract2Hash" -> ByteArrayConstant(Blake2b256(spendingProp3.bytes))
+      "spendingContract1Hash" -> ByteArrayConstant(Blake2b256(spendingProp1.treeWithSegregation.bytes)),
+      "spendingContract2Hash" -> ByteArrayConstant(Blake2b256(spendingProp3.treeWithSegregation.bytes))
     )
 
     // Basic compilation
@@ -357,7 +357,7 @@ class CoopExampleSpecification extends SigmaTestingCommons {
 
 
     val inputEnv = Map(
-      "thresholdProp" -> ByteArrayConstant(Blake2b256(thresholdProp.bytes)),
+      "thresholdProp" -> ByteArrayConstant(Blake2b256(thresholdProp.treeWithSegregation.bytes)),
       "pubkeyA" -> pubkeyA
     )
 

--- a/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/MixExampleSpecification.scala
@@ -61,7 +61,7 @@ class MixExampleSpecification extends SigmaTestingCommons {
       ScriptNameProp -> "halfMixEnv",
       "g" -> g,
       "gX" -> gX,
-      "fullMixScriptHash" -> Blake2b256(fullMixScript.bytes)
+      "fullMixScriptHash" -> Blake2b256(fullMixScript.treeWithSegregation.bytes)
     )
 
     // Note that below script allows Alice to spend the half-mix output anytime before Bob spends it.

--- a/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/RPSGameExampleSpecification.scala
@@ -80,7 +80,7 @@ class RPSGameExampleSpecification extends SigmaTestingCommons {
     val halfGameEnv = Map(
       ScriptNameProp -> "halfGameScript",
       "alice" -> alicePubKey,
-      "fullGameScriptHash" -> Blake2b256(fullGameScript.bytes)
+      "fullGameScriptHash" -> Blake2b256(fullGameScript.treeWithSegregation.bytes)
     )
 
     // Note that below script allows Alice to spend the half-game output anytime before Bob spends it.

--- a/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/ReversibleTxExampleSpecification.scala
@@ -96,7 +96,7 @@ class ReversibleTxExampleSpecification extends SigmaTestingCommons {
       "blocksIn24h" -> blocksIn24h,
       "maxFee" -> 10L,
       "feePropositionBytes" -> feeProposition.bytes,
-      "withdrawScriptHash" -> Blake2b256(withdrawScript.bytes)
+      "withdrawScriptHash" -> Blake2b256(withdrawScript.treeWithSegregation.bytes)
     )
 
     val depositScript = compile(depositEnv,

--- a/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/examples/XorGameExampleSpecification.scala
@@ -74,7 +74,7 @@ class XorGameExampleSpecification extends SigmaTestingCommons {
     val halfGameEnv = Map(
       ScriptNameProp -> "halfGameScript",
       "alice" -> alicePubKey,
-      "fullGameScriptHash" -> Blake2b256(fullGameScript.bytes)
+      "fullGameScriptHash" -> Blake2b256(fullGameScript.treeWithSegregation.bytes)
     )
 
     // Note that below script allows Alice to spend the half-game output anytime before Bob spends it.


### PR DESCRIPTION
Close #454 

Todo:
- [x] type check in `deserializeErgoTree`;
- [x] narrow `serial*/deserial*` methods to `SigmaPropValue` and add a type check on deserialization; 
- [x] test coverage of `ErgoTreeSerializer`;
- [x] remove any ser/deser except ErgoTree in ErgoTreeSerializer;
- [x] fix ergo (`SigmaProp` only ser/deser, `Value.bytes` removed);
- [x] for type mismatch in `DeserializeContext`, ensure that incorrect scripts will be declined by our verifier if the transaction was formed using different prover;
- [x] test for constant type mismatch case on deserialization (Not applicable. For a constant placeholder we store only an index for a constant and not the constant type. When deserializing constant placeholder we get the type from the constant store, i.e from deserialized segregated constant. It means that constant placeholder type follows the segregated constant type.);
- [x] check types underneath root node of the script? (extracted into #473)

ergo PR https://github.com/ergoplatform/ergo/pull/681