### PR TITLE
Improve costing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val sigma = (project in file("."))
     .settings(commonSettings: _*)
 
 def runErgoTask(task: String, sigmastateVersion: String, log: Logger): Unit = {
-  val ergoBranch = "new-sigma"
+  val ergoBranch = "costing-improvement-issue"
   log.info(s"Testing current build in Ergo (branch $ergoBranch):")
   val cwd = new File("").absolutePath
   val ergoPath = new File(cwd + "/ergo-tests/")

--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val sigma = (project in file("."))
     .settings(commonSettings: _*)
 
 def runErgoTask(task: String, sigmastateVersion: String, log: Logger): Unit = {
-  val ergoBranch = "costing-improvement-issue"
+  val ergoBranch = "v2.1"
   log.info(s"Testing current build in Ergo (branch $ergoBranch):")
   val cwd = new File("").absolutePath
   val ergoPath = new File(cwd + "/ergo-tests/")

--- a/src/main/scala/sigmastate/eval/Sized.scala
+++ b/src/main/scala/sigmastate/eval/Sized.scala
@@ -27,7 +27,7 @@ trait SizedLowPriority {
       else if (xs.tItem.isConstantSize)
         Colls.replicate(xs.length, Sized.sizeOf(xs(0)))
       else
-        xs.map(Sized[T].size)
+        new CViewColl(xs, Sized[T].size)
     new CSizeColl(sizes)
   }
   implicit def optionIsSized[T: Sized]: Sized[Option[T]] = (xs: Option[T]) => new CSizeOption(xs.map(Sized[T].size))


### PR DESCRIPTION
Comparison:
```
New:
2019-04-01 12:14:36 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:14:37 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:14:37 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:14:39 INFO  [pool-1-thread-2] s.c.u.NetworkTimeProvider - New offset adjusted: -29
Tx cost:1333370
Tx size: 38227
Input tokens: 0
Output tokens: 3
tx validation time: 1260
================================
Tx cost:1480305
Tx size: 36189
Input tokens: 9
Output tokens: 18
tx validation time: 706
================================
Tx cost:1572835
Tx size: 38157
Input tokens: 0
Output tokens: 2
tx validation time: 492
================================
Tx cost:1679670
Tx size: 41255
Input tokens: 17
Output tokens: 30
tx validation time: 649
================================
Tx cost:1647685
Tx size: 50349
Input tokens: 88
Output tokens: 165
tx validation time: 372
================================
Tx cost:1633580
Tx size: 39592
Input tokens: 0
Output tokens: 0
tx validation time: 411
================================
Tx cost:1618830
Tx size: 50865
Input tokens: 40
Output tokens: 68
tx validation time: 451
================================
Tx cost:1483875
Tx size: 39826
Input tokens: 125
Output tokens: 254
tx validation time: 330
================================
Tx cost:1639020
Tx size: 46195
Input tokens: 102
Output tokens: 192
tx validation time: 335
================================
Tx cost:1693695
Tx size: 48862
Input tokens: 0
Output tokens: 2
tx validation time: 356
================================
Process finished with exit code 0
Old:
2019-04-01 12:31:28 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:31:29 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:31:29 WARN  [ScalaTest-run] o.e.settings.ErgoSettings$ - NO CONFIGURATION FILE WAS PROVIDED. STARTING WITH DEFAULT SETTINGS FOR TESTNET!
2019-04-01 12:31:31 INFO  [pool-1-thread-2] s.c.u.NetworkTimeProvider - New offset adjusted: -8
Tx cost:1484955
Tx size: 37890
Input tokens: 62
Output tokens: 117
tx validation time: 3855
================================
Tx cost:1587090
Tx size: 40471
Input tokens: 64
Output tokens: 143
tx validation time: 3616
================================
Tx cost:1639895
Tx size: 39747
Input tokens: 0
Output tokens: 0
tx validation time: 3846
================================
Tx cost:1477765
Tx size: 36989
Input tokens: 38
Output tokens: 75
tx validation time: 3038
================================
Tx cost:1552100
Tx size: 42909
Input tokens: 0
Output tokens: 0
tx validation time: 3926
================================
Tx cost:1669665
Tx size: 40503
Input tokens: 0
Output tokens: 2
tx validation time: 3849
================================
Tx cost:1619045
Tx size: 39273
Input tokens: 0
Output tokens: 1
tx validation time: 3579
================================
Tx cost:1442810
Tx size: 35452
Input tokens: 15
Output tokens: 25
tx validation time: 2913
================================
Tx cost:1364740
Tx size: 33122
Input tokens: 0
Output tokens: 5
tx validation time: 3441
================================
Tx cost:1387875
Tx size: 36878
Input tokens: 106
Output tokens: 192
tx validation time: 2763
================================
Process finished with exit code 0
```