### PR TITLE
Test for insert operation in AvlTreeSpecification

### DIFF
--- a/sigmastate/src/test/scala/sigmastate/serialization/AvlTreeSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/serialization/AvlTreeSpecification.scala
@@ -1,7 +1,13 @@
 package sigmastate.serialization
 
+import scorex.crypto.authds.{ADKey, ADValue}
+import scorex.crypto.authds.avltree.batch.{BatchAVLProver, Insert}
+import scorex.crypto.hash.{Blake2b256, Digest32}
 import sigmastate.Values.AvlTreeConstant
 import sigmastate.AvlTreeFlags
+import sigmastate._
+import sigmastate.eval.Extensions._
+import sigmastate.eval._
 
 class AvlTreeSpecification extends SerializationSpecification {
 
@@ -28,4 +34,30 @@ class AvlTreeSpecification extends SerializationSpecification {
       roundTripTest(v)
     }
   }
+
+  property("insert") {
+    val avlProver = new BatchAVLProver[Digest32, Blake2b256.type](keyLength = 32, None)
+
+    val digest = avlProver.digest
+    val flags = AvlTreeFlags(true, false, false)
+    val treeData = new AvlTreeData(digest, flags, 32, None)
+    val tree = SigmaDsl.avlTree(treeData)
+
+    val k = Blake2b256.hash("1")
+    val v = k
+    avlProver.performOneOperation(Insert(ADKey @@ k, ADValue @@ v))
+    val proof = avlProver.generateProof()
+
+    val resTree = tree.insert(Array(k.toColl -> v.toColl).toColl, proof.toColl).get
+    val resTreeAgain = tree.insert(Array(k.toColl -> v.toColl).toColl, proof.toColl).get
+
+    // It is possible to insert wrong key. However, verifier is getting different digest then,
+    // and this is to be checked independently.
+    val wrongKey = Blake2b256.hash("2")
+    val resTreeWrong = tree.insert(Array(wrongKey.toColl -> v.toColl).toColl, proof.toColl).get
+
+    resTree shouldBe resTreeAgain
+    resTree should not be resTreeWrong
+  }
+
 }


### PR DESCRIPTION
This PR is introducing a new test for insert operation in AvlTreeSpecification only.