### PR TITLE
Ensure v4.0 can support AOT -> JIT switch as v5.0 soft-fork (includes HF changes)

### DIFF
--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -8,16 +8,16 @@ import sigmastate.Values._
 import sigmastate._
 import sigmastate.eval.Extensions._
 import sigmastate.eval._
-import sigmastate.interpreter.{ContextExtension, InterpreterContext}
+import sigmastate.interpreter.{ContextExtension, InterpreterContext, Interpreter}
 import sigmastate.serialization.OpCodes
 import sigmastate.serialization.OpCodes.OpCode
 import special.collection.Coll
 import special.sigma
-import special.sigma.{AnyValue, Header, PreHeader}
+import special.sigma.{AnyValue, PreHeader, Header}
 import spire.syntax.all.cfor
 
-/**
-  * TODO lastBlockUtxoRoot should be calculated from headers if it is nonEmpty
+/** Represents a script evaluation context to be passed to a prover and a verifier to execute and
+  * validate guarding proposition of input boxes of a transaction.
   *
   * @param selfIndex              - index of the box in `boxesToSpend` that contains the script we're evaluating
   * @param lastBlockUtxoRoot      - state root before current block application
@@ -31,8 +31,17 @@ import spire.syntax.all.cfor
   * @param validationSettings     validataion parameters passed to Interpreter.verify to detect soft-fork conditions
   * @param costLimit              hard limit on accumulated execution cost, if exceeded lead to CostLimitException to be thrown
   * @param initCost               initial value of execution cost already accumulated before Interpreter.verify is called
-  * @param activatedScriptVersion Maximum version of ErgoTree currently activated on the
-  * network. The activation is performed via miners voting.
+  * @param activatedScriptVersion Maximum version of ErgoTree currently activated on the network.
+  *                               The activation is performed via miners voting majority switches to higher version.
+  *                               For verification of *mined* blocks this parameter should  be passed according
+  *                               to the latest voted (activated) script version on the network.
+  *                               However this is not the case for *candidate* blocks.
+  *                               When `activatedScriptVersion > Interpreter.MaxSupportedScriptVersion`
+  *                               then the interpreter accept script without verification which is not
+  *                               what should happen for *candidate* blocks.
+  *                               This means Ergo node should always pass Interpreter.MaxSupportedScriptVersion
+  *                               as a value of ErgoLikeContext.activatedScriptVersion during
+  *                               verification of candidate blocks (which is a default).
   */
 class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
                       val headers: Coll[Header],
@@ -45,8 +54,9 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
                       val validationSettings: SigmaValidationSettings,
                       val costLimit: Long,
                       val initCost: Long,
-                      val activatedScriptVersion: Byte = 0
+                      val activatedScriptVersion: Byte = Interpreter.MaxSupportedScriptVersion
                  ) extends InterpreterContext {
+  // TODO lastBlockUtxoRoot should be calculated from headers if it is nonEmpty
 
   /* NOHF PROOF:
   Added: assert(preHeader != null)
@@ -96,30 +106,19 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
   val self: ErgoBox = boxesToSpend(selfIndex)
 
   override def withCostLimit(newCostLimit: Long): ErgoLikeContext =
-    new ErgoLikeContext(
-      lastBlockUtxoRoot, headers, preHeader,
-      dataBoxes, boxesToSpend, spendingTransaction, selfIndex, extension, validationSettings, newCostLimit, initCost)
+    ErgoLikeContext.copy(this)(costLimit = newCostLimit)
 
   override def withInitCost(newCost: Long): ErgoLikeContext =
-    new ErgoLikeContext(
-      lastBlockUtxoRoot, headers, preHeader,
-      dataBoxes, boxesToSpend, spendingTransaction, selfIndex, extension, validationSettings, costLimit, newCost)
+    ErgoLikeContext.copy(this)(initCost = newCost)
 
   override def withValidationSettings(newVs: SigmaValidationSettings): ErgoLikeContext =
-    new ErgoLikeContext(
-      lastBlockUtxoRoot, headers, preHeader,
-      dataBoxes, boxesToSpend, spendingTransaction, selfIndex, extension, newVs, costLimit, initCost)
+    ErgoLikeContext.copy(this)(validationSettings = newVs)
 
   override def withExtension(newExtension: ContextExtension): ErgoLikeContext =
-    new ErgoLikeContext(
-      lastBlockUtxoRoot, headers, preHeader,
-      dataBoxes, boxesToSpend, spendingTransaction, selfIndex, newExtension, validationSettings, costLimit, initCost)
+    ErgoLikeContext.copy(this)(extension = newExtension)
 
   def withTransaction(newSpendingTransaction: ErgoLikeTransactionTemplate[_ <: UnsignedInput]): ErgoLikeContext =
-    new ErgoLikeContext(
-      lastBlockUtxoRoot, headers, preHeader,
-      dataBoxes, boxesToSpend, newSpendingTransaction, selfIndex, extension, validationSettings, costLimit, initCost)
-
+    ErgoLikeContext.copy(this)(spendingTransaction = newSpendingTransaction)
 
   override def toSigmaContext(isCost: Boolean, extensions: Map[Byte, AnyValue] = Map()): sigma.Context = {
     import Evaluation._
@@ -167,14 +166,18 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
         extension == that.extension &&
         validationSettings == that.validationSettings &&
         costLimit == that.costLimit &&
-        initCost == that.initCost
+        initCost == that.initCost &&
+        activatedScriptVersion == that.activatedScriptVersion
     case _ => false
   }
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[ErgoLikeContext]
 
   override def hashCode(): Int = {
-    val state = Array(lastBlockUtxoRoot, headers, preHeader, dataBoxes, boxesToSpend, spendingTransaction, selfIndex, extension, validationSettings, costLimit, initCost)
+    val state = Array(
+      lastBlockUtxoRoot, headers, preHeader, dataBoxes, boxesToSpend, spendingTransaction,
+      selfIndex, extension, validationSettings, costLimit, initCost,
+      activatedScriptVersion)
     var hashCode = 0
     cfor(0)(_ < state.length, _ + 1) { i =>
       hashCode = 31 * hashCode + state(i).hashCode
@@ -182,7 +185,7 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
     hashCode
   }
 
-  override def toString = s"ErgoLikeContext(lastBlockUtxoRoot=$lastBlockUtxoRoot, headers=$headers, preHeader=$preHeader, dataBoxes=$dataBoxes, boxesToSpend=$boxesToSpend, spendingTransaction=$spendingTransaction, selfIndex=$selfIndex, extension=$extension, validationSettings=$validationSettings, costLimit=$costLimit, initCost=$initCost)"
+  override def toString = s"ErgoLikeContext(lastBlockUtxoRoot=$lastBlockUtxoRoot, headers=$headers, preHeader=$preHeader, dataBoxes=$dataBoxes, boxesToSpend=$boxesToSpend, spendingTransaction=$spendingTransaction, selfIndex=$selfIndex, extension=$extension, validationSettings=$validationSettings, costLimit=$costLimit, initCost=$initCost, activatedScriptVersion=$activatedScriptVersion)"
 }
 
 object ErgoLikeContext {
@@ -191,6 +194,28 @@ object ErgoLikeContext {
 
   /** Maximimum number of headers in `headers` collection of the context. */
   val MaxHeaders = SigmaConstants.MaxHeaders.value
+
+  /** Copies the given context allowing also to update fields.
+    * NOTE: it can be used ONLY for instances of ErgoLikeContext.
+    * @tparam T used here to limit use of this method to only ErgoLikeContext instances
+    * @return a new instance of [[ErgoLikeContext]]. */
+  @inline def copy[T >: ErgoLikeContext <: ErgoLikeContext](ctx: T)(
+      lastBlockUtxoRoot: AvlTreeData = ctx.lastBlockUtxoRoot,
+      headers: Coll[Header] = ctx.headers,
+      preHeader: PreHeader = ctx.preHeader,
+      dataBoxes: IndexedSeq[ErgoBox] = ctx.dataBoxes,
+      boxesToSpend: IndexedSeq[ErgoBox] = ctx.boxesToSpend,
+      spendingTransaction: ErgoLikeTransactionTemplate[_ <: UnsignedInput] = ctx.spendingTransaction,
+      selfIndex: Int = ctx.selfIndex,
+      extension: ContextExtension = ctx.extension,
+      validationSettings: SigmaValidationSettings = ctx.validationSettings,
+      costLimit: Long = ctx.costLimit,
+      initCost: Long = ctx.initCost,
+      activatedScriptVersion: Byte = ctx.activatedScriptVersion): ErgoLikeContext = {
+    new ErgoLikeContext(
+      lastBlockUtxoRoot, headers, preHeader, dataBoxes, boxesToSpend,
+      spendingTransaction, selfIndex, extension, validationSettings, costLimit, initCost, activatedScriptVersion)
+  }
 }
 
 /** When interpreted evaluates to a ByteArrayConstant built from Context.minerPubkey */

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -28,11 +28,11 @@ import spire.syntax.all.cfor
   * @param boxesToSpend           - boxes, that corresponds to id's of `spendingTransaction.inputs`
   * @param spendingTransaction    - transaction that contains `self` box
   * @param extension              - prover-defined key-value pairs, that may be used inside a script
-  * @param validationSettings     validataion parameters passed to Interpreter.verify to detect soft-fork conditions
+  * @param validationSettings     validation parameters passed to Interpreter.verify to detect soft-fork conditions
   * @param costLimit              hard limit on accumulated execution cost, if exceeded lead to CostLimitException to be thrown
   * @param initCost               initial value of execution cost already accumulated before Interpreter.verify is called
   * @param activatedScriptVersion Maximum version of ErgoTree currently activated on the network.
-  *                               The activation is performed via miners voting majority switches to higher version.
+  *                               The activation is performed via miners voting.
   *                               For verification of *mined* blocks this parameter should  be passed according
   *                               to the latest voted (activated) script version on the network.
   *                               However this is not the case for *candidate* blocks.

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -19,18 +19,20 @@ import spire.syntax.all.cfor
 /**
   * TODO lastBlockUtxoRoot should be calculated from headers if it is nonEmpty
   *
-  * @param selfIndex           - index of the box in `boxesToSpend` that contains the script we're evaluating
-  * @param lastBlockUtxoRoot   - state root before current block application
-  * @param headers             - fixed number of last block headers in descending order (first header is the newest one)
-  * @param preHeader           - fields of block header with the current `spendingTransaction`, that can be predicted
-  *                            by a miner before it's formation
-  * @param dataBoxes           -  boxes, that corresponds to id's of `spendingTransaction.dataInputs`
-  * @param boxesToSpend        - boxes, that corresponds to id's of `spendingTransaction.inputs`
-  * @param spendingTransaction - transaction that contains `self` box
-  * @param extension           - prover-defined key-value pairs, that may be used inside a script
-  * @param validationSettings  validataion parameters passed to Interpreter.verify to detect soft-fork conditions
-  * @param costLimit           hard limit on accumulated execution cost, if exceeded lead to CostLimitException to be thrown
-  * @param initCost            initial value of execution cost already accumulated before Interpreter.verify is called
+  * @param selfIndex              - index of the box in `boxesToSpend` that contains the script we're evaluating
+  * @param lastBlockUtxoRoot      - state root before current block application
+  * @param headers                - fixed number of last block headers in descending order (first header is the newest one)
+  * @param preHeader              - fields of block header with the current `spendingTransaction`, that can be predicted
+  *                               by a miner before it's formation
+  * @param dataBoxes              -  boxes, that corresponds to id's of `spendingTransaction.dataInputs`
+  * @param boxesToSpend           - boxes, that corresponds to id's of `spendingTransaction.inputs`
+  * @param spendingTransaction    - transaction that contains `self` box
+  * @param extension              - prover-defined key-value pairs, that may be used inside a script
+  * @param validationSettings     validataion parameters passed to Interpreter.verify to detect soft-fork conditions
+  * @param costLimit              hard limit on accumulated execution cost, if exceeded lead to CostLimitException to be thrown
+  * @param initCost               initial value of execution cost already accumulated before Interpreter.verify is called
+  * @param activatedScriptVersion Maximum version of ErgoTree currently activated on the
+  * network. The activation is performed via miners voting.
   */
 class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
                       val headers: Coll[Header],
@@ -42,7 +44,8 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
                       val extension: ContextExtension,
                       val validationSettings: SigmaValidationSettings,
                       val costLimit: Long,
-                      val initCost: Long
+                      val initCost: Long,
+                      val activatedScriptVersion: Byte = 0
                  ) extends InterpreterContext {
 
   /* NOHF PROOF:

--- a/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/validation/ValidationRules.scala
@@ -76,6 +76,12 @@ case class ValidationException(message: String, rule: ValidationRule, args: Seq[
   override def fillInStackTrace(): Throwable = this  // to avoid spending time on recording stack trace
 }
 
+/** All validation rules which are used to check soft-forkable conditions. Each validation
+  * rule throws a [[org.ergoplatform.validation.ValidationException]]. Each
+  * ValidationException can be caught and handled with respect to
+  * [[SigmaValidationSettings]], which can be changed by miners via voting.
+  * Thus, the behavior of the rules can be overridden without breaking consensus.
+  */
 object ValidationRules {
   /** The id of the first validation rule. Can be used as the beginning of the rules id range. */
   val FirstRuleId = 1000.toShort

--- a/sigmastate/src/main/scala/sigmastate/Values.scala
+++ b/sigmastate/src/main/scala/sigmastate/Values.scala
@@ -1043,9 +1043,20 @@ object Values {
     /** Default header with constant segregation enabled. */
     val ConstantSegregationHeader: Byte = (DefaultHeader | ConstantSegregationFlag).toByte
 
+    /** @return true if the constant segregation flag is set to 1 in the given header byte. */
     @inline final def isConstantSegregation(header: Byte): Boolean = (header & ConstantSegregationFlag) != 0
+
+    /** @return true if the size flag is set to 1 in the given header byte. */
     @inline final def hasSize(header: Byte): Boolean = (header & SizeFlag) != 0
+
+    /** @return a value of the version bits from the given header byte. */
     @inline final def getVersion(header: Byte): Byte = (header & VersionMask).toByte
+
+    /** Update the version bits of the given header byte with the given version value. */
+    @inline final def updateVersionBits(header: Byte, version: Byte): Byte = {
+      require(version < 8, s"ErgoTree.version should be < 8: $version")
+      (header | version).toByte
+    }
 
     def substConstants(root: SValue, constants: IndexedSeq[Constant[SType]]): SValue = {
       val store = new ConstantStore(constants)

--- a/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -195,11 +195,12 @@ trait Interpreter extends ScorexLogging {
   def fullReduction(ergoTree: ErgoTree,
                     context: CTX,
                     env: ScriptEnv): (SigmaBoolean, Long) = {
+    // TODO v5.0: the condition below should be revised if necessary
     // The following conditions define behavior which depend on the version of ergoTree
     // This works in addition to more fine-grained soft-forkabiltiy mechanism implemented
     // using ValidationRules (see trySoftForkable method call here and in reduceToCrypto).
     if (context.activatedScriptVersion > Interpreter.MaxSupportedScriptVersion) {
-      // majority has already switched to higher version, accept without verification
+      // > 90% has already switched to higher version, accept without verification
       // NOTE: this path should never be taken for validation of candidate blocks
       // in which case Ergo node should always pass Interpreter.MaxSupportedScriptVersion
       // as the value of ErgoLikeContext.activatedScriptVersion.

--- a/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -195,6 +195,8 @@ trait Interpreter extends ScorexLogging {
   def fullReduction(ergoTree: ErgoTree,
                     context: CTX,
                     env: ScriptEnv): (SigmaBoolean, Long) = {
+    if (context.activatedScriptVersion > Interpreter.MaxSupportedScriptVersion) {
+    }
     implicit val vs: SigmaValidationSettings = context.validationSettings
 
     val initCost = JMath.addExact(ergoTree.complexity.toLong, context.initCost)
@@ -345,6 +347,14 @@ object Interpreter {
   type ScriptEnv = Map[String, Any]
   val emptyEnv: ScriptEnv = Map.empty[String, Any]
   val ScriptNameProp = "ScriptName"
+
+  /** Maximum version of ErgoTree supported by this interpreter release.
+    * See version bits in `ErgoTree.header` for more details.
+    * This value should be increased with each new language update via soft-fork.
+    * For example in version 3.x-4.x this value should be 0, in 5.x increased to 1,
+    * in 6.x set to 2, etc.
+    */
+  val MaxSupportedScriptVersion: Int = 0
 
   def error(msg: String) = throw new InterpreterException(msg)
 

--- a/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/Interpreter.scala
@@ -196,6 +196,10 @@ trait Interpreter extends ScorexLogging {
                     context: CTX,
                     env: ScriptEnv): (SigmaBoolean, Long) = {
     if (context.activatedScriptVersion > Interpreter.MaxSupportedScriptVersion) {
+
+    } else {
+      if (ergoTree.version > context.activatedScriptVersion)
+        throw new InterpreterException(s"Not supported script version ${ergoTree.version}")
     }
     implicit val vs: SigmaValidationSettings = context.validationSettings
 

--- a/sigmastate/src/main/scala/sigmastate/interpreter/InterpreterContext.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/InterpreterContext.scala
@@ -53,7 +53,7 @@ trait InterpreterContext {
   /** Prover-defined key-value pairs, that may be used inside a script. */
   val extension: ContextExtension
 
-  /** Validataion parameters passed to Interpreter.verify to detect soft-fork conditions. */
+  /** Validation parameters passed to Interpreter.verify to detect soft-fork conditions. */
   val validationSettings: SigmaValidationSettings
 
   /** Hard limit on accumulated execution cost. Exceeding it leads to CostLimitException

--- a/sigmastate/src/main/scala/sigmastate/interpreter/InterpreterContext.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/InterpreterContext.scala
@@ -10,9 +10,15 @@ import special.sigma
 import special.sigma.AnyValue
 
 /**
-  * User-defined variables to be put into context
+  * User-defined variables to be put into context.
+  * Each variable is identified by `id: Byte` and can be accessed from a script
+  * using `getVar[T](id)` operation.
+  * The value of the variable is represented by [[sigmastate.Values.Constant]] instance,
+  * which contains both data value and [[SType]] descriptor. The descriptor is checked
+  * against the type `T` expected in the script operation. If the types don't match,
+  * exception is thrown and the box spending (protected by the script) fails.
   *
-  * @param values - key-value pairs
+  * @param values internal container of the key-value pairs
   */
 case class ContextExtension(values: Map[Byte, EvaluatedValue[_ <: SType]]) {
   def add(bindings: (Byte, EvaluatedValue[_ <: SType])*): ContextExtension =
@@ -40,11 +46,34 @@ object ContextExtension {
 }
 
 
+/** Base class of the context passed to verifier and prover.
+  * @see [[sigmastate.interpreter.Interpreter]]
+  */
 trait InterpreterContext {
+  /** Prover-defined key-value pairs, that may be used inside a script. */
   val extension: ContextExtension
+
+  /** Validataion parameters passed to Interpreter.verify to detect soft-fork conditions. */
   val validationSettings: SigmaValidationSettings
+
+  /** Hard limit on accumulated execution cost. Exceeding it leads to CostLimitException
+    * to be thrown.
+    */
   val costLimit: Long
+
+  /** Initial value of execution cost already accumulated before `Interpreter.verify`(or
+    * `prove`) is called.
+    */
   val initCost: Long
+
+  /** Maximum version of ErgoTree currently activated on the network. The activation is
+    * performed via miners voting.
+    * The maximum version supported by the interpreter is defined by
+    * `Interpreter.MaxSupportedScriptVersion`. As a result, the execution of the
+    * `Interpreter.verify` and `Interpreter.prove` methods depend on the relation between
+    * max supported and activated version. (see docs/aot-jit-switch.md).
+    */
+  def activatedScriptVersion: Byte
 
   /** Creates a new instance with costLimit updated with given value. */
   def withCostLimit(newCostLimit: Long): InterpreterContext

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -1,14 +1,20 @@
 package sigmastate
 
+import org.ergoplatform.ErgoBox.AdditionalRegisters
 import org.ergoplatform._
 import scorex.util.ModifierId
+import sigmastate.Values.ErgoTree.{DefaultHeader, updateVersionBits, SizeFlag}
 import sigmastate.Values._
-import sigmastate.basics.ProveDHTuple
 import sigmastate.eval._
+import sigmastate.helpers.ErgoLikeContextTesting
+import sigmastate.helpers.TestingHelpers.createBox
+import sigmastate.interpreter.Interpreter
+import sigmastate.lang.exceptions.InterpreterException
 import sigmastate.utxo._
+import sigmastate.utils.Helpers._
 import special.collection._
-import sigmastate.utils.Helpers
 import special.sigma.{SigmaDslTesting, Box}
+import sigmastate.helpers.TestingHelpers._
 
 import scala.util.Success
 
@@ -17,64 +23,29 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
   override implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 30)
   implicit def IR = createIR()
 
+  val b1 = CostingBox(
+    false,
+    new ErgoBox(
+      1L,
+      new ErgoTree(
+        0.toByte,
+        Vector(),
+        Right(BoolToSigmaProp(OR(ConcreteCollection(Array(FalseLeaf, AND(ConcreteCollection(Array(FalseLeaf, FalseLeaf), SBoolean))), SBoolean))))
+      ),
+      Coll(),
+      Map(),
+      ModifierId @@ ("008677ffff7ff36dff00f68031140400007689ff014c9201ce8000a9ffe6ceff"),
+      32767.toShort,
+      32827
+    )
+  )
+
   /** Rule#| SF Status| Block Type| Script Version | Release | Validation Action
     * -----|----------|-----------|----------------|---------|--------
     * 1    | inactive | candidate | Script v1      | v4.0    | R4.0-AOT-cost, R4.0-AOT-verify
     */
   property("Rule 1 | inactive SF | candidate block | Script v1") {
     val samples = genSamples[Coll[Box]](collOfN[Box](5), MinSuccessful(20))
-    val b1 = CostingBox(
-      false,
-      new ErgoBox(
-        1L,
-        new ErgoTree(
-          0.toByte,
-          Vector(),
-          Right(
-            SigmaPropConstant(
-              CSigmaProp(
-                ProveDHTuple(
-                  Helpers.decodeECPoint("02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b"),
-                  Helpers.decodeECPoint("027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e419"),
-                  Helpers.decodeECPoint("0257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281"),
-                  Helpers.decodeECPoint("033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd5")
-                )
-              )
-            )
-          )
-        ),
-        Coll(),
-        Map(
-          ErgoBox.R4 -> ByteArrayConstant(
-            Helpers.decodeBytes(
-              "7200004cccdac3008001bc80ffc7ff9633bca3e501801380ff007900019d7f0001a8c9dfff5600d964011617ca00583f989c7f80007fee7f99b07f7f870067dc315180828080307fbdf400"
-            )
-          ),
-          ErgoBox.R7 -> LongConstant(0L),
-          ErgoBox.R6 -> FalseLeaf,
-          ErgoBox.R5 -> ByteArrayConstant(Helpers.decodeBytes("7f"))
-        ),
-        ModifierId @@ ("7dffff48ab0000c101a2eac9ff17017f6180aa7fc6f2178000800179499380a5"),
-        21591.toShort,
-        638768
-      )
-    )
-    val b2 = CostingBox(
-      false,
-      new ErgoBox(
-        1000000000L,
-        new ErgoTree(
-          0.toByte,
-          Vector(),
-          Right(BoolToSigmaProp(OR(ConcreteCollection(Array(FalseLeaf, AND(ConcreteCollection(Array(FalseLeaf, FalseLeaf), SBoolean))), SBoolean))))
-        ),
-        Coll(),
-        Map(),
-        ModifierId @@ ("008677ffff7ff36dff00f68031140400007689ff014c9201ce8000a9ffe6ceff"),
-        32767.toShort,
-        32827
-      )
-    )
 
     verifyCases(
       {
@@ -82,7 +53,6 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
         Seq(
           (Coll[Box](), success(Coll[Box](), 37297)),
           (Coll[Box](b1), success(Coll[Box](), 37397)),
-          (Coll[Box](b1, b2), success(Coll[Box](b2), 37537))
         )
       },
       existingFeature({ (x: Coll[Box]) => x.filter({ (b: Box) => b.value > 1 }) },
@@ -97,4 +67,69 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
       preGeneratedSamples = Some(samples))
 
   }
+
+  def createErgoTree(headerFlags: Byte)(implicit IR: IRContext): ErgoTree = {
+    import ErgoTree._
+    val code =
+      s"""{
+        |  val func = { (x: Coll[Box]) => x.filter({(b: Box) => b.value > 1 }) }
+        |  val v = func(getVar[Coll[Box]](1).get)
+        |  val r = SELF.R4[Coll[Box]].get
+        |  sigmaProp(v == r)
+        |}
+      """.stripMargin
+    val env = Interpreter.emptyEnv
+
+    // The following ops are performed by frontend: typecheck, create graphs, compile to Tree
+    val compiledTree = {
+      val internalProp = compiler.typecheck(env, code)
+      val costingRes = getCostingResult(env, internalProp)(IR)
+      val calcF = costingRes.calcF
+      val tree = IR.buildTree(calcF)
+      tree
+    }
+    ErgoTree.withSegregation(headerFlags, compiledTree)
+  }
+
+  def testProve(ergoTree: ErgoTree, activatedScriptVersion: Byte) = {
+    val tpeA = SCollection(SBox)
+    val input = Coll[Box](b1)
+    val newRegisters: AdditionalRegisters = Map(
+      ErgoBox.R4 -> Constant[SType](Coll[Box]().asInstanceOf[SType#WrappedType], tpeA)
+    )
+
+    val ctx = copyContext(ErgoLikeContextTesting.dummy(
+      createBox(0, ergoTree, additionalRegisters = newRegisters)
+    ).withBindings(
+      1.toByte -> Constant[SType](input.asInstanceOf[SType#WrappedType], tpeA),
+    ).asInstanceOf[ErgoLikeContext])(activatedScriptVersion = activatedScriptVersion)
+    val prover = new FeatureProvingInterpreter()
+    val pr = prover.prove(ergoTree, ctx, fakeMessage).getOrThrow
+    pr
+  }
+
+  /** Rule#| SF Status| Block Type| Script Version | Release | Validation Action
+    * -----|----------|-----------|----------------|---------|--------
+    * 3    | inactive | candidate | Script v2      | v4.0    | skip-pool-tx (cannot handle)
+    */
+  property("Rule 3 | inactive SF | candidate block | Script v2") {
+
+    assertExceptionThrown(
+      createErgoTree(headerFlags = updateVersionBits(DefaultHeader, 1)),
+      { t =>
+        t.isInstanceOf[IllegalArgumentException] &&
+        t.getMessage.contains("For newer version the size bit is required")
+      })
+
+    val headerFlags = ErgoTree.SizeFlag | updateVersionBits(DefaultHeader, 1 /* Script v2 */)
+    val ergoTree = createErgoTree(headerFlags = headerFlags.toByte)
+    
+    assertExceptionThrown(
+      testProve(ergoTree, activatedScriptVersion = 0 /* SF Status: inactive */),
+      { t =>
+        t.isInstanceOf[InterpreterException] &&
+        t.getMessage.contains(s"Not supported script version ${ergoTree.version}")
+      })
+  }
+
 }

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -1,0 +1,100 @@
+package sigmastate
+
+import org.ergoplatform._
+import scorex.util.ModifierId
+import sigmastate.Values._
+import sigmastate.basics.ProveDHTuple
+import sigmastate.eval._
+import sigmastate.utxo._
+import special.collection._
+import sigmastate.utils.Helpers
+import special.sigma.{SigmaDslTesting, Box}
+
+import scala.util.Success
+
+/** Specification to verify that the interpreter behaves according to docs/aot-jit-switch.md. */
+class ScriptVersionSwitchSpecification extends SigmaDslTesting {
+  override implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 30)
+  implicit def IR = createIR()
+
+  /** Rule#| SF Status| Block Type| Script Version | Release | Validation Action
+    * -----|----------|-----------|----------------|---------|--------
+    * 1    | inactive | candidate | Script v1      | v4.0    | R4.0-AOT-cost, R4.0-AOT-verify
+    */
+  property("Rule 1 | inactive SF | candidate block | Script v1") {
+    val samples = genSamples[Coll[Box]](collOfN[Box](5), MinSuccessful(20))
+    val b1 = CostingBox(
+      false,
+      new ErgoBox(
+        1L,
+        new ErgoTree(
+          0.toByte,
+          Vector(),
+          Right(
+            SigmaPropConstant(
+              CSigmaProp(
+                ProveDHTuple(
+                  Helpers.decodeECPoint("02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b"),
+                  Helpers.decodeECPoint("027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e419"),
+                  Helpers.decodeECPoint("0257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281"),
+                  Helpers.decodeECPoint("033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd5")
+                )
+              )
+            )
+          )
+        ),
+        Coll(),
+        Map(
+          ErgoBox.R4 -> ByteArrayConstant(
+            Helpers.decodeBytes(
+              "7200004cccdac3008001bc80ffc7ff9633bca3e501801380ff007900019d7f0001a8c9dfff5600d964011617ca00583f989c7f80007fee7f99b07f7f870067dc315180828080307fbdf400"
+            )
+          ),
+          ErgoBox.R7 -> LongConstant(0L),
+          ErgoBox.R6 -> FalseLeaf,
+          ErgoBox.R5 -> ByteArrayConstant(Helpers.decodeBytes("7f"))
+        ),
+        ModifierId @@ ("7dffff48ab0000c101a2eac9ff17017f6180aa7fc6f2178000800179499380a5"),
+        21591.toShort,
+        638768
+      )
+    )
+    val b2 = CostingBox(
+      false,
+      new ErgoBox(
+        1000000000L,
+        new ErgoTree(
+          0.toByte,
+          Vector(),
+          Right(BoolToSigmaProp(OR(ConcreteCollection(Array(FalseLeaf, AND(ConcreteCollection(Array(FalseLeaf, FalseLeaf), SBoolean))), SBoolean))))
+        ),
+        Coll(),
+        Map(),
+        ModifierId @@ ("008677ffff7ff36dff00f68031140400007689ff014c9201ce8000a9ffe6ceff"),
+        32767.toShort,
+        32827
+      )
+    )
+
+    verifyCases(
+      {
+        def success[T](v: T, c: Int) = Success(Expected(v, c))
+        Seq(
+          (Coll[Box](), success(Coll[Box](), 37297)),
+          (Coll[Box](b1), success(Coll[Box](), 37397)),
+          (Coll[Box](b1, b2), success(Coll[Box](b2), 37537))
+        )
+      },
+      existingFeature({ (x: Coll[Box]) => x.filter({ (b: Box) => b.value > 1 }) },
+      "{ (x: Coll[Box]) => x.filter({(b: Box) => b.value > 1 }) }",
+      FuncValue(
+        Vector((1, SCollectionType(SBox))),
+        Filter(
+          ValUse(1, SCollectionType(SBox)),
+          FuncValue(Vector((3, SBox)), GT(ExtractAmount(ValUse(3, SBox)), LongConstant(1L)))
+        )
+      )),
+      preGeneratedSamples = Some(samples))
+
+  }
+}

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -177,7 +177,9 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
     val headerFlags = ergoTreeHeader( 0 /* Script v1 */)
     val ergoTree = createErgoTree(headerFlags = headerFlags)
 
-    val activatedVersion = 1.toByte // SF Status: active
+    // Even though the SF is active and the v2 scripts can be accepted in `mined` blocks
+    // this test case is for `candidate` block, so we MUST use
+    // Interpreter.MaxSupportedScriptVersion
 
     // both prove and verify are accepting with full evaluation
     val expectedCost = 5464L

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -52,7 +52,7 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
         def success[T](v: T, c: Int) = Success(Expected(v, c))
         Seq(
           (Coll[Box](), success(Coll[Box](), 37297)),
-          (Coll[Box](b1), success(Coll[Box](), 37397)),
+          (Coll[Box](b1), success(Coll[Box](), 37397))
         )
       },
       existingFeature({ (x: Coll[Box]) => x.filter({ (b: Box) => b.value > 1 }) },
@@ -101,7 +101,7 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
     val ctx = copyContext(ErgoLikeContextTesting.dummy(
       createBox(0, ergoTree, additionalRegisters = newRegisters)
     ).withBindings(
-      1.toByte -> Constant[SType](input.asInstanceOf[SType#WrappedType], tpeA),
+      1.toByte -> Constant[SType](input.asInstanceOf[SType#WrappedType], tpeA)
     ).asInstanceOf[ErgoLikeContext])(activatedScriptVersion = activatedScriptVersion)
     val prover = new FeatureProvingInterpreter()
     val pr = prover.prove(ergoTree, ctx, fakeMessage).getOrThrow

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -125,7 +125,7 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
 
     verifyCases(
       {
-        def success[T](v: T, c: Int) = Success(Expected(v, c))
+        def success[T](v: T, c: Int) = Expected(Success(v), c)
         Seq(
           (Coll[Box](), success(Coll[Box](), 37297)),
           (Coll[Box](b1), success(Coll[Box](), 37397))

--- a/sigmastate/src/test/scala/sigmastate/helpers/NegativeTesting.scala
+++ b/sigmastate/src/test/scala/sigmastate/helpers/NegativeTesting.scala
@@ -14,7 +14,7 @@ trait NegativeTesting extends Matchers {
   def assertExceptionThrown(fun: => Any, assertion: Throwable => Boolean, clue: => String = ""): Unit = {
     try {
       fun
-      fail("exception is expected")
+      fail("exception is expected but hasn't been thrown")
     }
     catch {
       case e: Throwable =>

--- a/sigmastate/src/test/scala/sigmastate/helpers/TestingHelpers.scala
+++ b/sigmastate/src/test/scala/sigmastate/helpers/TestingHelpers.scala
@@ -68,10 +68,11 @@ object TestingHelpers {
       extension: ContextExtension = ctx.extension,
       validationSettings: SigmaValidationSettings = ctx.validationSettings,
       costLimit: Long = ctx.costLimit,
-      initCost: Long = ctx.initCost): ErgoLikeContext = {
+      initCost: Long = ctx.initCost,
+      activatedScriptVersion: Byte = ctx.activatedScriptVersion): ErgoLikeContext = {
     new ErgoLikeContext(
       lastBlockUtxoRoot, headers, preHeader, dataBoxes, boxesToSpend,
-      spendingTransaction, selfIndex, extension, validationSettings, costLimit, initCost)
+      spendingTransaction, selfIndex, extension, validationSettings, costLimit, initCost, activatedScriptVersion)
   }
 
   /** Creates a new box by updating some of the additional registers with the given new bindings.


### PR DESCRIPTION
Closes #637 
Introduces hard-forking features necessary for AOT -> JIT switch, as a result, this PR should be merged into 
develop only as part of v4.0-RC .

PR implements [validation checks](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/develop/docs/aot-jit-switch.md) performed by v4.0 release (see specification test cases).
The new checks are designed to support future v5.0 soft-fork.