### PR TITLE
Limit Box.getReg to constant expressions only

### DIFF
--- a/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1897,10 +1897,11 @@ trait RuntimeCosting extends CostingRules with DataCosting with Slicing { IR: Ev
 //        }
 
       // fallback rule for MethodCall, should be the last case in the list
-      case Terms.MethodCall(obj, method, args, _) if method.objType.coster.isDefined =>
+      case Terms.MethodCall(obj, method, args, typeSubst) if method.objType.coster.isDefined =>
         val objC = eval(obj)
         val argsC = args.map(eval)
-        method.objType.coster.get(IR)(objC, method, argsC)
+        val elems = typeSubst.values.toSeq.map(tpe => liftElem(stypeToElem(tpe).asElem[Any]))
+        method.objType.coster.get(IR)(objC, method, argsC, elems)
 
       case _ =>
         error(s"Don't know how to evalNode($node)", node.sourceContext.toOption)

--- a/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -281,8 +281,7 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         if (regId.isConst)
           mkExtractRegisterAs(box.asBox, ErgoBox.allRegisters(regId.asValue), tpe)
         else
-          builder.mkMethodCall(box, SBox.getRegMethod, IndexedSeq(recurse(regId)),
-            Map(SBox.tT -> tpe.elemType))
+          error(s"Non constant expressions (${regId.rhs}) are not supported in getReg")
       case BoxM.creationInfo(In(box)) =>
         mkExtractCreationInfo(box.asBox)
       case BoxM.id(In(box)) =>
@@ -372,7 +371,7 @@ trait TreeBuilding extends RuntimeCosting { IR: Evaluation =>
         mkIf(cond, thenP, elseP)
 
       case Def(Tup(In(x), In(y))) =>
-        mkTuple(Seq(x, y))  
+        mkTuple(Seq(x, y))
       case Def(First(pair)) =>
         mkSelectField(recurse(pair), 1)
       case Def(Second(pair)) =>

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1132,7 +1132,7 @@ case object SBox extends SProduct with SPredefType with SMonoType {
   // should be lazy, otherwise lead to initialization error
   lazy val creationInfoMethod = SMethod(this, CreationInfo, ExtractCreationInfo.OpType, 6) // see ExtractCreationInfo
   lazy val getRegMethod = SMethod(this, "getReg",
-    SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7, MethodCallIrBuilder)
+    SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7)
   lazy val tokensMethod = SMethod(this, "tokens", SFunc(SBox, ErgoBox.STokensRegType), 8, MethodCallIrBuilder)
   // should be lazy to solve recursive initialization
   protected override def getMethods() = super.getMethods() ++ Vector(

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1131,7 +1131,8 @@ case object SBox extends SProduct with SPredefType with SMonoType {
   val GetReg = "getReg"
   // should be lazy, otherwise lead to initialization error
   lazy val creationInfoMethod = SMethod(this, CreationInfo, ExtractCreationInfo.OpType, 6) // see ExtractCreationInfo
-  lazy val getRegMethod = SMethod(this, "getReg", SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7)
+  lazy val getRegMethod = SMethod(this, "getReg",
+    SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7, MethodCallIrBuilder)
   lazy val tokensMethod = SMethod(this, "tokens", SFunc(SBox, ErgoBox.STokensRegType), 8, MethodCallIrBuilder)
   // should be lazy to solve recursive initialization
   protected override def getMethods() = super.getMethods() ++ Vector(

--- a/src/main/scala/sigmastate/types.scala
+++ b/src/main/scala/sigmastate/types.scala
@@ -1131,8 +1131,7 @@ case object SBox extends SProduct with SPredefType with SMonoType {
   val GetReg = "getReg"
   // should be lazy, otherwise lead to initialization error
   lazy val creationInfoMethod = SMethod(this, CreationInfo, ExtractCreationInfo.OpType, 6) // see ExtractCreationInfo
-  lazy val getRegMethod = SMethod(this, "getReg",
-    SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7)
+  lazy val getRegMethod = SMethod(this, "getReg", SFunc(IndexedSeq(SBox, SInt), SOption(tT), Seq(STypeParam(tT))), 7)
   lazy val tokensMethod = SMethod(this, "tokens", SFunc(SBox, ErgoBox.STokensRegType), 8, MethodCallIrBuilder)
   // should be lazy to solve recursive initialization
   protected override def getMethods() = super.getMethods() ++ Vector(

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -359,9 +359,9 @@ class BasicOpsSpecification extends SigmaTestingCommons {
   }
 
   // TODO related to https://github.com/ScorexFoundation/sigmastate-interpreter/issues/416
-  ignore("Box.getReg") {
+  property("Box.getReg") {
     test("Extract1", env, ext,
-      "{ SELF.getReg[Int]( (getVar[Int](intVar1).get + 4).toByte ).get == 1}",
+      "{ SELF.getReg[Int]( (getVar[Int](intVar1).get + 4)).get == 1}",
       BoolToSigmaProp(
         EQ(
           MethodCall(Self, SBox.getRegMethod,

--- a/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -359,7 +359,7 @@ class BasicOpsSpecification extends SigmaTestingCommons {
   }
 
   // TODO related to https://github.com/ScorexFoundation/sigmastate-interpreter/issues/416
-  property("Box.getReg") {
+  ignore("Box.getReg") {
     test("Extract1", env, ext,
       "{ SELF.getReg[Int]( (getVar[Int](intVar1).get + 4)).get == 1}",
       BoolToSigmaProp(


### PR DESCRIPTION
#416 

Since we don't serialize type substitutions in `MethodCallSerializer` we cannot support `getReg` with arbitrary expressions (with non-constant expressions it becomes `MethodCall`). Disabling `getReg` translation to `MethodCall` for now.