### PR TITLE
Preparation refactoring towards v5.0 (part 2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,6 @@ val debox              = "org.spire-math" %% "debox" % "0.8.0"
 val kiama              = "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.1.0"
 val fastparse          = "com.lihaoyi" %% "fastparse" % "1.0.0"
 val commonsIo          = "commons-io" % "commons-io" % "2.5"
-val commonsMath3       = "org.apache.commons" % "commons-math3" % "3.2"
 
 val specialVersion = "0.6.1"
 val meta        = "io.github.scalan" %% "meta" % specialVersion
@@ -257,7 +256,7 @@ lazy val sigmastate = (project in file("sigmastate"))
   .dependsOn(sigmaimpl % allConfigDependency, sigmalibrary % allConfigDependency)
   .settings(libraryDefSettings)
   .settings(libraryDependencies ++= Seq(
-    scorexUtil, kiama, fastparse, commonsMath3,
+    scorexUtil, kiama, fastparse,
     if (scalaVersion.value == scala211) circeCore211 else circeCore,
     if (scalaVersion.value == scala211) circeGeneric211 else circeGeneric,
     if (scalaVersion.value == scala211) circeParser211 else circeParser

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ val debox              = "org.spire-math" %% "debox" % "0.8.0"
 val kiama              = "org.bitbucket.inkytonik.kiama" %% "kiama" % "2.1.0"
 val fastparse          = "com.lihaoyi" %% "fastparse" % "1.0.0"
 val commonsIo          = "commons-io" % "commons-io" % "2.5"
+val commonsMath3       = "org.apache.commons" % "commons-math3" % "3.2"
 
 val specialVersion = "0.6.1"
 val meta        = "io.github.scalan" %% "meta" % specialVersion
@@ -256,7 +257,7 @@ lazy val sigmastate = (project in file("sigmastate"))
   .dependsOn(sigmaimpl % allConfigDependency, sigmalibrary % allConfigDependency)
   .settings(libraryDefSettings)
   .settings(libraryDependencies ++= Seq(
-    scorexUtil, kiama, fastparse,
+    scorexUtil, kiama, fastparse, commonsMath3,
     if (scalaVersion.value == scala211) circeCore211 else circeCore,
     if (scalaVersion.value == scala211) circeGeneric211 else circeGeneric,
     if (scalaVersion.value == scala211) circeParser211 else circeParser

--- a/common/src/main/scala/scalan/AnyVals.scala
+++ b/common/src/main/scala/scalan/AnyVals.scala
@@ -43,6 +43,16 @@ class AVHashMap[K,V](val hashMap: HashMap[K,V]) extends AnyVal {
   @inline final def keySet: java.util.Set[K] = hashMap.keySet()
 }
 object AVHashMap {
+  /** Helper method to create a new map with the given capacity. */
   def apply[K,V](initialCapacity: Int) = new AVHashMap[K,V](new HashMap[K,V](initialCapacity))
+
+  /** Helper method to create a new map form sequence of K, V pairs. */
+  def fromSeq[K,V](items: Seq[(K, V)]): AVHashMap[K,V] = {
+    val map = new AVHashMap[K,V](new HashMap[K,V](items.length))
+    items.foreach { case (k, v) =>
+      map.put(k, v)
+    }
+    map
+  }
 }
 

--- a/common/src/main/scala/scalan/AnyVals.scala
+++ b/common/src/main/scala/scalan/AnyVals.scala
@@ -45,14 +45,5 @@ class AVHashMap[K,V](val hashMap: HashMap[K,V]) extends AnyVal {
 object AVHashMap {
   /** Helper method to create a new map with the given capacity. */
   def apply[K,V](initialCapacity: Int) = new AVHashMap[K,V](new HashMap[K,V](initialCapacity))
-
-  /** Helper method to create a new map form sequence of K, V pairs. */
-  def fromSeq[K,V](items: Seq[(K, V)]): AVHashMap[K,V] = {
-    val map = new AVHashMap[K,V](new HashMap[K,V](items.length))
-    items.foreach { case (k, v) =>
-      map.put(k, v)
-    }
-    map
-  }
 }
 

--- a/common/src/main/scala/scalan/util/BenchmarkUtil.scala
+++ b/common/src/main/scala/scalan/util/BenchmarkUtil.scala
@@ -31,6 +31,15 @@ object BenchmarkUtil {
     (res, t - t0)
   }
 
+  /** Execute block and measure the time of its execution in nanoseconds. */
+  def measureTimeNano[T](block: => T): (T, Long) = {
+    val start = System.nanoTime()
+    val res = block
+    val end = System.nanoTime()
+    (res, end - start)
+  }
+
+  
   def runTasks(nTasks: Int)(block: Int => Unit) = {
     val (_, total) = measureTime {
       val tasks = (1 to nTasks).map(iTask => Future(block(iTask)))

--- a/common/src/main/scala/scalan/util/BenchmarkUtil.scala
+++ b/common/src/main/scala/scalan/util/BenchmarkUtil.scala
@@ -39,7 +39,7 @@ object BenchmarkUtil {
     (res, end - start)
   }
 
-  
+
   def runTasks(nTasks: Int)(block: Int => Unit) = {
     val (_, total) = measureTime {
       val tasks = (1 to nTasks).map(iTask => Future(block(iTask)))

--- a/common/src/test/scala/scalan/TestUtils.scala
+++ b/common/src/test/scala/scalan/TestUtils.scala
@@ -3,6 +3,7 @@ package scalan
 import scalan.util.FileUtil
 import org.scalactic.TripleEquals
 import org.scalatest.{Inside, Matchers, TestSuite}
+import scalan.util.StringUtil.StringUtilExtensions
 
 /**
   * Created by slesarenko on 11/10/2017.
@@ -35,8 +36,8 @@ trait TestUtils extends TestSuite with Matchers with Inside with TripleEquals {
 
   protected def currentTestName: String = {
     val testName = _currentTestName.get()
-    assert(testName != null, "currentTestName called outside a test")
-    testName
+    if (testName.isNullOrEmpty) "_outside_tests_"
+    else testName
   }
 
   protected def currentTestNameAsFileName: String = FileUtil.cleanFileName(currentTestName)

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -417,12 +417,14 @@ class Option[A] {
   def isDefined: Boolean;
   
   /** Returns the option's value if the option is nonempty, otherwise
-   * return the result of evaluating `default`.
-   *
-   * @param default  the default expression, which is evaluated only if option is None.
-   */
-  def getOrElse[B](default: => B): B
-  
+    * return the result of evaluating `default`.
+    * NOTE: the `default` is evaluated even if the option contains the value
+    * i.e. not lazily.
+    *
+    * @param default  the default expression.
+    */
+  def getOrElse[B](default: B): B  
+
   /** Returns the option's value.
    *  @note The option must be nonempty.
    *  @throws InterpreterException if the option is empty.
@@ -883,7 +885,62 @@ def longToByteArray(input: Long): Coll[Byte]
 def decodePoint(bytes: Coll[Byte]): GroupElement 
 
 
-/** Returns value of the given type from the context by its tag.*/
+/** Extracts Context variable by id and type.
+  * ErgoScript is typed, so accessing a the variables is an operation which involves
+  * some expected type given in brackets. Thus `getVar[Int](id)` expression should
+  * evaluate to a valid value of the `Option[Int]` type.
+  *
+  * For example `val x = getVar[Int](10)` expects the variable, if it is present, to have
+  * type `Int`. At runtime the corresponding type descriptor is passed as `cT`
+  * parameter.
+  *
+  * There are three cases:
+  * 1) If the variable doesn't exist.
+  *   Then `val x = getVar[Int](id)` succeeds and returns the None value, which conforms to
+  *   any value of type `Option[T]` for any T. (In the example above T is equal to
+  *   `Int`). Calling `x.get` fails when x is equal to None, but `x.isDefined`
+  *   succeeds and returns `false`.
+  * 2) If the variable contains a value `v` of type `Int`.
+  *   Then `val x = getVar[Int](id)` succeeds and returns `Some(v)`, which is a valid value
+  *   of type `Option[Int]`. In this case, calling `x.get` succeeds and returns the
+  *   value `v` of type `Int`. Calling `x.isDefined` returns `true`.
+  * 3) If the variable contains a value `v` of type T other then `Int`.
+  *   Then `val x = getVar[Int](id)` fails, because there is no way to return a valid value
+  *   of type `Option[Int]`. The value of variable is present, so returning it as None
+  *   would break the typed semantics of variables collection.
+  *
+  * In some use cases one variable may have values of different types. To access such
+  * variable an additional variable can be used as a tag.
+  *
+  * <pre class="stHighlight">
+  *   val tagOpt = getVar[Int](id)
+  *   val res = if (tagOpt.isDefined) {
+  *     val tag = tagOpt.get
+  *     if (tag == 1) {
+  *       val x = getVar[Int](id2).get
+  *       // compute res using value x is of type Int
+  *     } else if (tag == 2) {
+  *       val x = getVar[GroupElement](id2).get
+  *       // compute res using value x is of type GroupElement
+  *     } else if (tag == 3) {
+  *       val x = getVar[ Array[Byte] ](id2).get
+  *       // compute res using value x of type Array[Byte]
+  *     } else {
+  *       // compute `res` when `tag` is not 1, 2 or 3
+  *     }
+  *   }
+  *   else {
+  *     // compute value of res when the variable is not present
+  *   }
+  * </pre>
+  *
+  * @param id zero-based identifier of the variable.
+  * @tparam T expected type of the variable.
+  * @return Some(value) if the variable is defined in the context AND has the given type.
+  *         None otherwise
+  * @throws special.sigma.InvalidType exception when the type of the variable value is
+  *                                   different from cT.
+  */
 def getVar[T](tag: Int): Option[T]
 
 /** Construct a new SigmaProp value representing public key of Diffie Hellman signature protocol. 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,3 +1,4 @@
+
 ## Approximate sizes of different dependencies
 
 These dependencies can be removed with simple refactoring

--- a/library-api/src/main/scala/special/collection/Colls.scala
+++ b/library-api/src/main/scala/special/collection/Colls.scala
@@ -61,17 +61,6 @@ trait Coll[@specialized A] {
     */
   def isDefinedAt(idx: Int): Boolean
 
-  /** The elements at given indexes.
-    *  Indices start at `0` so that `xs.apply(0)` is the first element of collection `xs`.
-    *  Note the indexing syntax `xs(i)` is a shorthand for `xs.apply(i)`.
-    *
-    *  @param  indexes   the indexes of the elements to extract from this collection
-    *  @return       the elements at the given indexes
-    *  @throws       ArrayIndexOutOfBoundsException if `i < 0` or `length <= i`
-    *                                               for any `i` in `indexes`
-    */
-//  def applyMany(indexes: Coll[Int]): Coll[A]
-
   /** The element of the collection or default value.
     * If an index is out of bounds (`i < 0 || i >= length`) then `default` value is returned.
     * @param   i   the index
@@ -117,7 +106,7 @@ trait Coll[@specialized A] {
   /** Applies a binary operator to a start value and all elements of this collection,
     *  going left to right.
     *
-    *  @param   z    the start value.
+    *  @param   zero    the start value.
     *  @param   op   the binary operator.
     *  @tparam  B    the result type of the binary operator.
     *  @return  the result of inserting `op` between consecutive elements of this collection,
@@ -125,7 +114,7 @@ trait Coll[@specialized A] {
     *           {{{
     *             op(...op(z, x_1), x_2, ..., x_n)
     *           }}}
-    *           where `x,,1,,, ..., x,,n,,` are the elements of this collection.
+    *           where `x_1, ..., x_n` are the elements of this collection.
     *           Returns `z` if this collection is empty.
     */
   def foldLeft[B](zero: B, op: ((B, A)) => B): B

--- a/sigma-api/src/main/scala/special/sigma/SigmaDsl.scala
+++ b/sigma-api/src/main/scala/special/sigma/SigmaDsl.scala
@@ -3,9 +3,12 @@ package special.sigma
 import java.math.BigInteger
 
 import org.bouncycastle.math.ec.ECPoint
-
 import special.collection._
 import scalan._
+import scorex.crypto.authds.{ADDigest, ADValue}
+import scorex.crypto.authds.avltree.batch.Operation
+
+import scala.util.Try
 
 @scalan.Liftable
 trait CostModel {
@@ -543,7 +546,39 @@ trait AvlTree {
     * @param proof
     */
   def remove(operations: Coll[Coll[Byte]], proof: Coll[Byte]): Option[AvlTree]
+
+  def createVerifier(proof: Coll[Byte]): AvlTreeVerifier
 }
+
+trait AvlTreeVerifier {
+  /**
+    * If operation.key exists in the tree and the operation succeeds,
+    * returns Success(Some(v)), where v is the value associated with operation.key
+    * before the operation.
+    * If operation.key does not exists in the tree and the operation succeeds, returns Success(None).
+    * Returns Failure if the operation fails or the proof does not verify.
+    * After one failure, all subsequent operations will fail and digest
+    * is None.
+    *
+    * @param operation
+    * @return - Success(Some(old value)), Success(None), or Failure
+    */
+  def performOneOperation(operation: Operation): Try[Option[ADValue]]
+
+  /** Returns the max height of the tree extracted from the root digest. */
+  def treeHeight: Int
+
+  /**
+    * Returns Some[the current digest of the authenticated data structure],
+    * where the digest contains the root hash and the root height
+    * Returns None if the proof verification failed at construction
+    * or during any of the operations.
+    *
+    * @return - Some[digest] or None
+    */
+  def digest: Option[ADDigest]
+}
+
 
 /** Only header fields that can be predicted by a miner.
   * @since 2.0
@@ -665,8 +700,70 @@ trait Context {
   def preHeader: PreHeader
 
   def minerPubKey: Coll[Byte]
+
+  /** Extracts Context variable by id and type.
+    * ErgoScript is typed, so accessing a the variables is an operation which involves
+    * some expected type given in brackets. Thus `getVar[Int](id)` expression should
+    * evaluate to a valid value of the `Option[Int]` type.
+    *
+    * For example `val x = getVar[Int](10)` expects the variable, if it is present, to have
+    * type `Int`. At runtime the corresponding type descriptor is passed as `cT`
+    * parameter.
+    *
+    * There are three cases:
+    * 1) If the variable doesn't exist.
+    *   Then `val x = getVar[Int](id)` succeeds and returns the None value, which conforms to
+    *   any value of type `Option[T]` for any T. (In the example above T is equal to
+    *   `Int`). Calling `x.get` fails when x is equal to None, but `x.isDefined`
+    *   succeeds and returns `false`.
+    * 2) If the variable contains a value `v` of type `Int`.
+    *   Then `val x = getVar[Int](id)` succeeds and returns `Some(v)`, which is a valid value
+    *   of type `Option[Int]`. In this case, calling `x.get` succeeds and returns the
+    *   value `v` of type `Int`. Calling `x.isDefined` returns `true`.
+    * 3) If the variable contains a value `v` of type T other then `Int`.
+    *   Then `val x = getVar[Int](id)` fails, because there is no way to return a valid value
+    *   of type `Option[Int]`. The value of variable is present, so returning it as None
+    *   would break the typed semantics of variables collection.
+    *
+    * In some use cases one variable may have values of different types. To access such
+    * variable an additional variable can be used as a tag.
+    *
+    * <pre class="stHighlight">
+    *   val tagOpt = getVar[Int](id)
+    *   val res = if (tagOpt.isDefined) {
+    *     val tag = tagOpt.get
+    *     if (tag == 1) {
+    *       val x = getVar[Int](id2).get
+    *       // compute res using value x is of type Int
+    *     } else if (tag == 2) {
+    *       val x = getVar[GroupElement](id2).get
+    *       // compute res using value x is of type GroupElement
+    *     } else if (tag == 3) {
+    *       val x = getVar[ Array[Byte] ](id2).get
+    *       // compute res using value x of type Array[Byte]
+    *     } else {
+    *       // compute `res` when `tag` is not 1, 2 or 3
+    *     }
+    *   }
+    *   else {
+    *     // compute value of res when the variable is not present
+    *   }
+    * </pre>
+    *
+    * @param id zero-based identifier of the variable.
+    * @tparam T expected type of the variable.
+    * @return Some(value) if the variable is defined in the context AND has the given type.
+    *         None otherwise
+    * @throws special.sigma.InvalidType exception when the type of the variable value is
+    *                                   different from cT.
+    */
   def getVar[T](id: Byte)(implicit cT: RType[T]): Option[T]
+
   def vars: Coll[AnyValue]
+
+  /** Maximum version of ErgoTree currently activated on the network.
+    * See [[ErgoLikeContext]] class for details. */
+  def activatedScriptVersion: Byte
 }
 
 @scalan.Liftable
@@ -710,8 +807,7 @@ trait SigmaContract {
   @Reified("T")
   def substConstants[T](scriptBytes: Coll[Byte],
       positions: Coll[Int],
-      newValues: Coll[T])
-      (implicit cT: RType[T]): Coll[Byte] = this.builder.substConstants(scriptBytes, positions, newValues)
+      newValues: Coll[T]): Coll[Byte] = this.builder.substConstants(scriptBytes, positions, newValues)
 }
 
 /** Runtime representation of SGlobal ErgoTree type.
@@ -828,7 +924,7 @@ trait SigmaDslBuilder {
     * @return original scriptBytes array where only specified constants are replaced and all other bytes remain exactly the same
     */
   @Reified("T")
-  def substConstants[T](scriptBytes: Coll[Byte], positions: Coll[Int], newValues: Coll[T])(implicit cT: RType[T]): Coll[Byte]
+  def substConstants[T](scriptBytes: Coll[Byte], positions: Coll[Int], newValues: Coll[T]): Coll[Byte]
 
   /** Decodes the given bytes to the corresponding GroupElement using default serialization.
     * @param encoded serialized bytes of some GroupElement value

--- a/sigma-api/src/main/scala/special/sigma/SigmaDsl.scala
+++ b/sigma-api/src/main/scala/special/sigma/SigmaDsl.scala
@@ -547,9 +547,18 @@ trait AvlTree {
     */
   def remove(operations: Coll[Coll[Byte]], proof: Coll[Byte]): Option[AvlTree]
 
+  /** Creates a new instance of [[AvlTreeVerifier]] with the given `proof` and using
+    * properties of this AvlTree (digest, keyLength, valueLengthOpt) for constructor
+    * arguments.
+    *
+    * @param proof bytes of the serialized proof which is used to represent the tree.
+    */
   def createVerifier(proof: Coll[Byte]): AvlTreeVerifier
 }
 
+/** Represents operations of AVL tree verifier in an abstract (implementation independent)
+  * way which allows declaration of the [[AvlTree.createVerifier()]] method.
+  */
 trait AvlTreeVerifier {
   /**
     * If operation.key exists in the tree and the operation succeeds,
@@ -560,7 +569,7 @@ trait AvlTreeVerifier {
     * After one failure, all subsequent operations will fail and digest
     * is None.
     *
-    * @param operation
+    * @param operation an operation descriptor
     * @return - Success(Some(old value)), Success(None), or Failure
     */
   def performOneOperation(operation: Operation): Try[Option[ADValue]]

--- a/sigma-impl/src/main/scala/special/sigma/Mocks.scala
+++ b/sigma-impl/src/main/scala/special/sigma/Mocks.scala
@@ -5,9 +5,10 @@ import scalan.{NeverInline, OverloadId}
 import special.collection.Builder.DefaultCollBuilder
 import special.collection.{Coll, Builder}
 
-/**NOTE: this should extend SigmaProp because semantically it subclass of SigmaProp
-  * and DefaultSigma is used just to mixin implementations. */
-
+// TODO refactor: remove this class
+/** NOTE: this should extend SigmaProp because semantically it subclass of SigmaProp
+  * and DefaultSigma is used just to mixin implementations.
+  */
 case class MockSigma(val _isValid: Boolean) extends SigmaProp {
 
   def propBytes: Coll[Byte] = DefaultCollBuilder.fromItems(if(isValid) 1 else 0)
@@ -25,7 +26,6 @@ case class MockSigma(val _isValid: Boolean) extends SigmaProp {
   @NeverInline
   @OverloadId("or_bool")
   def ||(other: Boolean): SigmaProp = MockSigma(isValid || other)
-
 }
 
 case class MockProveDlog(var isValid: Boolean, val propBytes: Coll[Byte]) extends SigmaProp {

--- a/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
+++ b/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
@@ -80,8 +80,7 @@ class TestSigmaDslBuilder extends SigmaDslBuilder {
   @NeverInline
   override def substConstants[T](scriptBytes: Coll[Byte],
       positions: Coll[Int],
-      newValues: Coll[T])
-      (implicit cT: RType[T]): Coll[Byte] = ???
+      newValues: Coll[T]): Coll[Byte] = ???
 
   @NeverInline
   override def decodePoint(encoded: Coll[Byte]): GroupElement =

--- a/sigma-library/src/main/scala/special/sigma/SigmaDslUnit.scala
+++ b/sigma-library/src/main/scala/special/sigma/SigmaDslUnit.scala
@@ -179,7 +179,7 @@ package special.sigma {
       def proveDHTuple(g: Ref[GroupElement], h: Ref[GroupElement], u: Ref[GroupElement], v: Ref[GroupElement]): Ref[SigmaProp] = this.builder.proveDHTuple(g, h, u, v);
       def groupGenerator: Ref[GroupElement] = this.builder.groupGenerator;
       def decodePoint(encoded: Ref[Coll[Byte]]): Ref[GroupElement] = this.builder.decodePoint(encoded);
-      @Reified(value = "T") def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]])(implicit cT: Elem[T]): Ref[Coll[Byte]] = this.builder.substConstants[T](scriptBytes, positions, newValues)
+      @Reified(value = "T") def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]]): Ref[Coll[Byte]] = this.builder.substConstants[T](scriptBytes, positions, newValues)
     };
     @Liftable @WithMethodCallRecognizers trait SigmaDslBuilder extends Def[SigmaDslBuilder] {
       def Colls: Ref[CollBuilder];
@@ -202,7 +202,7 @@ package special.sigma {
       def proveDlog(g: Ref[GroupElement]): Ref[SigmaProp];
       def proveDHTuple(g: Ref[GroupElement], h: Ref[GroupElement], u: Ref[GroupElement], v: Ref[GroupElement]): Ref[SigmaProp];
       def groupGenerator: Ref[GroupElement];
-      @Reified(value = "T") def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]])(implicit cT: Elem[T]): Ref[Coll[Byte]];
+      @Reified(value = "T") def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]]): Ref[Coll[Byte]];
       def decodePoint(encoded: Ref[Coll[Byte]]): Ref[GroupElement];
       def avlTree(operationFlags: Ref[Byte], digest: Ref[Coll[Byte]], keyLength: Ref[Int], valueLengthOpt: Ref[WOption[Int]]): Ref[AvlTree];
       def xor(l: Ref[Coll[Byte]], r: Ref[Coll[Byte]]): Ref[Coll[Byte]]

--- a/sigma-library/src/main/scala/special/sigma/impl/SigmaDslImpl.scala
+++ b/sigma-library/src/main/scala/special/sigma/impl/SigmaDslImpl.scala
@@ -3332,11 +3332,11 @@ object SigmaDslBuilder extends EntityObject("SigmaDslBuilder") {
         true, false, element[GroupElement]))
     }
 
-    override def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]])(implicit cT: Elem[T]): Ref[Coll[Byte]] = {
+    override def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]]): Ref[Coll[Byte]] = {
       implicit val eT = newValues.eA
       asRep[Coll[Byte]](mkMethodCall(self,
-        SigmaDslBuilderClass.getMethod("substConstants", classOf[Sym], classOf[Sym], classOf[Sym], classOf[Elem[_]]),
-        Array[AnyRef](scriptBytes, positions, newValues, cT),
+        SigmaDslBuilderClass.getMethod("substConstants", classOf[Sym], classOf[Sym], classOf[Sym]),
+        Array[AnyRef](scriptBytes, positions, newValues),
         true, false, element[Coll[Byte]]))
     }
 
@@ -3525,11 +3525,11 @@ object SigmaDslBuilder extends EntityObject("SigmaDslBuilder") {
         true, true, element[GroupElement]))
     }
 
-    def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]])(implicit cT: Elem[T]): Ref[Coll[Byte]] = {
+    def substConstants[T](scriptBytes: Ref[Coll[Byte]], positions: Ref[Coll[Int]], newValues: Ref[Coll[T]]): Ref[Coll[Byte]] = {
       implicit val eT = newValues.eA
       asRep[Coll[Byte]](mkMethodCall(source,
-        SigmaDslBuilderClass.getMethod("substConstants", classOf[Sym], classOf[Sym], classOf[Sym], classOf[Elem[_]]),
-        Array[AnyRef](scriptBytes, positions, newValues, cT),
+        SigmaDslBuilderClass.getMethod("substConstants", classOf[Sym], classOf[Sym], classOf[Sym]),
+        Array[AnyRef](scriptBytes, positions, newValues),
         true, true, element[Coll[Byte]]))
     }
 
@@ -3793,13 +3793,13 @@ object SigmaDslBuilder extends EntityObject("SigmaDslBuilder") {
     }
 
     object substConstants {
-      def unapply(d: Def[_]): Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]], Elem[T]) forSome {type T}] = d match {
+      def unapply(d: Def[_]): Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]]) forSome {type T}] = d match {
         case MethodCall(receiver, method, args, _) if method.getName == "substConstants" && receiver.elem.isInstanceOf[SigmaDslBuilderElem[_]] =>
-          val res = (receiver, args(0), args(1), args(2), args(3))
-          Nullable(res).asInstanceOf[Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]], Elem[T]) forSome {type T}]]
+          val res = (receiver, args(0), args(1), args(2))
+          Nullable(res).asInstanceOf[Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]]) forSome {type T}]]
         case _ => Nullable.None
       }
-      def unapply(exp: Sym): Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]], Elem[T]) forSome {type T}] = unapply(exp.node)
+      def unapply(exp: Sym): Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Ref[Coll[Int]], Ref[Coll[T]]) forSome {type T}] = unapply(exp.node)
     }
 
     object decodePoint {

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoBox.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoBox.scala
@@ -120,8 +120,7 @@ object ErgoBox {
   trait RegisterId {
     val number: Byte
     def asIndex: Int = number.toInt
-
-    override def toString: Idn = "R" + number
+    override def toString: String = "R" + number
   }
 
   abstract class MandatoryRegisterId(override val number: Byte, val purpose: String) extends RegisterId

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -50,6 +50,7 @@ class ErgoBoxCandidate(val value: Long,
   lazy val propositionBytes: Array[Byte] = ergoTree.bytes
 
   /** Serialized bytes of this Box without transaction reference data (transactionId and boxIndex). */
+  // TODO v5.0: re-implement extracting directly from `ErgoBox.bytes` array
   lazy val bytesWithNoRef: Array[Byte] = ErgoBoxCandidate.serializer.toBytes(this)
 
   /** Creates a new [[ErgoBox]] based on this candidate using the given transaction reference data.
@@ -93,7 +94,7 @@ class ErgoBoxCandidate(val value: Long,
     ScalaRunTime._hashCode((value, ergoTree, additionalTokens, additionalRegisters, creationHeight))
   }
 
-  override def toString: Idn = s"ErgoBoxCandidate($value, $ergoTree," +
+  override def toString: String = s"ErgoBoxCandidate($value, $ergoTree," +
     s"tokens: (${additionalTokens.map(t => ErgoAlgos.encode(t._1) + ":" + t._2).toArray.mkString(", ")}), " +
     s"$additionalRegisters, creationHeight: $creationHeight)"
 

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -152,9 +152,10 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
     }
     val vars = contextVars(varMap ++ extensions)
     val avlTree = CAvlTree(lastBlockUtxoRoot)
+    val selfBox = boxesToSpend(selfIndex).toTestBox(isCost)
     CostingDataContext(
-      dataInputs, headers, preHeader, inputs, outputs, preHeader.height, boxesToSpend(selfIndex).toTestBox(isCost), avlTree,
-      preHeader.minerPk.getEncoded, vars, isCost)
+      dataInputs, headers, preHeader, inputs, outputs, preHeader.height, selfBox, avlTree,
+      preHeader.minerPk.getEncoded, vars, activatedScriptVersion, isCost)
   }
 
 

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeInterpreter.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeInterpreter.scala
@@ -40,4 +40,5 @@ class ErgoLikeInterpreter(implicit val IR: IRContext) extends Interpreter {
         }.orElse(d.default)
       case _ => super.substDeserialize(context, updateContext, node)
     }
+    
 }

--- a/sigmastate/src/main/scala/org/ergoplatform/SigmaConstants.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/SigmaConstants.scala
@@ -76,6 +76,10 @@ object SigmaConstants {
     "size of nonce array from Autolykos POW solution in Header.powNonce array") {
   }
 
+  object MaxCollSize extends SizeConstant[Int](4 * 1024, 16,
+    "Maximum number of items in a collection") {
+  }
+
   val ConstTable: Seq[SizeConstant[_]] = {
     val rows = Seq(
       MaxBoxSize,
@@ -92,7 +96,8 @@ object SigmaConstants {
       ScriptCostLimit,
       MaxLoopLevelInCostFunction,
       VotesArraySize,
-      AutolykosPowSolutionNonceArraySize
+      AutolykosPowSolutionNonceArraySize,
+      MaxCollSize
     )
     require(rows.length == rows.distinctBy(_.id).length, s"Duplicate constant id in $rows")
     rows

--- a/sigmastate/src/main/scala/org/ergoplatform/SigmaConstants.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/SigmaConstants.scala
@@ -76,10 +76,6 @@ object SigmaConstants {
     "size of nonce array from Autolykos POW solution in Header.powNonce array") {
   }
 
-  object MaxCollSize extends SizeConstant[Int](4 * 1024, 16,
-    "Maximum number of items in a collection") {
-  }
-
   val ConstTable: Seq[SizeConstant[_]] = {
     val rows = Seq(
       MaxBoxSize,
@@ -96,8 +92,7 @@ object SigmaConstants {
       ScriptCostLimit,
       MaxLoopLevelInCostFunction,
       VotesArraySize,
-      AutolykosPowSolutionNonceArraySize,
-      MaxCollSize
+      AutolykosPowSolutionNonceArraySize
     )
     require(rows.length == rows.distinctBy(_.id).length, s"Duplicate constant id in $rows")
     rows

--- a/sigmastate/src/main/scala/org/ergoplatform/dsl/ContractSyntax.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/dsl/ContractSyntax.scala
@@ -11,7 +11,7 @@ import special.sigma.{SigmaProp, SigmaContract, Context, DslSyntaxExtensions, Si
 import scala.language.implicitConversions
 
 trait ContractSyntax { contract: SigmaContract =>
-  override def builder: SigmaDslBuilder = new CostingSigmaDslBuilder
+  override def builder: SigmaDslBuilder = CostingSigmaDslBuilder
   val spec: ContractSpec
   val syntax = new DslSyntaxExtensions(builder)
   def contractEnv: ScriptEnv

--- a/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
@@ -98,6 +98,11 @@ case class CSigmaProp(sigmaTree: SigmaBoolean) extends SigmaProp with WrapperOf[
   override def toString: String = s"SigmaProp(${wrappedValue.showToString})"
 }
 
+/** Implementation of the [[special.sigma.AvlTreeVerifier]] trait based on
+  * [[scorex.crypto.authds.avltree.batch.BatchAVLVerifier]].
+  *
+  * @see BatchAVLVerifier, AvlTreeVerifier
+  */
 class CAvlTreeVerifier(startingDigest: ADDigest,
                        proof: SerializedAdProof,
                        override val keyLength: Int,

--- a/sigmastate/src/main/scala/sigmastate/eval/Evaluation.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/Evaluation.scala
@@ -197,7 +197,7 @@ trait Evaluation extends RuntimeCosting { IR: IRContext =>
       case OM.getOrElse(_, _) => OptionGetOrElseCode
       case OM.fold(_, _, _) => MethodCallCode
       case OM.isDefined(_) => OptionIsDefinedCode
-      case SDBM.substConstants(_, _, _, _, _) => SubstConstantsCode
+      case SDBM.substConstants(_, _, _, _) => SubstConstantsCode
       case SDBM.longToByteArray(_, _) => LongToByteArrayCode
       case SDBM.byteArrayToBigInt(_, _) => ByteArrayToBigIntCode
       case SDBM.byteArrayToLong(_, _) => ByteArrayToLongCode
@@ -572,7 +572,7 @@ trait Evaluation extends RuntimeCosting { IR: IRContext =>
           case SDBM.substConstants(_,
             In(input: special.collection.Coll[Byte]@unchecked),
             In(positions: special.collection.Coll[Int]@unchecked),
-            In(newVals: special.collection.Coll[Any]@unchecked), _) =>
+            In(newVals: special.collection.Coll[Any]@unchecked)) =>
             // TODO refactor: call sigmaDslBuilderValue.substConstants
             val typedNewVals = newVals.toArray.map(v => builder.liftAny(v) match {
               case Nullable(v) => v

--- a/sigmastate/src/main/scala/sigmastate/eval/Evaluation.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/Evaluation.scala
@@ -573,13 +573,8 @@ trait Evaluation extends RuntimeCosting { IR: IRContext =>
             In(input: special.collection.Coll[Byte]@unchecked),
             In(positions: special.collection.Coll[Int]@unchecked),
             In(newVals: special.collection.Coll[Any]@unchecked)) =>
-            // TODO refactor: call sigmaDslBuilderValue.substConstants
-            val typedNewVals = newVals.toArray.map(v => builder.liftAny(v) match {
-              case Nullable(v) => v
-              case _ => sys.error(s"Cannot evaluate substConstants($input, $positions, $newVals): cannot lift value $v")
-            })
-            val byteArray = SubstConstants.eval(input.toArray, positions.toArray, typedNewVals)(sigmaDslBuilderValue.validationSettings)
-            out(sigmaDslBuilderValue.Colls.fromArray(byteArray))
+            val res = sigmaDslBuilderValue.substConstants(input, positions, newVals)
+            out(res)
 
           case CBM.replicate(In(b: special.collection.CollBuilder), In(n: Int), xSym @ In(x)) =>
             out(b.replicate(n, x)(asType[Any](xSym.elem.sourceType)))

--- a/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala
@@ -1819,7 +1819,7 @@ trait RuntimeCosting extends CostingRules { IR: IRContext =>
         RCCostedColl(values, costs, sizes, cost)
 
       case SubstConstants(InCollByte(bytes), InCollInt(positions), InCollAny(newValues)) =>
-        val values = sigmaDslBuilder.substConstants(bytes.values, positions.values, newValues.values)(AnyElement)
+        val values = sigmaDslBuilder.substConstants(bytes.values, positions.values, newValues.values)
         val len = bytes.size.dataSize + newValues.size.dataSize
         val cost = opCost(values, Array(bytes.cost, positions.cost, newValues.cost), perKbCostOf(node, len))
         mkCostedColl(values, len.toInt, cost)

--- a/sigmastate/src/main/scala/sigmastate/eval/TreeBuilding.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/TreeBuilding.scala
@@ -348,7 +348,7 @@ trait TreeBuilding extends RuntimeCosting { IR: IRContext =>
         mkByteArrayToLong(recurse(colSym))
       case SDBM.decodePoint(_, colSym) =>
         mkDecodePoint(recurse(colSym))
-      case SDBM.substConstants(_, In(scriptBytes), In(positions), In(newValues), _) =>
+      case SDBM.substConstants(_, In(scriptBytes), In(positions), In(newValues)) =>
         mkSubstConst(scriptBytes.asByteArray, positions.asIntArray, newValues.asCollection[SType])
 
       case Def(IfThenElseLazy(condSym, thenPSym, elsePSym)) =>

--- a/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
+++ b/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
@@ -66,13 +66,16 @@ trait ContractsTestkit {
 
 
   def testContext(inputs: Array[Box], outputs: Array[Box], height: Int, self: Box,
-                  tree: AvlTree, minerPk: Array[Byte], vars: Array[AnyValue]) =
+                  tree: AvlTree, minerPk: Array[Byte], activatedScriptVersion: Byte, vars: Array[AnyValue]) =
     new CostingDataContext(
       noInputs.toColl, noHeaders, dummyPreHeader,
-      inputs.toColl, outputs.toColl, height, self, tree, minerPk.toColl, vars.toColl, false)
+      inputs.toColl, outputs.toColl, height, self, tree,
+      minerPk.toColl, vars.toColl, activatedScriptVersion, false)
 
-  def newContext(height: Int, self: Box, vars: AnyValue*): CostingDataContext = {
-    testContext(noInputs, noOutputs, height, self, emptyAvlTree, dummyPubkey, vars.toArray)
+  def newContext(height: Int, self: Box, activatedScriptVersion: Byte, vars: AnyValue*): CostingDataContext = {
+    testContext(
+      noInputs, noOutputs, height, self, emptyAvlTree, dummyPubkey,
+      activatedScriptVersion, vars.toArray)
   }
 
   implicit class TestContextOps(ctx: CostingDataContext) {

--- a/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
+++ b/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
@@ -46,7 +46,7 @@ trait ContractsTestkit {
   }
 
   def contextVars(m: Map[Byte, AnyValue]): Coll[AnyValue] = {
-    val maxKey = if (m.keys.isEmpty) 0 else m.keys.max
+    val maxKey = if (m.keys.isEmpty) 0 else m.keys.max  // TODO optimize: max takes 90% of this method
     val res = new Array[AnyValue](maxKey)
     for ((id, v) <- m) {
       val i = id - 1

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -3654,6 +3654,7 @@ class SigmaDslSpecification extends SigmaDslTesting with CrossVersionProps { sui
           .append(Coll[AnyValue](
             TestValue(Helpers.decodeBytes("00"), CollType(RType.ByteType)),
             TestValue(true, RType.BooleanType))),
+      activatedScriptVersion = activatedVersionInTests,
       false
     )
     val ctx2 = ctx.copy(vars = Coll[AnyValue](null, null, null))
@@ -6276,7 +6277,7 @@ class SigmaDslSpecification extends SigmaDslTesting with CrossVersionProps { sui
       },
       existingFeature(
         { (x: (Coll[Byte], Int)) =>
-          SigmaDsl.substConstants(x._1, Coll[Int](x._2), Coll[Any](SigmaDsl.sigmaProp(false))(RType.AnyType))(RType.AnyType)
+          SigmaDsl.substConstants(x._1, Coll[Int](x._2), Coll[Any](SigmaDsl.sigmaProp(false))(RType.AnyType))
         },
         "{ (x: (Coll[Byte], Int)) => substConstants[Any](x._1, Coll[Int](x._2), Coll[Any](sigmaProp(false))) }",
         FuncValue(

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslStaginTests.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslStaginTests.scala
@@ -6,6 +6,7 @@ import scala.language.reflectiveCalls
 import scalan.{BaseLiftableTests, BaseCtxTests}
 import sigmastate.eval.Extensions._
 import sigmastate.eval.{IRContext, ErgoScriptTestkit}
+import sigmastate.interpreter.Interpreter
 
 class SigmaDslStaginTests extends BaseCtxTests with ErgoScriptTestkit with BaseLiftableTests {
   class Ctx extends TestContext with IRContext with LiftableTestKit {
@@ -29,7 +30,7 @@ class SigmaDslStaginTests extends BaseCtxTests with ErgoScriptTestkit with BaseL
     type RSigmaProp = cake.SigmaProp
     val boxA1 = newAliceBox(1, 100)
     val boxA2 = newAliceBox(2, 200)
-    val ctx: SContext = newContext(10, boxA1)
+    val ctx: SContext = newContext(10, boxA1, Interpreter.MaxSupportedScriptVersion)
       .withInputs(boxA2)
       .withVariables(Map(1 -> toAnyValue(30), 2 -> toAnyValue(40)))
     val p1: SSigmaProp = new special.sigma.MockSigma(true)


### PR DESCRIPTION
This PR contains refactoring and code improvements which can be merged into v4.0.
The changes are motivated by v5.0 work, but can be made in v4.0 and thus minimize v5.0 PR.
This is part 1, which contains:
- [x] declared dependency "org.apache.commons" % "commons-math3" % "3.2"
- [x] AVHashMap.fromSeq method added
- [x] AvlTree.createVerifier method added
- [x] AvlTreeVerifier trait added
- [x] substConstants signature simplified
- [x] Context.activatedScriptVersion property added


