### PR TITLE
Check script tree depth limit during deserialization

### DIFF
--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -35,7 +35,6 @@ import sigmastate.serialization.transformers.ProveDHTupleSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import special.sigma.{AnyValue, AvlTree, Header, PreHeader}
 import sigmastate.lang.SourceContext
-import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
 import special.collection.Coll
 
 
@@ -628,8 +627,6 @@ object Values {
 
       override def parse(r: SigmaByteReader): SigmaBoolean = {
         val depth = r.level
-        if (depth > SigmaSerializer.MaxTreeDepth)
-          throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
         r.level = depth + 1
         val opCode = r.getByte()
         val res = opCode match {

--- a/src/main/scala/sigmastate/Values.scala
+++ b/src/main/scala/sigmastate/Values.scala
@@ -1,21 +1,21 @@
 package sigmastate
 
 import java.math.BigInteger
-import java.util.{Objects, Arrays}
+import java.util.{Arrays, Objects}
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
-import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{strategy, everywherebu}
+import org.bitbucket.inkytonik.kiama.rewriting.Rewriter.{everywherebu, strategy}
 import org.ergoplatform.ErgoLikeContext
 import scalan.{Nullable, RType}
 import scorex.crypto.authds.{ADDigest, SerializedAdProof}
 import scorex.crypto.authds.avltree.batch.BatchAVLVerifier
-import scorex.crypto.hash.{Digest32, Blake2b256}
+import scorex.crypto.hash.{Blake2b256, Digest32}
 import scalan.util.CollectionUtil._
 import sigmastate.SCollection.SByteArray
 import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate.interpreter.CryptoConstants
 import sigmastate.serialization._
-import sigmastate.serialization.{OpCodes, ConstantStore}
+import sigmastate.serialization.{ConstantStore, OpCodes}
 import sigmastate.serialization.OpCodes._
 import sigmastate.TrivialProp.{FalseProp, TrueProp}
 import sigmastate.basics.DLogProtocol.ProveDlog
@@ -33,8 +33,9 @@ import sigmastate.lang.DefaultSigmaBuilder._
 import sigmastate.serialization.ErgoTreeSerializer.DefaultSerializer
 import sigmastate.serialization.transformers.ProveDHTupleSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
-import special.sigma.{Header, AnyValue, AvlTree, PreHeader}
+import special.sigma.{AnyValue, AvlTree, Header, PreHeader}
 import sigmastate.lang.SourceContext
+import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
 import special.collection.Coll
 
 
@@ -626,6 +627,10 @@ object Values {
       }
 
       override def parse(r: SigmaByteReader): SigmaBoolean = {
+        val depth = r.level
+        if (depth > SigmaSerializer.MaxTreeDepth)
+          throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
+        r.level = depth + 1
         val opCode = r.getByte()
         val res = opCode match {
           case FalseProp.opCode => FalseProp
@@ -646,6 +651,7 @@ object Values {
             val children = (0 until n).map(_ => serializer.parse(r))
             CTHRESHOLD(k, children)
         }
+        r.level = r.level - 1
         res
       }
     }

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -8,9 +8,6 @@ final class InvalidTypePrefix(message: String, source: Option[SourceContext] = N
 final class InputSizeLimitExceeded(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
 
-final class TypeDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
-  extends SerializerException(message, source)
-
 final class DeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
 

--- a/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
+++ b/src/main/scala/sigmastate/lang/exceptions/SigmaSerializerExceptions.scala
@@ -11,7 +11,7 @@ final class InputSizeLimitExceeded(message: String, source: Option[SourceContext
 final class TypeDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
 
-final class ValueDeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
+final class DeserializeCallDepthExceeded(message: String, source: Option[SourceContext] = None)
   extends SerializerException(message, source)
 
 final class InvalidOpCode(message: String, source: Option[SourceContext] = None)

--- a/src/main/scala/sigmastate/serialization/DataSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/DataSerializer.scala
@@ -9,7 +9,6 @@ import sigmastate.Values.SigmaBoolean
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate._
 import sigmastate.eval.{Evaluation, _}
-import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
 import special.collection._
 import special.sigma._
 
@@ -78,8 +77,6 @@ object DataSerializer {
     * to the type descriptor `tpe`. */
   def deserialize[T <: SType](tpe: T, r: SigmaByteReader): (T#WrappedType) = {
     val depth = r.level
-    if (depth > SigmaSerializer.MaxTreeDepth)
-      throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
     r.level = depth + 1
     val res = (tpe match {
       case SUnit => ()

--- a/src/main/scala/sigmastate/serialization/DataSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/DataSerializer.scala
@@ -9,6 +9,7 @@ import sigmastate.Values.SigmaBoolean
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 import sigmastate._
 import sigmastate.eval.{Evaluation, _}
+import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
 import special.collection._
 import special.sigma._
 
@@ -75,43 +76,51 @@ object DataSerializer {
 
   /** Reads a data value from Reader. The data value bytes is expected to confirm
     * to the type descriptor `tpe`. */
-  def deserialize[T <: SType](tpe: T, r: SigmaByteReader): (T#WrappedType) = (tpe match {
-    case SUnit => ()
-    case SBoolean => r.getUByte() != 0
-    case SByte => r.getByte()
-    case SShort => r.getShort()
-    case SInt => r.getInt()
-    case SLong => r.getLong()
-    case SString =>
-      val size = r.getUInt().toInt
-      val bytes = r.getBytes(size)
-      new String(bytes, StandardCharsets.UTF_8)
-    case SBigInt =>
-      val size: Short = r.getUShort().toShort
-      val valueBytes = r.getBytes(size)
-      SigmaDsl.BigInt(new BigInteger(valueBytes))
-    case SGroupElement =>
-      SigmaDsl.GroupElement(GroupElementSerializer.parse(r))
-    case SSigmaProp =>
-      SigmaDsl.SigmaProp(SigmaBoolean.serializer.parse(r))
-    case SBox =>
-      SigmaDsl.Box(ErgoBox.sigmaSerializer.parse(r))
-    case SAvlTree =>
-      SigmaDsl.avlTree(AvlTreeData.serializer.parse(r))
-    case tColl: SCollectionType[a] =>
-      val len = r.getUShort()
-      if (tColl.elemType == SByte)
-        Colls.fromArray(r.getBytes(len))
-      else
-        deserializeColl(len, tColl.elemType, r)
-    case tuple: STuple =>
-      val arr = tuple.items.map { t =>
-        deserialize(t, r)
-      }.toArray[Any]
-      val coll = Colls.fromArray(arr)(RType.AnyType)
-      Evaluation.toDslTuple(coll, tuple)
-    case _ => sys.error(s"Don't know how to deserialize $tpe")
-  }).asInstanceOf[T#WrappedType]
+  def deserialize[T <: SType](tpe: T, r: SigmaByteReader): (T#WrappedType) = {
+    val depth = r.level
+    if (depth > SigmaSerializer.MaxTreeDepth)
+      throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
+    r.level = depth + 1
+    val res = (tpe match {
+      case SUnit => ()
+      case SBoolean => r.getUByte() != 0
+      case SByte => r.getByte()
+      case SShort => r.getShort()
+      case SInt => r.getInt()
+      case SLong => r.getLong()
+      case SString =>
+        val size = r.getUInt().toInt
+        val bytes = r.getBytes(size)
+        new String(bytes, StandardCharsets.UTF_8)
+      case SBigInt =>
+        val size: Short = r.getUShort().toShort
+        val valueBytes = r.getBytes(size)
+        SigmaDsl.BigInt(new BigInteger(valueBytes))
+      case SGroupElement =>
+        SigmaDsl.GroupElement(GroupElementSerializer.parse(r))
+      case SSigmaProp =>
+        SigmaDsl.SigmaProp(SigmaBoolean.serializer.parse(r))
+      case SBox =>
+        SigmaDsl.Box(ErgoBox.sigmaSerializer.parse(r))
+      case SAvlTree =>
+        SigmaDsl.avlTree(AvlTreeData.serializer.parse(r))
+      case tColl: SCollectionType[a] =>
+        val len = r.getUShort()
+        if (tColl.elemType == SByte)
+          Colls.fromArray(r.getBytes(len))
+        else
+          deserializeColl(len, tColl.elemType, r)
+      case tuple: STuple =>
+        val arr = tuple.items.map { t =>
+          deserialize(t, r)
+        }.toArray[Any]
+        val coll = Colls.fromArray(arr)(RType.AnyType)
+        Evaluation.toDslTuple(coll, tuple)
+      case _ => sys.error(s"Don't know how to deserialize $tpe")
+    }).asInstanceOf[T#WrappedType]
+    r.level = r.level - 1
+    res
+  }
 
   def deserializeColl[T <: SType](len: Int, tpeElem: T, r: SigmaByteReader): Coll[T#WrappedType] =
     tpeElem match {

--- a/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/SigmaSerializer.scala
@@ -22,8 +22,10 @@ object SigmaSerializer {
   def startReader(bytes: Array[Byte], pos: Int = 0): SigmaByteReader = {
     val buf = ByteBuffer.wrap(bytes)
     buf.position(pos)
-    val r = new SigmaByteReader(new VLQByteBufferReader(buf), new ConstantStore(), resolvePlaceholdersToConstants = false)
-        .mark()
+    val r = new SigmaByteReader(new VLQByteBufferReader(buf),
+      new ConstantStore(),
+      resolvePlaceholdersToConstants = false,
+      maxTreeDepth = MaxTreeDepth).mark()
     r
   }
 
@@ -31,8 +33,10 @@ object SigmaSerializer {
                   constantStore: ConstantStore,
                   resolvePlaceholdersToConstants: Boolean): SigmaByteReader = {
     val buf = ByteBuffer.wrap(bytes)
-    val r = new SigmaByteReader(new VLQByteBufferReader(buf), constantStore, resolvePlaceholdersToConstants)
-      .mark()
+    val r = new SigmaByteReader(new VLQByteBufferReader(buf),
+      constantStore,
+      resolvePlaceholdersToConstants,
+      maxTreeDepth = MaxTreeDepth).mark()
     r
   }
 
@@ -63,7 +67,11 @@ trait SigmaSerializer[TFamily, T <: TFamily] extends Serializer[TFamily, T, Sigm
   }
 
   def parseWithGenericReader(r: Reader): TFamily = {
-    parse(new SigmaByteReader(r,  new ConstantStore(), resolvePlaceholdersToConstants = false))
+    parse(
+      new SigmaByteReader(r,
+        new ConstantStore(),
+        resolvePlaceholdersToConstants = false,
+        maxTreeDepth = SigmaSerializer.MaxTreeDepth))
   }
 
   def error(msg: String) = throw new SerializerException(msg, None)

--- a/src/main/scala/sigmastate/serialization/TypeSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/TypeSerializer.scala
@@ -3,7 +3,7 @@ package sigmastate.serialization
 import java.nio.charset.StandardCharsets
 
 import sigmastate._
-import sigmastate.lang.exceptions.{InvalidTypePrefix, TypeDeserializeCallDepthExceeded}
+import sigmastate.lang.exceptions.InvalidTypePrefix
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
 
 /** Serialization of types according to specification in TypeSerialization.md. */
@@ -115,8 +115,6 @@ object TypeSerializer extends ByteBufferSerializer[SType] {
   override def deserialize(r: SigmaByteReader): SType = deserialize(r, 0)
 
   private def deserialize(r: SigmaByteReader, depth: Int): SType = {
-    if (depth > SigmaSerializer.MaxTreeDepth)
-      throw new TypeDeserializeCallDepthExceeded(s"deserialize call depth exceeds ${SigmaSerializer.MaxTreeDepth}")
     val c = r.getUByte()
     if (c <= 0)
       throw new InvalidTypePrefix(s"Cannot deserialize type prefix $c. Unexpected buffer $r with bytes ${r.getBytes(r.remaining)}")

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -6,7 +6,7 @@ import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.DeserializationSigmaBuilder
 import sigmastate.lang.Terms.OperationId
-import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, DeserializeCallDepthExceeded}
+import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode}
 import sigmastate.serialization.OpCodes._
 import sigmastate.serialization.transformers._
 import sigmastate.serialization.trees.{QuadrupleSerializer, Relation2Serializer}
@@ -178,8 +178,6 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     if (bytesRemaining > SigmaSerializer.MaxInputSize)
       throw new InputSizeLimitExceeded(s"input size $bytesRemaining exceeds ${ SigmaSerializer.MaxInputSize}")
     val depth = r.level
-    if (depth > SigmaSerializer.MaxTreeDepth)
-      throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
     r.level = depth + 1
     val firstByte = r.peekByte().toUByte
     val v = if (firstByte <= LastConstantCode) {

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -6,7 +6,7 @@ import sigmastate.Values._
 import sigmastate._
 import sigmastate.lang.DeserializationSigmaBuilder
 import sigmastate.lang.Terms.OperationId
-import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, ValueDeserializeCallDepthExceeded}
+import sigmastate.lang.exceptions.{InputSizeLimitExceeded, InvalidOpCode, DeserializeCallDepthExceeded}
 import sigmastate.serialization.OpCodes._
 import sigmastate.serialization.transformers._
 import sigmastate.serialization.trees.{QuadrupleSerializer, Relation2Serializer}
@@ -179,7 +179,7 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
       throw new InputSizeLimitExceeded(s"input size $bytesRemaining exceeds ${ SigmaSerializer.MaxInputSize}")
     val depth = r.level
     if (depth > SigmaSerializer.MaxTreeDepth)
-      throw new ValueDeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
+      throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($depth) exceeds allowed maximum ${SigmaSerializer.MaxTreeDepth}")
     r.level = depth + 1
     val firstByte = r.peekByte().toUByte
     val v = if (firstByte <= LastConstantCode) {

--- a/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -190,7 +190,7 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
       val opCode = r.getByte()
       getSerializer(opCode).parse(r)
     }
-    r.level = depth - 1
+    r.level = r.level - 1
     v
   }
 

--- a/src/main/scala/sigmastate/utils/SigmaByteReader.scala
+++ b/src/main/scala/sigmastate/utils/SigmaByteReader.scala
@@ -1,16 +1,16 @@
 package sigmastate.utils
 
-import java.nio.ByteBuffer
-
-import scorex.util.serialization.{Reader, VLQByteBufferReader}
+import scorex.util.Extensions._
+import scorex.util.serialization.Reader
 import sigmastate.SType
 import sigmastate.Values.SValue
+import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
 import sigmastate.serialization.{ConstantStore, TypeSerializer, ValDefTypeStore, ValueSerializer}
-import scorex.util.Extensions._
 
 class SigmaByteReader(val r: Reader,
                       var constantStore: ConstantStore,
-                      var resolvePlaceholdersToConstants: Boolean)
+                      var resolvePlaceholdersToConstants: Boolean,
+                      val maxTreeDepth: Int)
   extends Reader {
 
   val valDefTypeStore: ValDefTypeStore = new ValDefTypeStore()
@@ -67,7 +67,12 @@ class SigmaByteReader(val r: Reader,
 
   private var lvl: Int = 0
   @inline def level: Int = lvl
-  @inline def level_=(v: Int): Unit = lvl = v
+  @inline def level_=(v: Int): Unit = {
+    if (v > maxTreeDepth)
+      throw new DeserializeCallDepthExceeded(s"nested value deserialization call depth($v) exceeds allowed maximum $maxTreeDepth")
+    lvl = v
+  }
+
   @inline def getValues(): IndexedSeq[SValue] = {
     val size = getUInt().toIntExact
     val xs = new Array[SValue](size)

--- a/src/main/scala/sigmastate/utils/SigmaByteReader.scala
+++ b/src/main/scala/sigmastate/utils/SigmaByteReader.scala
@@ -5,12 +5,12 @@ import scorex.util.serialization.Reader
 import sigmastate.SType
 import sigmastate.Values.SValue
 import sigmastate.lang.exceptions.DeserializeCallDepthExceeded
-import sigmastate.serialization.{ConstantStore, TypeSerializer, ValDefTypeStore, ValueSerializer}
+import sigmastate.serialization.{ConstantStore, SigmaSerializer, TypeSerializer, ValDefTypeStore, ValueSerializer}
 
 class SigmaByteReader(val r: Reader,
                       var constantStore: ConstantStore,
                       var resolvePlaceholdersToConstants: Boolean,
-                      val maxTreeDepth: Int)
+                      val maxTreeDepth: Int = SigmaSerializer.MaxTreeDepth)
   extends Reader {
 
   val valDefTypeStore: ValDefTypeStore = new ValDefTypeStore()

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -74,10 +74,10 @@ class DeserializationResilience extends SerializationSpecification {
       val levels: mutable.ArrayBuilder[Int] = mutable.ArrayBuilder.make[Int]()
       override def level_=(v: Int): Unit = {
         if (v >= super.level) {
-          // going deeper (save new depth to account added depth by the caller)
+          // going deeper (depth is increasing), save new depth to account added depth level by the caller
           levels += v
         } else {
-          // going up (save previous depth to account added depth be the caller)
+          // going up (depth is decreasing), save previous depth to account added depth level for the caller
           levels += super.level
         }
         super.level_=(v)

--- a/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -101,7 +101,8 @@ class DeserializationResilience extends SerializationSpecification {
           val stackTrace = e.getStackTrace
           val depth = stackTrace.count { se =>
             (se.getClassName.contains("ValueSerializer") && se.getMethodName == "deserialize") ||
-              (se.getClassName.contains("DataSerializer") && se.getMethodName == "deserialize")
+              (se.getClassName.contains("DataSerializer") && se.getMethodName == "deserialize") ||
+              (se.getClassName.contains("SigmaBoolean") && se.getMethodName == "parse")
           }
           callDepthsBuilder += depth
       }
@@ -117,6 +118,10 @@ class DeserializationResilience extends SerializationSpecification {
     forAll(numExprTreeNodeGen) { numExpr =>
       val expr = EQ(numExpr, IntConstant(1))
       val (callDepths, levels) = traceReaderCallDepth(expr)
+      callDepths shouldEqual levels
+    }
+    forAll(sigmaBooleanGen) { sigmaBool =>
+      val (callDepths, levels) = traceReaderCallDepth(sigmaBool)
       callDepths shouldEqual levels
     }
   }

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -3,8 +3,6 @@ package sigmastate.serialization
 import org.scalacheck.Arbitrary._
 import org.scalatest.Assertion
 import sigmastate._
-import sigmastate.lang.exceptions.TypeDeserializeCallDepthExceeded
-import scorex.util.Extensions._
 
 class TypeSerializerSpecification extends SerializationSpecification {
 

--- a/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
+++ b/src/test/scala/sigmastate/serialization/TypeSerializerSpecification.scala
@@ -93,12 +93,6 @@ class TypeSerializerSpecification extends SerializationSpecification {
       Array[Byte](TupleTypeCode, 5, SLong.typeCode, SLong.typeCode, SByte.typeCode, SBoolean.typeCode, SInt.typeCode))
   }
 
-  property("tuple of tuples crazy deep") {
-    val bytes = List.tabulate(SigmaSerializer.MaxTreeDepth + 1)(_ => Array[Byte](TupleTypeCode, 2))
-      .toArray.flatten
-    an[TypeDeserializeCallDepthExceeded] should be thrownBy SigmaSerializer.startReader(bytes, 0).getType()
-  }
-
   property("STypeIdent serialization roundtrip") {
     forAll(sTypeIdentGen) { ti =>
       roundtrip(ti)

--- a/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
+++ b/src/test/scala/sigmastate/serialization/generators/ValueGenerators.scala
@@ -109,7 +109,16 @@ trait ValueGenerators extends TypeGenerators {
     vv <- groupElementGen
   } yield ProveDHTuple(gv, hv, uv, vv)
 
-  val sigmaBooleanGen: Gen[SigmaBoolean] = Gen.oneOf(proveDlogGen, proveDHTGen)
+  def sigmaTreeNodeGen: Gen[SigmaBoolean] = for {
+    left <- sigmaBooleanGen
+    right <- sigmaBooleanGen
+    node <- Gen.oneOf(
+      COR(Seq(left, right)),
+      CAND(Seq(left, right))
+    )
+  } yield node
+
+  val sigmaBooleanGen: Gen[SigmaBoolean] = Gen.oneOf(proveDlogGen, proveDHTGen, Gen.delay(sigmaTreeNodeGen))
   val sigmaPropGen: Gen[SigmaProp] = sigmaBooleanGen.map(SigmaDsl.SigmaProp)
   val sigmaPropValueGen: Gen[SigmaPropValue] =
     Gen.oneOf(proveDlogGen.map(SigmaPropConstant(_)), proveDHTGen.map(SigmaPropConstant(_)))


### PR DESCRIPTION
Close #270 

- [x] check that `SigmaByteReader.level` corresponds to the actual recursive call depth of the serializer(s);
- [x] count depth in `DataSerializer`, 
- [x] count depth in `SigmaBoolean.serializer`;