### PR TITLE
Accumulated changes for v5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ commands += Command.command("ergoItTest") { state =>
 }
 
 def runSpamTestTask(task: String, sigmastateVersion: String, log: Logger): Unit = {
-  val spamBranch = "revert-23-revert-22-serialize-opt"
+  val spamBranch = "v4"
   val envVars = Seq("SIGMASTATE_VERSION" -> sigmastateVersion,
     "SPECIAL_VERSION" -> specialVersion,
     // SSH_SPAM_REPO_KEY should be set (see Jenkins Credentials Binding Plugin)

--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,7 @@ lazy val testSettings = Seq(
   baseDirectory in Test := file("."),
   publishArtifact in Test := true,
   publishArtifact in(Test, packageSrc) := true,
+  publishArtifact in(Compile, packageDoc) := false,
   publishArtifact in(Test, packageDoc) := false,
   test in assembly := {})
 

--- a/build.sbt
+++ b/build.sbt
@@ -118,9 +118,9 @@ libraryDependencies ++= Seq(
 ) ++ testingDependencies
 
 val circeVersion = "0.10.0"
-val circeCore = "io.circe" %% "circe-core" % circeVersion 
-val circeGeneric = "io.circe" %% "circe-generic" % circeVersion 
-val circeParser = "io.circe" %% "circe-parser" % circeVersion 
+val circeCore = "io.circe" %% "circe-core" % circeVersion
+val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
+val circeParser = "io.circe" %% "circe-parser" % circeVersion
 
 libraryDependencies ++= Seq( circeCore, circeGeneric, circeParser )
 

--- a/core/src/main/scala/scalan/staged/Transforming.scala
+++ b/core/src/main/scala/scalan/staged/Transforming.scala
@@ -184,9 +184,9 @@ trait Transforming { self: Scalan =>
 
       // new effects may appear during body mirroring
       // thus we need to forget original Reify node and create a new one
-//      val oldStack = lambdaStack
+      val oldStack = lambdaStack
       try {
-//        lambdaStack = newLambdaCandidate :: lambdaStack
+        lambdaStack = newLambdaCandidate :: lambdaStack
         val newRoot = { // reifyEffects block
           val schedule = lam.scheduleIds
           val t2 = mirrorSymbols(t1, rewriter, lam, schedule)
@@ -196,7 +196,7 @@ trait Transforming { self: Scalan =>
         ySym.assignDefFrom(newRoot)
       }
       finally {
-//        lambdaStack = oldStack
+        lambdaStack = oldStack
       }
 
       // we don't use toExp here to avoid rewriting pass for new Lambda

--- a/docs/hard-fork-changes.md
+++ b/docs/hard-fork-changes.md
@@ -25,3 +25,5 @@ Thus this is better to be fixed as part of upcoming hard-fork.
 5. Complexity of Fold.opCode changed 4034 -> 8034 (i.e. increased for better approximations of the costs)
 
 6. Append operation cost also increased (see `("Append", "(Coll[IV],Coll[IV]) => Coll[IV]", appendCost)`)
+
+7. Removed RW Rule: replicate(n,x).zip(ys).map(f)  ==>  ys.map(y => f(x, y))

--- a/docs/hard-fork-changes.md
+++ b/docs/hard-fork-changes.md
@@ -27,3 +27,5 @@ Thus this is better to be fixed as part of upcoming hard-fork.
 6. Append operation cost also increased (see `("Append", "(Coll[IV],Coll[IV]) => Coll[IV]", appendCost)`)
 
 7. Removed RW Rule: replicate(n,x).zip(ys).map(f)  ==>  ys.map(y => f(x, y))
+
+8. Changes marked as // HF change:

--- a/docs/hard-fork-changes.md
+++ b/docs/hard-fork-changes.md
@@ -1,0 +1,27 @@
+## A list of hard-fork changes
+
+Please describe here all changes which may lead to hard fork (HF for short).
+
+**Note for reviewers: Pull requests targeted to the next HF branch (e.g. v4.x) should be rejected, 
+if they contain HF change, which is not described here**.
+
+### Hard-fork changes in v4.0 (since v3.0.0)
+
+1. This version v4.0.x is based on special/v0.6.x and inherit its hard-fork changes 
+  [see corresponding file](https://github.com/scalan/special/blob/v0.6.0/docs/hard-fork-changes.md).
+  
+2. CheckAppendInFoldLoop validation rule added.
+
+3. Costing rule for Append is changed. The same script will have different cost in this version.
+   Hence some transactions may become invalid.
+   
+4. ModQ operations serializers removed from serializers table, because these operations
+are not fully implemented.
+This means old v3.0 nodes can successfully serialize but throw exception later.
+New v4.0 nodes will throw during deserialization. For this reason this opCodes 
+cannot be used, even after new operations are fully implemented via soft-fork.
+Thus this is better to be fixed as part of upcoming hard-fork.
+
+5. Complexity of Fold.opCode changed 4034 -> 8034 (i.e. increased for better approximations of the costs)
+
+6. Append operation cost also increased (see `("Append", "(Coll[IV],Coll[IV]) => Coll[IV]", appendCost)`)

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -2,6 +2,7 @@ package org.ergoplatform
 
 import java.util
 
+import scalan.util.Extensions.LongOps
 import org.ergoplatform.ErgoBox._
 import org.ergoplatform.settings.ErgoAlgos
 import scorex.crypto.hash.Digest32
@@ -146,14 +147,14 @@ object ErgoBoxCandidate {
       r.positionLimit = r.position + ErgoBox.MaxBoxSize
       val value = r.getULong()                  // READ
       val tree = DefaultSerializer.deserializeErgoTree(r, SigmaSerializer.MaxPropositionSize)  // READ
-      val creationHeight = r.getUInt().toInt    // READ
+      val creationHeight = r.getUInt().toIntExact // READ   // HF change: was r.getUInt().toInt
       val nTokens = r.getUByte()                // READ
       val tokenIds = new Array[Digest32](nTokens)
       val tokenAmounts = new Array[Long](nTokens)
       val tokenIdSize = TokenId.size
       cfor(0)(_ < nTokens, _ + 1) { i =>
         val tokenId = if (digestsInTx.isDefined) {
-          val digestIndex = r.getUInt().toInt   // READ
+          val digestIndex = r.getUInt().toIntExact // READ  // HF change: was r.getUInt().toInt
           val digests = digestsInTx.get
           if (!digests.isDefinedAt(digestIndex)) sys.error(s"failed to find token id with index $digestIndex")
           digests(digestIndex)

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
@@ -1,5 +1,6 @@
 package org.ergoplatform
 
+import scalan.util.Extensions.LongOps
 import org.ergoplatform.ErgoBox.TokenId
 import scorex.crypto.authds.ADKey
 import scorex.crypto.hash.{Blake2b256, Digest32}
@@ -157,7 +158,7 @@ object ErgoLikeTransactionSerializer extends SigmaSerializer[ErgoLikeTransaction
       dataInputsBuilder += DataInput(ADKey @@ r.getBytes(ErgoBox.BoxId.size))
     }
     // parse distinct ids of tokens in transaction outputs
-    val tokensCount = r.getUInt().toInt
+    val tokensCount = r.getUInt().toIntExact             // HF change: was r.getUInt().toInt
     val tokensBuilder = mutable.ArrayBuilder.make[TokenId]()
     for (_ <- 0 until tokensCount) {
       tokensBuilder += Digest32 @@ r.getBytes(TokenId.size)

--- a/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
@@ -330,14 +330,6 @@ object ValidationRules {
     }
   }
 
-  object CheckAppendInFoldLoop extends ValidationRule(1016,
-    "Check that Append operation is not appear in loop body") with SoftForkWhenReplaced {
-    def apply(level: Int): Unit = {
-      validate(level == 0,
-      new CosterException(s"Append is not allowed in Fold loop", None), Seq(level), {})
-    }
-  }
-
   val ruleSpecs: Seq[ValidationRule] = Seq(
     CheckDeserializedScriptType,
     CheckDeserializedScriptIsSigmaProp,

--- a/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
@@ -319,6 +319,17 @@ object ValidationRules {
     }
   }
 
+  object CheckAppendInFoldLoop extends ValidationRule(1016,
+    "Check that Append operation is not appear in loop body") with SoftForkWhenReplaced {
+    def apply(level: Int): Unit = {
+      checkRule()
+      if (level == 0)
+        throwValidationException(
+          new CosterException(s"Append is not allowed in Fold loop", None),
+          Array(level))
+    }
+  }
+
   val ruleSpecs: Seq[ValidationRule] = Seq(
     CheckDeserializedScriptType,
     CheckDeserializedScriptIsSigmaProp,

--- a/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
@@ -330,6 +330,14 @@ object ValidationRules {
     }
   }
 
+  object CheckAppendInFoldLoop extends ValidationRule(1016,
+    "Check that Append operation is not appear in loop body") with SoftForkWhenReplaced {
+    def apply(level: Int): Unit = {
+      validate(level == 0,
+      new CosterException(s"Append is not allowed in Fold loop", None), Seq(level), {})
+    }
+  }
+
   val ruleSpecs: Seq[ValidationRule] = Seq(
     CheckDeserializedScriptType,
     CheckDeserializedScriptIsSigmaProp,
@@ -346,7 +354,8 @@ object ValidationRules {
     CheckHeaderSizeBit,
     CheckCostFuncOperation,
     CheckPositionLimit,
-    CheckLoopLevelInCostFunction
+    CheckLoopLevelInCostFunction,
+    CheckAppendInFoldLoop
   )
 
   /** Validation settings that correspond to the current version of the ErgoScript implementation.

--- a/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
@@ -265,7 +265,7 @@ object ValidationRules {
    * because at the time of parsing we may assume that `ChangedRule.newValue`
    * has correct length, so we just parse it until end of bytes (of cause
    * checking consistency). */
-  object CheckCostFuncOperation extends ValidationRule(1013,
+  object CheckCostFuncOpCode extends ValidationRule(1013,
     "Check the opcode is allowed in cost function") with SoftForkWhenCodeAdded {
     final def apply[Ctx <: IRContext, T](ctx: Ctx)(opCode: OpCodeExtra): Unit = {
       checkRule()
@@ -323,7 +323,7 @@ object ValidationRules {
     "Check that Append operation is not appear in loop body") with SoftForkWhenReplaced {
     def apply(level: Int): Unit = {
       checkRule()
-      if (level == 0)
+      if (level > 0)
         throwValidationException(
           new CosterException(s"Append is not allowed in Fold loop", None),
           Array(level))
@@ -344,7 +344,7 @@ object ValidationRules {
     CheckTypeWithMethods,
     CheckAndGetMethod,
     CheckHeaderSizeBit,
-    CheckCostFuncOperation,
+    CheckCostFuncOpCode,
     CheckPositionLimit,
     CheckLoopLevelInCostFunction,
     CheckAppendInFoldLoop

--- a/sigmastate/src/main/scala/sigmastate/AvlTreeData.scala
+++ b/sigmastate/src/main/scala/sigmastate/AvlTreeData.scala
@@ -2,7 +2,7 @@ package sigmastate
 
 import java.util
 import java.util.{Arrays, Objects}
-
+import scalan.util.Extensions.LongOps
 import scorex.crypto.authds.ADDigest
 import sigmastate.interpreter.CryptoConstants
 import sigmastate.serialization.SigmaSerializer
@@ -93,8 +93,8 @@ object AvlTreeData {
     override def parse(r: SigmaByteReader): AvlTreeData = {
       val digest = r.getBytes(DigestSize)
       val tf = AvlTreeFlags(r.getByte())
-      val keyLength = r.getUInt().toInt
-      val valueLengthOpt = r.getOption(r.getUInt().toInt)
+      val keyLength = r.getUInt().toIntExact  // HF change: was r.getUInt().toInt
+      val valueLengthOpt = r.getOption(r.getUInt().toIntExact)  // HF change: was r.getUInt().toInt
       AvlTreeData(ADDigest @@ digest, tf, keyLength, valueLengthOpt)
     }
   }

--- a/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1418,9 +1418,10 @@ trait RuntimeCosting extends CostingRules { IR: IRContext =>
         val col1 = asRep[CostedColl[Any]](_col1)
         val col2 = asRep[CostedColl[Any]](_col2)
         val values = col1.values.append(col2.values)
-        val costs = col1.costs.append(col2.costs)
+        val len = col1.costs.length + col2.costs.length
+        val costs = colBuilder.replicate(len, IntZero)
         val sizes = col1.sizes.append(col2.sizes)
-        RCCostedColl(values, costs, sizes, opCost(values, Array(col1.cost, col2.cost), costOf(node)))
+        RCCostedColl(values, costs, sizes, opCost(values, Array(col1.cost, col2.cost), costOf(node) + perItemCostOf(node, len)))
 
       case Filter(input, p) =>
         val inputC = evalNode(ctx, env, input)

--- a/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -556,10 +556,11 @@ trait RuntimeCosting extends CostingRules { IR: IRContext =>
         case _ => super.rewriteDef(d)
       }
 
-      case CM.map(CM.zip(CBM.replicate(_, n, x: Ref[a]), ys: RColl[b]@unchecked), _f) =>
-        val f = asRep[((a,b)) => Any](_f)
-        implicit val eb = ys.elem.eItem
-        ys.map(fun { y: Ref[b] => f(Pair(x, y))})
+//      // Rule: replicate(n,x).zip(ys).map(f)  ==>  ys.map(y => f(x, y))
+//      case CM.map(CM.zip(CBM.replicate(_, n, x: Ref[a]), ys: RColl[b]@unchecked), _f) =>
+//        val f = asRep[((a,b)) => Any](_f)
+//        implicit val eb = ys.elem.eItem
+//        ys.map(fun { y: Ref[b] => f(Pair(x, y))})
 
       // Rule: l.isValid op Thunk {... root} => (l op TrivialSigma(root)).isValid
       case ApplyBinOpLazy(op, SigmaM.isValid(l), Def(ThunkDef(root, sch))) if root.elem == BooleanElement =>

--- a/sigmastate/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -405,8 +405,8 @@ trait TreeBuilding extends RuntimeCosting { IR: IRContext =>
     var curEnv = env
     for (s <- subG.schedule) {
       val d = s.node
-//      val nonRootLoop = LoopOperation.unapply(d).isDefined && !subG.roots.contains(s)
-      if ((mainG.hasManyUsagesGlobal(s)/* || nonRootLoop*/)
+      val nonRootLoop = LoopOperation.unapply(d).isDefined && !subG.roots.contains(s)
+      if ((mainG.hasManyUsagesGlobal(s) || nonRootLoop)
         && IsContextProperty.unapply(d).isEmpty
         && IsInternalDef.unapply(d).isEmpty
           // to increase effect of constant segregation we need to treat the constants specially

--- a/sigmastate/src/main/scala/sigmastate/serialization/ConstantPlaceholderSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ConstantPlaceholderSerializer.scala
@@ -1,5 +1,6 @@
 package sigmastate.serialization
 
+import scalan.util.Extensions.LongOps
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
@@ -13,8 +14,8 @@ case class ConstantPlaceholderSerializer(cons: (Int, SType) => Value[SType])
   }
 
   override def parse(r: SigmaByteReader): Value[SType] = {
-    val id = r.getUInt().toInt
-    val constant = r.constantStore.get(id)  // TODO HF move this under if branch
+    val id = r.getUInt().toIntExact         // HF change: was r.getUInt().toInt
+    val constant = r.constantStore.get(id)
     if (r.resolvePlaceholdersToConstants)
       constant
     else

--- a/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala
@@ -3,6 +3,7 @@ package sigmastate.serialization
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 
+import scalan.util.Extensions.LongOps
 import org.ergoplatform.ErgoBox
 import org.ergoplatform.validation.ValidationRules.CheckSerializableTypeCode
 import scalan.RType
@@ -92,7 +93,7 @@ object DataSerializer {
       case SInt => r.getInt()
       case SLong => r.getLong()
       case SString =>
-        val size = r.getUInt().toInt
+        val size = r.getUInt().toIntExact  // HF change: was r.getUInt().toInt
         val bytes = r.getBytes(size)
         new String(bytes, StandardCharsets.UTF_8)
       case SBigInt =>

--- a/sigmastate/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ErgoTreeSerializer.scala
@@ -212,7 +212,7 @@ class ErgoTreeSerializer {
     */
   private def deserializeConstants(header: Byte, r: SigmaByteReader): Array[Constant[SType]] = {
     val constants = if (ErgoTree.isConstantSegregation(header)) {
-      val nConsts = r.getUInt().toInt
+      val nConsts = r.getUInt().toIntExact
       val res = new Array[Constant[SType]](nConsts)
       cfor(0)(_ < nConsts, _ + 1) { i =>
         res(i) = constantSerializer.deserialize(r)

--- a/sigmastate/src/main/scala/sigmastate/serialization/FuncValueSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/FuncValueSerializer.scala
@@ -30,7 +30,7 @@ case class FuncValueSerializer(cons: (IndexedSeq[(Int, SType)], Value[SType]) =>
     val argsSize = r.getUInt().toIntExact
     val argsBuilder = mutable.ArrayBuilder.make[(Int, SType)]()
     for (_ <- 0 until argsSize) {
-      val id = r.getUInt().toInt
+      val id = r.getUInt().toIntExact   // HF change: was r.getUInt().toInt
       val tpe = r.getType()
       r.valDefTypeStore(id) = tpe
       argsBuilder += ((id, tpe))

--- a/sigmastate/src/main/scala/sigmastate/serialization/ValDefSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ValDefSerializer.scala
@@ -29,7 +29,7 @@ case class ValDefSerializer(override val opDesc: ValueCompanion) extends ValueSe
   }
 
   override def parse(r: SigmaByteReader): Value[SType] = {
-    val id = r.getUInt().toInt
+    val id = r.getUInt().toIntExact   // HF change: was r.getUInt().toInt
     val tpeArgs: Seq[STypeVar] = opCode match {
       case FunDefCode =>
         val nTpeArgs = r.getByte()

--- a/sigmastate/src/main/scala/sigmastate/serialization/ValUseSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ValUseSerializer.scala
@@ -1,5 +1,6 @@
 package sigmastate.serialization
 
+import scalan.util.Extensions.LongOps
 import sigmastate.Values._
 import sigmastate._
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
@@ -12,7 +13,7 @@ case class ValUseSerializer(cons: (Int, SType) => Value[SType]) extends ValueSer
   }
 
   override def parse(r: SigmaByteReader): Value[SType] = {
-    val id = r.getUInt().toInt
+    val id = r.getUInt().toIntExact  // HF change: was r.getUInt().toInt
     val tpe = r.valDefTypeStore(id)
     cons(id, tpe)
   }

--- a/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -134,13 +134,15 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     SigmaTransformerSerializer(SigmaOr, mkSigmaOr),
     BoolToSigmaPropSerializer(mkBoolToSigmaProp),
 
+    // TODO https://github.com/ScorexFoundation/sigmastate-interpreter/issues/327
     // TODO hard-fork: this ModQ serializers should be removed only as part of hard-fork
     // because their removal may break deserialization of transaction, when for example
     // ModQ operation happen to be in one of the outputs (i.e. script is not executed
     // during validation, however deserializer is still used)
-    ModQSerializer,
-    ModQArithOpSerializer(ModQArithOp.PlusModQ, mkPlusModQ),
-    ModQArithOpSerializer(ModQArithOp.MinusModQ, mkMinusModQ),
+
+    //    ModQSerializer,
+    //    ModQArithOpSerializer(ModQArithOp.PlusModQ, mkPlusModQ),
+    //    ModQArithOpSerializer(ModQArithOp.MinusModQ, mkMinusModQ),
 
     SubstConstantsSerializer,
     CreateProveDlogSerializer(mkCreateProveDlog),

--- a/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -134,16 +134,6 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     SigmaTransformerSerializer(SigmaOr, mkSigmaOr),
     BoolToSigmaPropSerializer(mkBoolToSigmaProp),
 
-    // TODO https://github.com/ScorexFoundation/sigmastate-interpreter/issues/327
-    // TODO hard-fork: this ModQ serializers should be removed only as part of hard-fork
-    // because their removal may break deserialization of transaction, when for example
-    // ModQ operation happen to be in one of the outputs (i.e. script is not executed
-    // during validation, however deserializer is still used)
-
-    //    ModQSerializer,
-    //    ModQArithOpSerializer(ModQArithOp.PlusModQ, mkPlusModQ),
-    //    ModQArithOpSerializer(ModQArithOp.MinusModQ, mkMinusModQ),
-
     SubstConstantsSerializer,
     CreateProveDlogSerializer(mkCreateProveDlog),
     CreateProveDHTupleSerializer(mkCreateProveDHTuple),

--- a/sigmastate/src/main/scala/sigmastate/serialization/transformers/SigmaTransformerSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/transformers/SigmaTransformerSerializer.scala
@@ -1,7 +1,8 @@
 package sigmastate.serialization.transformers
 
-import sigmastate.{SigmaTransformerCompanion, SigmaTransformer}
-import sigmastate.Values.{SigmaPropValue, SValue}
+import scalan.util.Extensions.LongOps
+import sigmastate.{SigmaTransformer, SigmaTransformerCompanion}
+import sigmastate.Values.{ValueCompanion, SigmaPropValue}
 import sigmastate.serialization.ValueSerializer
 import sigmastate.utils.SigmaByteWriter.{DataInfo, valuesItemInfo}
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
@@ -17,7 +18,7 @@ case class SigmaTransformerSerializer[I <: SigmaPropValue, O <: SigmaPropValue]
     w.putValues(obj.items, itemsInfo, itemsItemInfo)
 
   override def parse(r: SigmaByteReader): SigmaPropValue = {
-    val itemsSize = r.getUInt().toInt
+    val itemsSize = r.getUInt().toIntExact    // HF change: was r.getUInt().toInt
     val res = new Array[SigmaPropValue](itemsSize)
     cfor(0)(_ < itemsSize, _ + 1) { i =>
       res(i) = r.getValue().asInstanceOf[SigmaPropValue]

--- a/sigmastate/src/main/scala/sigmastate/serialization/transformers/SigmaTransformerSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/transformers/SigmaTransformerSerializer.scala
@@ -1,8 +1,8 @@
 package sigmastate.serialization.transformers
 
 import scalan.util.Extensions.LongOps
-import sigmastate.{SigmaTransformer, SigmaTransformerCompanion}
-import sigmastate.Values.{ValueCompanion, SigmaPropValue}
+import sigmastate.{SigmaTransformerCompanion, SigmaTransformer}
+import sigmastate.Values.{SigmaPropValue, SValue}
 import sigmastate.serialization.ValueSerializer
 import sigmastate.utils.SigmaByteWriter.{DataInfo, valuesItemInfo}
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}

--- a/sigmastate/src/main/scala/sigmastate/utxo/ComplexityTable.scala
+++ b/sigmastate/src/main/scala/sigmastate/utxo/ComplexityTable.scala
@@ -11,7 +11,7 @@ object ComplexityTable {
   val MinimalComplexity = 100
 
   val OpCodeComplexity: Map[OpCode, Int] = Seq(
-    Fold.opCode                    -> 4034,  // count = 122
+    Fold.opCode                    -> 8034,  // count = 122
     MapCollection.opCode           -> 2514,  // count = 402
     BinAnd.opCode                  -> 2000,  // count = 21858
     BinOr.opCode                   -> 2000,  // count = 9894

--- a/sigmastate/src/main/scala/sigmastate/utxo/CostTable.scala
+++ b/sigmastate/src/main/scala/sigmastate/utxo/CostTable.scala
@@ -78,6 +78,8 @@ object CostTable {
   val collByIndex = 5 // TODO costing: should be >= selectField
 
   val collToColl = 20
+  val appendCost = 50
+  val appendPerItemCost = 2
   val lambdaInvoke = 30  // interpreter overhead on each lambda invocation (map, filter, forall, etc)
   val concreteCollectionItemCost = 10  // since each item is a separate graph node
   val comparisonCost = 10
@@ -147,7 +149,9 @@ object CostTable {
     ("SGroupElement$.negate", "(GroupElement) => GroupElement", negateGroup),
 
     ("Slice", "(Coll[IV],Int,Int) => Coll[IV]", collToColl),
-    ("Append", "(Coll[IV],Coll[IV]) => Coll[IV]", collToColl),
+
+    ("Append", "(Coll[IV],Coll[IV]) => Coll[IV]", appendCost),
+    ("Append_per_item", "(Coll[IV],Coll[IV]) => Coll[IV]", appendPerItemCost),
 
     ("SizeOf", "(Coll[IV]) => Int", collLength),
     ("ByIndex", "(Coll[IV],Int) => IV", collByIndex),

--- a/sigmastate/src/test/scala/sigmastate/CostingSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/CostingSpecification.scala
@@ -314,7 +314,7 @@ class CostingSpecification extends SigmaTestingData {
 
     cost(s"{ $coll.append(OUTPUTS).size > 0 }")(
       selectField + accessBox * tx.outputs.length +
-      accessBox * tx.outputs.length * 2 + collToColl + LengthGTConstCost)
+        appendPerItemCost * tx.outputs.length * 2 + appendCost + LengthGTConstCost)
 
     cost(s"{ $coll.indices.size > 0 }")(
       selectField + accessBox * tx.outputs.length + selectField + LengthGTConstCost)

--- a/sigmastate/src/test/scala/sigmastate/CostingSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/CostingSpecification.scala
@@ -1,5 +1,6 @@
 package sigmastate
 
+import scalan.util.Extensions.LongOps
 import org.ergoplatform.SigmaConstants.ScriptCostLimit
 import org.ergoplatform.ErgoScriptPredef.TrueProp
 import org.ergoplatform.validation.ValidationRules
@@ -241,7 +242,7 @@ class CostingSpecification extends SigmaTestingData {
 
   val AccessRootHash = selectField
   def perKbCostOf(dataSize: Long, opCost: Int) = {
-    ((dataSize / 1024L).toInt + 1) * opCost
+    ((dataSize / 1024L).toIntExact + 1) * opCost
   }
 
   property("AvlTree operations cost") {

--- a/sigmastate/src/test/scala/sigmastate/SoftForkabilitySpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/SoftForkabilitySpecification.scala
@@ -1,7 +1,7 @@
 package sigmastate
 
 import org.ergoplatform._
-import org.ergoplatform.validation.ValidationRules.{CheckValidOpCode, trySoftForkable, CheckCostFuncOperation, CheckTupleType, CheckCostFunc, CheckDeserializedScriptIsSigmaProp, _}
+import org.ergoplatform.validation.ValidationRules.{CheckValidOpCode, trySoftForkable, CheckCostFuncOpCode, CheckTupleType, CheckCostFunc, CheckDeserializedScriptIsSigmaProp, _}
 import org.ergoplatform.validation._
 import sigmastate.SPrimType.MaxPrimTypeCode
 import sigmastate.Values.ErgoTree.EmptyConstants
@@ -315,9 +315,9 @@ class SoftForkabilitySpecification extends SigmaTestingData {
 
   property("CheckCostFuncOperation rule") {
     val exp = Height
-    val v2vs = vs.updated(CheckCostFuncOperation.id,
-      ChangedRule(CheckCostFuncOperation.encodeVLQUShort(Seq(OpCodes.toExtra(Height.opCode)))))
-    checkRule(CheckCostFuncOperation, v2vs, {
+    val v2vs = vs.updated(CheckCostFuncOpCode.id,
+      ChangedRule(CheckCostFuncOpCode.encodeVLQUShort(Seq(OpCodes.toExtra(Height.opCode)))))
+    checkRule(CheckCostFuncOpCode, v2vs, {
       val costingRes = IR.doCostingEx(emptyEnv, exp, okRemoveIsProven = false)
       // use calcF as costing function to have forbidden (not allowed) op (Height) in the costing function
       CheckCostFunc(IR)(IR.asRep[Any => Int](costingRes.calcF))
@@ -330,9 +330,9 @@ class SoftForkabilitySpecification extends SigmaTestingData {
     }
     val tIR = new TestingIRContextEmptyCodes
     import tIR._
-    val v2vs = vs.updated(CheckCostFuncOperation.id,
-      ChangedRule(CheckCostFuncOperation.encodeVLQUShort(Seq(OpCodes.OpCostCode))))
-    checkRule(CheckCostFuncOperation, v2vs, {
+    val v2vs = vs.updated(CheckCostFuncOpCode.id,
+      ChangedRule(CheckCostFuncOpCode.encodeVLQUShort(Seq(OpCodes.OpCostCode))))
+    checkRule(CheckCostFuncOpCode, v2vs, {
       implicit val anyType = AnyElement
       val v1 = variable[Int]
       val costF = fun[Any, Int] {_ => opCost(v1, Seq(1), 2) }

--- a/sigmastate/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
+++ b/sigmastate/src/test/scala/sigmastate/eval/ErgoTreeBuildingTest.scala
@@ -94,18 +94,21 @@ class ErgoTreeBuildingTest extends BaseCtxTests
     val projectPK = prover.dlogSecrets(1).publicImage
     val env = envCF ++ Seq("projectPubKey" -> projectPK, "backerPubKey" -> backerPK)
     build(env, "CrowdFunding", crowdFundingScript,
-      BlockValue(Array(
-        ValDef(1,Nil,SigmaPropConstant(projectPK))),
-        SigmaOr(Array(
-          SigmaAnd(Array(BoolToSigmaProp(GE(Height,IntConstant(100))),SigmaPropConstant(backerPK))),
-          SigmaAnd(Array(
-            BoolToSigmaProp(AND(Array(
+      BlockValue(Vector(
+        ValDef(1,List(), SigmaPropConstant(projectPK)),
+        ValDef(2,List(), Exists(Outputs, FuncValue(Vector((2,SBox)),
+          BinAnd(
+            GE(ExtractAmount(ValUse(2,SBox)),LongConstant(1000)),
+            EQ(ExtractScriptBytes(ValUse(2,SBox)), SigmaPropBytes(ValUse(1,SSigmaProp)))))
+        ))
+      ),
+        SigmaOr(Seq(
+          SigmaAnd(Seq(BoolToSigmaProp(GE(Height,IntConstant(100))),SigmaPropConstant(backerPK))),
+          SigmaAnd(Seq(
+            BoolToSigmaProp(AND(Vector(
               LT(Height,IntConstant(100)),
-              Exists(Outputs, FuncValue(Array((2,SBox)),
-                BinAnd(
-                  GE(ExtractAmount(ValUse(2,SBox)),LongConstant(1000)),
-                  EQ(ExtractScriptBytes(ValUse(2,SBox)), SigmaPropBytes(ValUse(1,SSigmaProp)))))
-              )))),
+              ValUse(2, SBoolean)
+            ))),
             ValUse(1,SSigmaProp)
           ))))))
   }

--- a/sigmastate/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/utxo/CollectionOperationsSpecification.scala
@@ -528,7 +528,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
             MethodCall(
               ValUse(1, SLongArray),
               PatchMethod.withConcreteTypes(Map(tIV -> SLong)),
-              Vector(IntConstant(0), ConcreteCollection(LongConstant(3)), IntConstant(1)),
+              Vector(IntConstant(0), ConcreteCollection.fromItems(LongConstant(3)), IntConstant(1)),
               Map()).asCollection[SType],
             IntConstant(0)
           ),
@@ -563,7 +563,7 @@ class CollectionOperationsSpecification extends SigmaTestingCommons {
             MethodCall(
               ValUse(1, SLongArray),
               UpdateManyMethod.withConcreteTypes(Map(tIV -> SLong)),
-              Vector(ConcreteCollection(IntConstant(0)), ConcreteCollection(LongConstant(3))),
+              Vector(ConcreteCollection.fromItems(IntConstant(0)), ConcreteCollection.fromItems(LongConstant(3))),
               Map()).asCollection[SType],
             IntConstant(0)
           ),

--- a/sigmastate/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -226,17 +226,17 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons
         |  pubkey && outValues.fold(0L, { (x: Long, y: Long) => x + y }) > 20
          }""".stripMargin).asSigmaProp
 
-    val propExp = SigmaAnd(
-      Seq(
-        SigmaPropConstant(pubkey),
-        BoolToSigmaProp(
-          GT(
-            Fold.sum[SLong.type](MapCollection(Outputs,
-              FuncValue(Vector((1, SBox)), ExtractAmount(ValUse(1, SBox)))), 1),
-            LongConstant(20))
+    val propExp = BlockValue(
+      Vector(
+        ValDef(1, MapCollection(Outputs, FuncValue(Vector((1, SBox)), ExtractAmount(ValUse(1, SBox))))),
+        ValDef(2, Fold.sum[SLong.type](ValUse(1, SCollection.SLongArray), 2))
+      ),
+      SigmaAnd(
+        Seq(
+          SigmaPropConstant(pubkey),
+          BoolToSigmaProp(GT(ValUse(2, SLong), LongConstant(20)))
         )
-      )
-    )
+      ))
     prop shouldBe propExp
 
     val newBox1 = ErgoBox(11, pubkey, 0)

--- a/sigmastate/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/utxo/ErgoLikeInterpreterSpecification.scala
@@ -174,7 +174,7 @@ class ErgoLikeInterpreterSpecification extends SigmaTestingCommons
         """{
           |  val notTimePassed = HEIGHT <= timeout
           |  val outBytes = OUTPUTS.map({(box: Box) => box.bytesWithoutRef})
-          |  val outSumBytes = outBytes.fold(Coll[Byte](), {(arr1: Coll[Byte], arr2: Coll[Byte]) => arr1 ++ arr2})
+          |  val outSumBytes = outBytes.flatMap({(bytes: Coll[Byte]) => bytes})
           |  val timePassed = HEIGHT > timeout
           |  notTimePassed && blake2b256(outSumBytes) == properHash || timePassed && sender
            }""".stripMargin).asSigmaProp


### PR DESCRIPTION
OUTDATED: (keeping it for archive)
This changes was previously planned for v4.0 interpreter and done in #568 
They have never made its way into release because of switch to JIT costing interpreter.
 

This PR is to accumulate all the changes that cannot be done in 4.x series because require a separate soft-fork and [activation protocol](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/develop/docs/aot-jit-switch.md).
