### PR TITLE
Avoid ClassCastException in kiama rewritings

### DIFF
--- a/sigmastate/src/main/scala/sigmastate/Values.scala
+++ b/sigmastate/src/main/scala/sigmastate/Values.scala
@@ -1018,7 +1018,7 @@ object Values {
 
     def substConstants(root: SValue, constants: IndexedSeq[Constant[SType]]): SValue = {
       val store = new ConstantStore(constants)
-      val substRule = strategy[Value[_ <: SType]] {
+      val substRule = strategy[Any] {
         case ph: ConstantPlaceholder[_] =>
           Some(store.get(ph.id))
         case _ => None

--- a/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -107,7 +107,7 @@ trait Interpreter extends ScorexLogging {
     * We can estimate cost of the tree evaluation only after this step.*/
   def applyDeserializeContext(context: CTX, exp: Value[SType]): (BoolValue, CTX) = {
     val currContext = new MutableCell(context)
-    val substRule = strategy[Value[_ <: SType]] { case x =>
+    val substRule = strategy[Any] { case x: SValue =>
       substDeserialize(currContext.value, { ctx: CTX => currContext.value = ctx }, x)
     }
     val Some(substTree: SValue) = everywherebu(substRule)(exp)
@@ -284,7 +284,7 @@ trait Interpreter extends ScorexLogging {
     * per the verifier algorithm of the leaf's Sigma-protocol.
     * If the verifier algorithm of the Sigma-protocol for any of the leaves rejects, then reject the entire proof.
     */
-  val computeCommitments: Strategy = everywherebu(rule[UncheckedSigmaTree] {
+  val computeCommitments: Strategy = everywherebu(rule[Any] {
     case c: UncheckedConjecture => c // Do nothing for internal nodes
 
     case sn: UncheckedSchnorr =>
@@ -295,7 +295,7 @@ trait Interpreter extends ScorexLogging {
       val (a, b) = DiffieHellmanTupleInteractiveProver.computeCommitment(dh.proposition, dh.challenge, dh.secondMessage)
       dh.copy(commitmentOpt = Some(FirstDiffieHellmanTupleProverMessage(a, b)))
 
-    case _ => ???
+    case _: UncheckedSigmaTree => ???
   })
 
   def verify(ergoTree: ErgoTree,

--- a/sigmastate/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/ProverInterpreter.scala
@@ -127,7 +127,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
     * In a bottom-up traversal of the tree, do the following for each node:
     *
     */
-  def markReal(hintsBag: HintsBag): Strategy = everywherebu(rule[UnprovenTree] {
+  def markReal(hintsBag: HintsBag): Strategy = everywherebu(rule[Any] {
     case and: CAndUnproven =>
       // If the node is AND, mark it "real" if all of its children are marked real; else mark it "simulated"
       val simulated = and.children.exists(_.asInstanceOf[UnprovenTree].simulated)
@@ -151,7 +151,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
         case in: SigmaProtocolPrivateInput[_, _] => in.publicImage == ul.proposition
       }
       ul.withSimulated(!isReal)
-    case t =>
+    case t: UnprovenTree =>
       error(s"Don't know how to markReal($t)")
   })
 
@@ -160,7 +160,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
     * the right number of simulated children.
     * In a top-down traversal of the tree, do the following for each node:
     */
-  val polishSimulated: Strategy = everywheretd(rule[UnprovenTree] {
+  val polishSimulated: Strategy = everywheretd(rule[Any] {
     case and: CAndUnproven =>
       // If the node is marked "simulated", mark all of its children "simulated"
       if (and.simulated) and.copy(children = and.children.map(_.asInstanceOf[UnprovenTree].withSimulated(true)))
@@ -208,7 +208,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
       }
     case su: UnprovenSchnorr => su
     case dhu: UnprovenDiffieHellmanTuple => dhu
-    case _ => ???
+    case _: UnprovenTree => ???
   })
 
   /**
@@ -218,7 +218,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
     * Prover Step 6: For every leaf marked "real", use the first prover step of the Sigma-protocol for that leaf to
     * compute the commitment a.
     */
-  def simulateAndCommit(hintsBag: HintsBag): Strategy = everywheretd(rule[ProofTree] {
+  def simulateAndCommit(hintsBag: HintsBag): Strategy = everywheretd(rule[Any] {
     // Step 4 part 1: If the node is marked "real", then each of its simulated children gets a fresh uniformly
     // random challenge in {0,1}^t.
     case and: CAndUnproven if and.real => and // A real AND node has no simulated children
@@ -354,7 +354,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
           }
         }
 
-    case a: Any => error(s"Don't know how to challengeSimulated($a)")
+    case t: ProofTree => error(s"Don't know how to challengeSimulated($t)")
   })
 
   private def extractChallenge(pt: ProofTree): Option[Array[Byte]] = pt match {
@@ -369,7 +369,7 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
     * the challenge e for every node marked "real" below the root and, additionally, the response z for every leaf
     * marked "real"
     */
-  def proving(hintsBag: HintsBag): Strategy = everywheretd(rule[ProofTree] {
+  def proving(hintsBag: HintsBag): Strategy = everywheretd(rule[Any] {
     // If the node is a non-leaf marked real whose challenge is e_0, proceed as follows:
     case and: CAndUnproven if and.real =>
       assert(and.challengeOpt.isDefined)
@@ -500,7 +500,9 @@ trait ProverInterpreter extends Interpreter with ProverUtils with AttributionCor
 
     case ut: UnprovenTree => ut
 
-    case a: Any => log.warn("Wrong input in prove(): ", a); ???
+    case t: ProofTree =>
+      log.warn("Wrong input in prove(): ", t);
+      ???
   })
 
 

--- a/sigmastate/src/main/scala/sigmastate/lang/SigmaBinder.scala
+++ b/sigmastate/src/main/scala/sigmastate/lang/SigmaBinder.scala
@@ -37,7 +37,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
 
   /** Rewriting of AST with respect to environment to resolve all references to global names
     * and infer their types. */
-  private def eval(e: SValue, env: ScriptEnv): SValue = rewrite(reduce(strategy[SValue]({
+  private def eval(e: SValue, env: ScriptEnv): SValue = rewrite(reduce(strategy[Any]({
     case i @ Ident(n, NoType) => env.get(n) match {
       case Some(v) => Option(liftAny(v).get.withPropagatedSrcCtx(i.sourceContext))
       case None => n match {

--- a/sigmastate/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/lang/SigmaSpecializer.scala
@@ -29,7 +29,7 @@ class SigmaSpecializer(val builder: SigmaBuilder) {
 
   /** Rewriting of AST with respect to environment to resolve all references
     * to let bound and lambda bound names. */
-  private def eval(env: Map[String, SValue], e: SValue): SValue = rewrite(reduce(strategy[SValue]({
+  private def eval(env: Map[String, SValue], e: SValue): SValue = rewrite(reduce(strategy[Any]({
     case Ident(n, _) => env.get(n)
 
     case _ @ Block(binds, res) =>

--- a/sigmastate/src/main/scala/sigmastate/lang/SigmaTyper.scala
+++ b/sigmastate/src/main/scala/sigmastate/lang/SigmaTyper.scala
@@ -598,8 +598,8 @@ class SigmaTyper(val builder: SigmaBuilder, predefFuncRegistry: PredefinedFuncRe
 
     // traverse the tree bottom-up checking that all the nodes have a type
     var untyped: SValue = null
-    rewrite(everywherebu(rule[SValue]{
-      case v =>
+    rewrite(everywherebu(rule[Any]{
+      case v: SValue =>
         if (v.tpe == NoType) untyped = v
         v
     }))(assigned)
@@ -671,7 +671,7 @@ object SigmaTyper {
       val remainingVars = tparams.filterNot { p => subst.contains(p.ident) }
       SFunc(args.map(applySubst(_, subst)), applySubst(res, subst), remainingVars)
     case _ =>
-      val substRule = rule[SType] {
+      val substRule = rule[Any] {
         case id: STypeVar if subst.contains(id) => subst(id)
       }
       rewrite(everywherebu(substRule))(tpe)

--- a/sigmastate/src/main/scala/sigmastate/lang/Terms.scala
+++ b/sigmastate/src/main/scala/sigmastate/lang/Terms.scala
@@ -272,8 +272,8 @@ object Terms {
       * @return AST where all nodes with missing source context are set to the given srcCtx
       */
     def withPropagatedSrcCtx[T <: SType](srcCtx: Nullable[SourceContext]): Value[T] = {
-      rewrite(everywherebu(rule[SValue] {
-        case node if node != null && node.sourceContext.isEmpty =>
+      rewrite(everywherebu(rule[Any] {
+        case node: SValue if node != null && node.sourceContext.isEmpty =>
           node.withSrcCtx(srcCtx)
       }))(v).asValue[T]
     }

--- a/sigmastate/src/main/scala/sigmastate/trees.scala
+++ b/sigmastate/src/main/scala/sigmastate/trees.scala
@@ -549,7 +549,8 @@ object ArithOp {
 }
 
 /** Negation operation on numeric type T. */
-case class Negation[T <: SNumericType](input: Value[T]) extends OneArgumentOperation[T, T] {
+case class Negation[T <: SType](input: Value[T]) extends OneArgumentOperation[T, T] {
+  require(input.tpe.isNumTypeOrNoType, s"invalid type ${input.tpe}")
   override def companion = Negation
   override def tpe: T = input.tpe
 }
@@ -558,7 +559,8 @@ object Negation extends OneArgumentOperationCompanion {
   override def argInfos: Seq[ArgInfo] = NegationInfo.argInfos
 }
 
-case class BitInversion[T <: SNumericType](input: Value[T]) extends OneArgumentOperation[T, T] {
+case class BitInversion[T <: SType](input: Value[T]) extends OneArgumentOperation[T, T] {
+  require(input.tpe.isNumTypeOrNoType, s"invalid type ${input.tpe}")
   override def companion = BitInversion
   override def tpe: T = input.tpe
 }
@@ -567,8 +569,9 @@ object BitInversion extends OneArgumentOperationCompanion {
   override def argInfos: Seq[ArgInfo] = BitInversionInfo.argInfos
 }
 
-case class BitOp[T <: SNumericType](left: Value[T], right: Value[T], override val opCode: OpCode)
+case class BitOp[T <: SType](left: Value[T], right: Value[T], override val opCode: OpCode)
   extends TwoArgumentsOperation[T, T, T] with NotReadyValue[T] {
+  require(left.tpe.isNumTypeOrNoType && right.tpe.isNumTypeOrNoType, s"invalid types left:${left.tpe}, right:${right.tpe}")
   override def companion = BitOp.operations(opCode)
   override def tpe: T = left.tpe
 }

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -64,6 +64,11 @@ sealed trait SType extends SigmaNode {
   /** Approximate size of the given value in bytes. It is actual size only for primitive types.*/
   def dataSize(v: SType#WrappedType): Long
 
+  /** Returns true if this type embeddable, i.e. a type that can be combined with type
+    * constructor for optimized encoding. For each embeddable type `T`, and type
+    * constructor `C`, the type `C[T]` can be represented by a single byte.
+    * @see [[sigmastate.serialization.TypeSerializer]]
+    */
   def isEmbeddable: Boolean = false
 
   /** Returns true if dataSize doesn't depend on data value.
@@ -150,7 +155,17 @@ object SType {
         val okRange = f1.tRange.canBeTypedAs(f2.tRange)
         okDom && okRange
     }
+
+    /** Returns true if this type is numeric (Byte, Short, etc.)
+      * @see [[sigmastate.SNumericType]]
+      */
     def isNumType: Boolean = tpe.isInstanceOf[SNumericType]
+
+    /** Returns true if this type is either numeric (Byte, Short, etc.) or is NoType.
+      * @see [[sigmastate.SNumericType]]
+      */
+    def isNumTypeOrNoType: Boolean = isNumType || tpe == NoType
+
     def asNumType: SNumericType = tpe.asInstanceOf[SNumericType]
     def asFunc: SFunc = tpe.asInstanceOf[SFunc]
     def asProduct: SProduct = tpe.asInstanceOf[SProduct]

--- a/sigmastate/src/test/scala/sigmastate/helpers/NegativeTesting.scala
+++ b/sigmastate/src/test/scala/sigmastate/helpers/NegativeTesting.scala
@@ -1,0 +1,36 @@
+package sigmastate.helpers
+
+import org.scalatest.Matchers
+
+import scala.annotation.tailrec
+
+trait NegativeTesting extends Matchers {
+
+  /** Checks that a [[Throwable]] is thrown and satisfies the given predicate.
+    * @param fun  block of code to execute
+    * @param assertion  expected assertion on the thrown exception
+    * @param clue  added to the error message
+    */
+  def assertExceptionThrown(fun: => Any, assertion: Throwable => Boolean, clue: => String = ""): Unit = {
+    try {
+      fun
+      fail("exception is expected")
+    }
+    catch {
+      case e: Throwable =>
+        if (!assertion(e))
+          fail(
+            s"""exception check failed on $e (root cause: ${rootCause(e)})
+              |clue: $clue
+              |trace:
+              |${e.getStackTrace.mkString("\n")}}""".stripMargin)
+    }
+  }
+
+  /** Returns the root cause of the chain of exceptions. */
+  @tailrec
+  final def rootCause(t: Throwable): Throwable =
+    if (t.getCause == null) t
+    else rootCause(t.getCause)
+
+}

--- a/sigmastate/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
+++ b/sigmastate/src/test/scala/sigmastate/helpers/SigmaTestingCommons.scala
@@ -25,13 +25,13 @@ import sigmastate.interpreter.CryptoConstants.EcPointType
 import sigmastate.utils.Helpers._
 import special.sigma
 
-import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 trait SigmaTestingCommons extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks
-  with Matchers with TestUtils with TestContexts with ValidationSpecification {
+  with Matchers with TestUtils with TestContexts with ValidationSpecification
+  with NegativeTesting {
 
   val fakeSelf: ErgoBox = createBox(0, TrueProp)
 
@@ -246,27 +246,6 @@ trait SigmaTestingCommons extends PropSpec
     val Terms.Apply(funcVal, _) = compiledTree.asInstanceOf[SValue]
     CompiledFunc(funcScript, bindings.toSeq, funcVal, f)
   }
-
-  def assertExceptionThrown(fun: => Any, assertion: Throwable => Boolean, clue: => String = ""): Unit = {
-    try {
-      fun
-      fail("exception is expected")
-    }
-    catch {
-      case e: Throwable =>
-        if (!assertion(e))
-          fail(
-            s"""exception check failed on $e (root cause: ${rootCause(e)})
-              |clue: $clue
-              |trace:
-              |${e.getStackTrace.mkString("\n")}}""".stripMargin)
-    }
-  }
-
-  @tailrec
-  final def rootCause(t: Throwable): Throwable =
-    if (t.getCause == null) t
-    else rootCause(t.getCause)
 
   protected def roundTripTest[T](v: T)(implicit serializer: SigmaSerializer[T, T]): Assertion = {
     // using default sigma reader/writer

--- a/sigmastate/src/test/scala/sigmastate/lang/LangTests.scala
+++ b/sigmastate/src/test/scala/sigmastate/lang/LangTests.scala
@@ -1,7 +1,7 @@
 package sigmastate.lang
 
 import sigmastate.lang.Terms.{MethodCallLike, Ident}
-import sigmastate.Values.{LongConstant, SValue, Value, SigmaBoolean, GroupElementConstant, ConcreteCollection}
+import sigmastate.Values.{LongConstant, SValue, Value, SigmaBoolean, ConcreteCollection}
 import sigmastate._
 import java.math.BigInteger
 
@@ -14,9 +14,10 @@ import sigmastate.interpreter.CryptoConstants
 import sigmastate.interpreter.Interpreter.ScriptEnv
 import special.sigma._
 import sigmastate.eval._
+import sigmastate.helpers.NegativeTesting
 import special.collection.Coll
 
-trait LangTests extends Matchers {
+trait LangTests extends Matchers with NegativeTesting {
 
   def BoolIdent(name: String): Value[SBoolean.type] = Ident(name).asValue[SBoolean.type]
   def IntIdent(name: String): Value[SLong.type] = Ident(name).asValue[SLong.type]
@@ -75,8 +76,8 @@ trait LangTests extends Matchers {
 
   def assertSrcCtxForAllNodes(tree: SValue): Unit = {
     import org.bitbucket.inkytonik.kiama.rewriting.Rewriter._
-    rewrite(everywherebu(rule[SValue] {
-      case node =>
+    rewrite(everywherebu(rule[Any] {
+      case node: SValue =>
         withClue(s"Missing sourceContext for $node") { node.sourceContext.isDefined shouldBe true }
         node
     }))(tree)


### PR DESCRIPTION
Most of the kiama rewriting rules were throwing exceptions for some tree nodes. 
This is interpreted by kiama as the rule is not applicable, so the node is preserved and is not rewritten.

This PR changes the rules, so that they have the same effect, but without exception.