### PR TITLE
Switch to opCost with costedValue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "more-opcost-asserts-1e6b0688-SNAPSHOT"
+val specialVersion = "more-opcost-asserts-dc39b717-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "more-opcost-asserts-dc39b717-SNAPSHOT"
+val specialVersion = "more-opcost-asserts-ac960d1d-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "master-f599f15a-SNAPSHOT"
+val specialVersion = "assert-opcost-value-id-393dfa62-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "master-b3370484-SNAPSHOT"
+val specialVersion = "remove-opcost-defaultvalid-dd0b7675-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "more-opcost-asserts-ac960d1d-SNAPSHOT"
+val specialVersion = "master-d1624dc1-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "remove-opcost-defaultvalid-dd0b7675-SNAPSHOT"
+val specialVersion = "master-f599f15a-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "assert-opcost-value-id-4ced1445-SNAPSHOT"
+val specialVersion = "more-opcost-asserts-1e6b0688-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val scorexUtil         = "org.scorexfoundation" %% "scorex-util" % "0.1.3"
 val macroCompat        = "org.typelevel" %% "macro-compat" % "1.1.1"
 val paradise           = "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 
-val specialVersion = "assert-opcost-value-id-393dfa62-SNAPSHOT"
+val specialVersion = "assert-opcost-value-id-4ced1445-SNAPSHOT"
 val specialCommon  = "io.github.scalan" %% "common" % specialVersion
 val specialCore    = "io.github.scalan" %% "core" % specialVersion
 val specialLibrary = "io.github.scalan" %% "library" % specialVersion

--- a/src/main/scala/sigmastate/eval/CostingRules.scala
+++ b/src/main/scala/sigmastate/eval/CostingRules.scala
@@ -230,7 +230,7 @@ trait CostingRules extends SigmaLibrary { IR: RuntimeCosting =>
     def defaultOptionPropertyAccess[R: Elem](prop: Rep[T] => ROption[R], propSize: RSize[T] => RSize[WOption[R]], itemCost: Rep[Int]): RCostedOption[R] = {
       val v = prop(obj.value)
       val s = propSize(obj.size)
-      RCCostedOption(v, SOME(itemCost), asSizeOption(s).sizeOpt, opCost(obj.value, costOfArgs, selectFieldCost))
+      RCCostedOption(v, SOME(itemCost), asSizeOption(s).sizeOpt, opCost(v, costOfArgs, selectFieldCost))
     }
 
     def defaultCollPropertyAccess[R: Elem](prop: Rep[T] => RColl[R], propSize: RSize[T] => RSize[Coll[R]], itemCost: Rep[Int]): RCostedColl[R] = {

--- a/src/main/scala/sigmastate/eval/CostingRules.scala
+++ b/src/main/scala/sigmastate/eval/CostingRules.scala
@@ -387,9 +387,9 @@ trait CostingRules extends SigmaLibrary { IR: RuntimeCosting =>
 
     def creationInfo: RCosted[(Int, Coll[Byte])] = {
       val info = obj.value.creationInfo
-      val cost = opCost(info, Seq(obj.cost), getRegisterCost)
       val l = RCCostedPrim(info._1, 0, SizeInt)
       val r = mkCostedColl(info._2, CryptoConstants.hashLength, 0)
+      val cost = opCost(Pair(l, r), Seq(obj.cost), getRegisterCost)
       RCCostedPair(l, r, cost)
     }
 
@@ -609,10 +609,10 @@ trait CostingRules extends SigmaLibrary { IR: RuntimeCosting =>
       val Pair(lvalues, rvalues) = xsC.value.partition(pred.value)
       val costs = xsC.costs
       val sizes = xsC.sizes
-      val c = opCost(obj.value, costOfArgs, costOf(method))
-      RCCostedPair(
-        RCCostedColl(lvalues, costs, sizes, CostTable.newCollValueCost),
-        RCCostedColl(rvalues, costs, sizes, CostTable.newCollValueCost), c)
+      val l = RCCostedColl(lvalues, costs, sizes, CostTable.newCollValueCost)
+      val r = RCCostedColl(rvalues, costs, sizes, CostTable.newCollValueCost)
+      val c = opCost(Pair(l, r), costOfArgs, costOf(method))
+      RCCostedPair(l, r, c)
     }
 
     def patch(from: RCosted[Int], patch: RCosted[Coll[T]], replaced: RCosted[Int]): RCosted[Coll[T]] = {

--- a/src/main/scala/sigmastate/eval/CostingRules.scala
+++ b/src/main/scala/sigmastate/eval/CostingRules.scala
@@ -210,8 +210,10 @@ trait CostingRules extends SigmaLibrary { IR: RuntimeCosting =>
       RCCostedPrim(value, opCost(value, costOfArgs, selectFieldCost), size)
     }
 
-    def knownLengthCollPropertyAccess[R](prop: Rep[T] => Rep[Coll[R]], len: Rep[Int]): Rep[CostedColl[R]] =
-      mkCostedColl(prop(obj.value), len, opCost(obj.value, costOfArgs, selectFieldCost))
+    def knownLengthCollPropertyAccess[R](prop: Rep[T] => Rep[Coll[R]], len: Rep[Int]): Rep[CostedColl[R]] = {
+      val value = prop(obj.value)
+      mkCostedColl(value, len, opCost(value, costOfArgs, selectFieldCost))
+    }
 
     def digest32PropertyAccess(prop: Rep[T] => Rep[Coll[Byte]]): Rep[CostedColl[Byte]] =
       knownLengthCollPropertyAccess(prop, CryptoConstants.hashLength)
@@ -402,7 +404,7 @@ trait CostingRules extends SigmaLibrary { IR: RuntimeCosting =>
       val sInfo = mkSizeColl(len, sToken)
       val costs = colBuilder.replicate(len, 0)
       val sizes = colBuilder.replicate(len, sToken)
-      RCCostedColl(tokens, costs, sizes, opCost(obj.value, Seq(obj.cost), costOf(method)))
+      RCCostedColl(tokens, costs, sizes, opCost(tokens, Seq(obj.cost), costOf(method)))
     }
 
     def getReg[T](i: RCosted[Int])(implicit tT: Rep[WRType[T]]): RCosted[WOption[T]] = {

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1341,7 +1341,7 @@ trait RuntimeCosting extends CostingRules with DataCosting with Slicing { IR: Ev
         }
 
       case Values.Tuple(InSeq(Seq(x, y))) =>
-        RCCostedPair(x, y, opCost(Pair(x.value, y.value), Seq(x.cost, y.cost), CostTable.newPairValueCost))
+        RCCostedPair(x, y, opCost(Pair(x, y), Seq(x.cost, y.cost), CostTable.newPairValueCost))
 
       case Values.Tuple(InSeq(items)) =>
         val fields = items.zipWithIndex.map { case (x, i) => (s"_${i+1}", x)}

--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -733,7 +733,10 @@ trait RuntimeCosting extends CostingRules with DataCosting with Slicing { IR: Ev
   def costedPrimToPair[A,B](p: Rep[(A,B)], c: Rep[Int], s: RSize[(A,B)]) = s.elem.asInstanceOf[Any] match {
     case se: SizeElem[_,_] if se.eVal.isInstanceOf[PairElem[_,_]] =>
       val sPair = asSizePair(s)
-      RCCostedPair(RCCostedPrim(p._1, 0, sPair.l), RCCostedPrim(p._2, 0, sPair.r), c)
+      val l = RCCostedPrim(p._1, 0, sPair.l)
+      val r = RCCostedPrim(p._2, 0, sPair.r)
+      val newCost = opCost(Pair(l, r), Seq(c), 0)
+      RCCostedPair(l, r, newCost)
     case _ =>
       !!!(s"Expected RCSizePair node but was $s -> ${s.rhs}")
   }
@@ -1141,7 +1144,7 @@ trait RuntimeCosting extends CostingRules with DataCosting with Slicing { IR: Ev
         RCCostedColl(v, xsC.costs, xsC.sizes, newCost(v, c))
       case e: PairElem[a,b] =>
         val pC = asCostedPair[a,b](asCosted[(a,b)](source))
-        RCCostedPair(pC.l, pC.r, newCost(pC, pC.cost))
+        RCCostedPair(pC.l, pC.r, newCost(Pair(pC.l, pC.r), pC.cost))
       case e =>
         val c = source.cost  // this is a current cost of the value
         val v = source.value


### PR DESCRIPTION

- [x] remove `opCost` without costedValue completely (https://github.com/scalan/special/pull/20);