### PR TITLE
Finalize v5.0: fix non-lazy If

### DIFF
--- a/sigmastate/src/main/scala/sigmastate/interpreter/ErgoTreeEvaluator.scala
+++ b/sigmastate/src/main/scala/sigmastate/interpreter/ErgoTreeEvaluator.scala
@@ -2,17 +2,17 @@ package sigmastate.interpreter
 
 import org.ergoplatform.ErgoLikeContext
 import org.ergoplatform.SigmaConstants.ScriptCostLimit
-import sigmastate.{FixedCost, JitCost, PerItemCost, SType, TypeBasedCost}
+import sigmastate.{FixedCost, JitCost, PerItemCost, SType, TypeBasedCost, Versions}
 import sigmastate.Values._
 import sigmastate.eval.Profiler
 import sigmastate.interpreter.ErgoTreeEvaluator.DataEnv
-import sigmastate.interpreter.Interpreter.JitReductionResult
+import sigmastate.interpreter.Interpreter.{JitReductionResult, error}
 import special.sigma.{Context, SigmaProp}
 import scalan.util.Extensions._
 import sigmastate.interpreter.EvalSettings._
-import sigmastate.lang.Terms.MethodCall
 import supertagged.TaggedType
 import debox.{Buffer => DBuffer}
+
 import scala.collection.mutable
 import scala.util.DynamicVariable
 
@@ -133,6 +133,9 @@ class ErgoTreeEvaluator(
   
   /** Evaluates the given expression in the given data environment. */
   def eval(env: DataEnv, exp: SValue): Any = {
+    if (Versions.currentErgoTreeVersion != context.currentErgoTreeVersion) {
+      error(s"Global Versions.currentErgoTreeVersion = ${Versions.currentErgoTreeVersion} while context.currentErgoTreeVersion = ${context.currentErgoTreeVersion}.")
+    }
     ErgoTreeEvaluator.currentEvaluator.withValue(this) {
       exp.evalTo[Any](env)(this)
     }

--- a/sigmastate/src/test/scala/sigmastate/TestsBase.scala
+++ b/sigmastate/src/test/scala/sigmastate/TestsBase.scala
@@ -23,7 +23,7 @@ trait TestsBase extends Matchers {
   def activatedVersionInTests: Byte = _currActivatedVersion.value
 
   /** Checks if the current activated script version used in tests corresponds to v4.x. */
-  def isActivatedVersion4: Boolean = activatedVersionInTests < 2
+  def isActivatedVersion4: Boolean = activatedVersionInTests < Versions.JitActivationVersion
 
   val ergoTreeVersions: Seq[Byte] =
     (0 to Versions.MaxSupportedScriptVersion).map(_.toByte).toArray[Byte]

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -5123,7 +5123,9 @@ class SigmaDslSpecification extends SigmaDslTesting
           (Coll[Boolean](false, false, true, true), successNew(true, 37101, newV = false,  newC = 8214))
         )
       },
-      existingFeature((x: Coll[Boolean]) => SigmaDsl.xorOf(x),
+      changedFeature(
+        (x: Coll[Boolean]) => SigmaDsl.xorOf(x),
+        (x: Coll[Boolean]) => SigmaDsl.xorOf(x),
         "{ (x: Coll[Boolean]) => xorOf(x) }",
         FuncValue(Vector((1, SBooleanArray)), XorOf(ValUse(1, SBooleanArray)))))
   }

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -4634,11 +4634,12 @@ class SigmaDslSpecification extends SigmaDslTesting
       ),
       changedFeature(
         scalaFunc = { (x: Context) =>
-          // this error is expected in v3.x
+          // this error is expected in v3.x, v4.x
           throw expectedError
         },
         scalaFuncNew = { (x: Context) =>
-          // TODO v5.0: this is expected in v5.0
+          // this is expected in v5.0, so the semantics of the script should correspond
+          // to this Scala code
           val dataBox = x.dataInputs(0)
           val ok = if (x.OUTPUTS(0).R5[Long].get == 1L) {
             dataBox.R4[Long].get <= x.SELF.value
@@ -4647,53 +4648,54 @@ class SigmaDslSpecification extends SigmaDslTesting
           }
           ok
         },
-      s"""{ (x: Context) =>
-        |  val dataBox = x.dataInputs(0)
-        |  val ok = if (x.OUTPUTS(0).R5[Long].get == 1L) {
-        |    dataBox.R4[Long].get <= x.SELF.value
-        |  } else {
-        |    dataBox.R4[Coll[Byte]].get != x.SELF.propositionBytes
-        |  }
-        |  ok
-        |}
-        |""".stripMargin,
-      FuncValue(
-        Array((1, SContext)),
-        BlockValue(
-          Array(
-            ValDef(
-              3,
-              List(),
-              ByIndex(
-                MethodCall.typed[Value[SCollection[SBox.type]]](
-                  ValUse(1, SContext),
-                  SContext.getMethodByName("dataInputs"),
-                  Vector(),
-                  Map()
+        s"""{ (x: Context) =>
+          |  val dataBox = x.dataInputs(0)
+          |  val ok = if (x.OUTPUTS(0).R5[Long].get == 1L) {
+          |    dataBox.R4[Long].get <= x.SELF.value
+          |  } else {
+          |    dataBox.R4[Coll[Byte]].get != x.SELF.propositionBytes
+          |  }
+          |  ok
+          |}
+          |""".stripMargin,
+        FuncValue(
+          Array((1, SContext)),
+          BlockValue(
+            Array(
+              ValDef(
+                3,
+                List(),
+                ByIndex(
+                  MethodCall.typed[Value[SCollection[SBox.type]]](
+                    ValUse(1, SContext),
+                    SContext.getMethodByName("dataInputs"),
+                    Vector(),
+                    Map()
+                  ),
+                  IntConstant(0),
+                  None
+                )
+              )
+            ),
+            If(
+              EQ(
+                OptionGet(
+                  ExtractRegisterAs(ByIndex(Outputs, IntConstant(0), None), ErgoBox.R5, SOption(SLong))
                 ),
-                IntConstant(0),
-                None
+                LongConstant(1L)
+              ),
+              LE(
+                OptionGet(ExtractRegisterAs(ValUse(3, SBox), ErgoBox.R4, SOption(SLong))),
+                ExtractAmount(Self)
+              ),
+              NEQ(
+                OptionGet(ExtractRegisterAs(ValUse(3, SBox), ErgoBox.R4, SOption(SByteArray))),
+                ExtractScriptBytes(Self)
               )
             )
-          ),
-          If(
-            EQ(
-              OptionGet(
-                ExtractRegisterAs(ByIndex(Outputs, IntConstant(0), None), ErgoBox.R5, SOption(SLong))
-              ),
-              LongConstant(1L)
-            ),
-            LE(
-              OptionGet(ExtractRegisterAs(ValUse(3, SBox), ErgoBox.R4, SOption(SLong))),
-              ExtractAmount(Self)
-            ),
-            NEQ(
-              OptionGet(ExtractRegisterAs(ValUse(3, SBox), ErgoBox.R4, SOption(SByteArray))),
-              ExtractScriptBytes(Self)
-            )
           )
-        )
-      )
+        ),
+        allowNewToSucceed = true
       ),
       preGeneratedSamples = Some(mutable.WrappedArray.empty))
   }
@@ -6557,7 +6559,8 @@ class SigmaDslSpecification extends SigmaDslTesting
             ),
             LongConstant(5L)
           )
-        )))
+        ),
+        allowNewToSucceed = true))
   }
 
   def formatter(costKind: PerItemCost) = (info: MeasureInfo[Coll[Byte]]) => {

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
@@ -478,7 +478,7 @@ class SigmaDslTesting extends PropSpec
     scalaFunc: A => B,
     expectedExpr: Option[SValue],
     printExpectedExpr: Boolean = true,
-    logScript: Boolean = LogScriptDefault,
+    logScript: Boolean = LogScriptDefault
   )(implicit IR: IRContext, tA: RType[A], tB: RType[B],
              override val evalSettings: EvalSettings) extends Feature[A, B] {
 

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
@@ -472,7 +472,6 @@ class SigmaDslTesting extends PropSpec
     *                          compiler for the given feature-function
     * @param printExpectedExpr if true, print test vectors for expectedExpr
     * @param logScript         if true, log scripts to console
-    * @param requireMCLowering if true, MethodCall lowering is performed by ErgoScript compiler
     */
   case class ExistingFeature[A, B](
     script: String,
@@ -480,7 +479,6 @@ class SigmaDslTesting extends PropSpec
     expectedExpr: Option[SValue],
     printExpectedExpr: Boolean = true,
     logScript: Boolean = LogScriptDefault,
-    requireMCLowering: Boolean = false
   )(implicit IR: IRContext, tA: RType[A], tB: RType[B],
              override val evalSettings: EvalSettings) extends Feature[A, B] {
 
@@ -614,7 +612,6 @@ class SigmaDslTesting extends PropSpec
     *                          compiler for the given feature-function
     * @param printExpectedExpr if true, print test vectors for expectedExpr
     * @param logScript         if true, log scripts to console
-    * @param requireMCLowering if true, MethodCall lowering is performed by ErgoScript compiler
     * @param allowNewToSucceed if true, we allow some scripts which fail in v4.x to pass in v5.0.
     *                          Before activation, all ErgoTrees with version < JitActivationVersion are
     *                          processed by v4.x interpreter, so this difference is not a problem.
@@ -631,7 +628,6 @@ class SigmaDslTesting extends PropSpec
     expectedExpr: Option[SValue],
     printExpectedExpr: Boolean = true,
     logScript: Boolean = LogScriptDefault,
-    requireMCLowering: Boolean = false,
     allowNewToSucceed: Boolean = false
   )(implicit IR: IRContext, override val evalSettings: EvalSettings)
     extends Feature[A, B] {
@@ -889,17 +885,15 @@ class SigmaDslTesting extends PropSpec
     * @param scalaFunc    semantic function for both v1 and v2 script interpretations
     * @param script       the script to be tested against semantic function
     * @param expectedExpr expected ErgoTree expression which corresponds to the given script
-    * @param requireMCLowering if true, MethodCall lowering is performed by ErgoScript compiler
     * @return feature test descriptor object which can be used to execute this test case in
     *         various ways
     */
   def existingFeature[A: RType, B: RType]
       (scalaFunc: A => B, script: String,
-       expectedExpr: SValue = null, requireMCLowering: Boolean = false)
+       expectedExpr: SValue = null)
       (implicit IR: IRContext, evalSettings: EvalSettings): Feature[A, B] = {
     ExistingFeature(
-      script, scalaFunc, Option(expectedExpr),
-      requireMCLowering = requireMCLowering)
+      script, scalaFunc, Option(expectedExpr))
   }
 
   /** Describes existing language feature which should be differently supported in both


### PR DESCRIPTION
Old implementation is done in https://github.com/ScorexFoundation/sigmastate-interpreter/blob/e0905cc8c135fc4a6669f04636dd888aaa11572b/sigmastate/src/main/scala/sigmastate/eval/RuntimeCosting.scala#L1722 which is non-lazy.

The new v5.0 implementation is done in https://github.com/ScorexFoundation/sigmastate-interpreter/blob/68365862ac5548a644d91f9b062a38b1bebcfeef/sigmastate/src/main/scala/sigmastate/trees.scala#L1495-L1494 which is lazy for each branch and fixes the problem (See `property("Conditional access (data box register)")`).

In this PR:
- [x] ErgoTreeEvaluator always check global versions to be equal Context versions
- [x] added allowNewToSucceed parameter for ChangedFeature descriptor
- [x] the SigmaDslSpecification test for `if` statement is updated to correctly test difference between v4.x and v5.0 implementations (https://github.com/ScorexFoundation/sigmastate-interpreter/pull/763/commits/dd59bd09096957c87773cdb577440879ce4e8c56)