### PR TITLE
Finalize v5.0: resolve all TODO mainnet

### DIFF
--- a/common/src/main/scala/sigmastate/VersionContext.scala
+++ b/common/src/main/scala/sigmastate/VersionContext.scala
@@ -20,6 +20,10 @@ case class VersionContext(activatedVersion: Byte, ergoTreeVersion: Byte) {
 
   /** @return true, if JIT version of Ergo protocol was activated. */
   def isJitActivated: Boolean = activatedVersion >= JitActivationVersion
+
+  /** @return true, if ErgoTree version >= JitActivationVersion. */
+  def isEvaluateErgoTreeUsingJIT: Boolean =
+    ergoTreeVersion >= JitActivationVersion
 }
 
 object VersionContext {
@@ -39,16 +43,18 @@ object VersionContext {
     */
   val JitActivationVersion: Byte = 2
 
+  private val _defaultContext = VersionContext(
+    activatedVersion = 1/* v4.x */,
+    ergoTreeVersion = 1
+  )
+
   /** Universally accessible version context which is used to version the code
     * across the whole repository.
     *
     * The default value represent activated Ergo protocol and highest ErgoTree version.
     */
   private val _versionContext: DynamicVariable[VersionContext] =
-    new DynamicVariable[VersionContext](VersionContext(
-      activatedVersion = 1/* v4.x */,
-      ergoTreeVersion = 1
-    ))
+    new DynamicVariable[VersionContext](_defaultContext)
 
   /** Returns the current VersionContext attached to the current thread.
     * Each thread can have only one current version context at any time, which can be

--- a/common/src/main/scala/sigmastate/util.scala
+++ b/common/src/main/scala/sigmastate/util.scala
@@ -1,18 +1,31 @@
 package sigmastate
 
+import scalan.util.CollectionUtil
+
 import scala.reflect.ClassTag
 
 object util {
   /** Maximum length of an allocatable array. */
   val MaxArrayLength: Int = 100000
 
+  private def checkLength[A](len: Int)(implicit tA: ClassTag[A]) = {
+    if (len > MaxArrayLength)
+      throw new RuntimeException(
+        s"Cannot allocate array of $tA with $len items: max limit is $MaxArrayLength")
+  }
+
   /** Allocates a new array with `len` items of type `A`.
     * Should be used instead of `new Array[A](n)` or `Array.ofDim[A](n)`
     */
   final def safeNewArray[A](len: Int)(implicit tA: ClassTag[A]): Array[A] = {
-    if (len > MaxArrayLength)
-      throw new RuntimeException(
-        s"Cannot allocate array of $tA with $len items: max limit is $MaxArrayLength")
+    checkLength[A](len)
     new Array[A](len)
+  }
+
+  /** Concatenate two arrays checking length limit of the resulting array.
+    * Should be used in implementation of Coll operations of v5.0 and above. */
+  final def safeConcatArrays_v5[A](arr1: Array[A], arr2: Array[A])(implicit tA: ClassTag[A]): Array[A] = {
+    checkLength[A](arr1.length + arr2.length)
+    CollectionUtil.concatArrays_v5(arr1, arr2)
   }
 }

--- a/common/src/test/scala/sigmastate/VersionTesting.scala
+++ b/common/src/test/scala/sigmastate/VersionTesting.scala
@@ -1,0 +1,87 @@
+package sigmastate
+
+import spire.syntax.all.cfor
+
+import scala.util.DynamicVariable
+
+trait VersionTesting {
+
+  protected val activatedVersions: Seq[Byte] =
+    (0 to VersionContext.MaxSupportedScriptVersion).map(_.toByte).toArray[Byte]
+
+  private[sigmastate] val _currActivatedVersion = new DynamicVariable[Byte](0)
+  def activatedVersionInTests: Byte = _currActivatedVersion.value
+
+  /** Checks if the current activated script version used in tests corresponds to v4.x. */
+  def isActivatedVersion4: Boolean = activatedVersionInTests < VersionContext.JitActivationVersion
+
+  val ergoTreeVersions: Seq[Byte] =
+    (0 to VersionContext.MaxSupportedScriptVersion).map(_.toByte).toArray[Byte]
+
+  private[sigmastate] val _currErgoTreeVersion = new DynamicVariable[Byte](0)
+
+  /** Current ErgoTree version assigned dynamically. */
+  def ergoTreeVersionInTests: Byte = _currErgoTreeVersion.value
+
+  /** Executes the given block for each combination of _currActivatedVersion and
+    * _currErgoTreeVersion assigned to dynamic variables.
+    */
+  def forEachScriptAndErgoTreeVersion
+    (activatedVers: Seq[Byte], ergoTreeVers: Seq[Byte])
+    (block: => Unit): Unit = {
+    cfor(0)(_ < activatedVers.length, _ + 1) { i =>
+      val activatedVersion = activatedVers(i)
+      // setup each activated version
+      _currActivatedVersion.withValue(activatedVersion) {
+
+        cfor(0)(
+          i => i < ergoTreeVers.length && ergoTreeVers(i) <= activatedVersion,
+          _ + 1) { j =>
+          val treeVersion = ergoTreeVers(j)
+          // for each tree version up to currently activated, set it up and execute block
+          _currErgoTreeVersion.withValue(treeVersion)(block)
+        }
+
+      }
+    }
+  }
+
+  /** Helper method which executes the given `block` once for each `activatedVers`.
+    * The method sets the dynamic variable activatedVersionInTests with is then available
+    * in the block.
+    */
+  def forEachActivatedScriptVersion(activatedVers: Seq[Byte])(block: => Unit): Unit = {
+    cfor(0)(_ < activatedVers.length, _ + 1) { i =>
+      val activatedVersion = activatedVers(i)
+      _currActivatedVersion.withValue(activatedVersion)(block)
+    }
+  }
+
+  /** Helper method which executes the given `block` once for each `ergoTreeVers`.
+    * The method sets the dynamic variable ergoTreeVersionInTests with is then available
+    * in the block.
+    */
+  def forEachErgoTreeVersion(ergoTreeVers: Seq[Byte])(block: => Unit): Unit = {
+    cfor(0)(_ < ergoTreeVers.length, _ + 1) { i =>
+      val version = ergoTreeVers(i)
+      _currErgoTreeVersion.withValue(version)(block)
+    }
+  }
+
+  val printVersions: Boolean = false
+
+  protected def testFun_Run(testName: String, testFun: => Any): Unit = {
+    def msg = s"""property("$testName")(ActivatedVersion = $activatedVersionInTests; ErgoTree version = $ergoTreeVersionInTests)"""
+    if (printVersions) println(msg)
+    try testFun
+    catch {
+      case t: Throwable =>
+        if (!printVersions) {
+          // wasn't printed, print it now
+          println(msg)
+        }
+        throw t
+    }
+  }
+
+}

--- a/common/src/test/scala/sigmastate/VersionTestingProperty.scala
+++ b/common/src/test/scala/sigmastate/VersionTestingProperty.scala
@@ -4,7 +4,7 @@ import org.scalactic.source.Position
 import org.scalatest.{PropSpec, Tag}
 
 /** Decorator trait which allows to redefine `property` so that it is executed repeatedly for each valid
-  * [[VersionContext]], which is property initialized.
+  * [[VersionContext]], which is properly initialized.
   * Thus, the properties can be versioned using `VersionContext.current`.
   */
 trait VersionTestingProperty extends PropSpec with VersionTesting {

--- a/common/src/test/scala/sigmastate/VersionTestingProperty.scala
+++ b/common/src/test/scala/sigmastate/VersionTestingProperty.scala
@@ -1,0 +1,26 @@
+package sigmastate
+
+import org.scalactic.source.Position
+import org.scalatest.{PropSpec, Tag}
+
+/** Decorator trait which allows to redefine `property` so that it is executed repeatedly for each valid
+  * [[VersionContext]], which is property initialized.
+  * Thus, the properties can be versioned using `VersionContext.current`.
+  */
+trait VersionTestingProperty extends PropSpec with VersionTesting {
+
+  /** Redefine `property` so that testFun is executed repeatedly for each valid
+   * [[VersionContext]] */
+  override protected def property(testName: String, testTags: Tag*)
+                                 (testFun: => Any)
+                                 (implicit pos: Position): Unit = {
+    super.property(testName, testTags:_*) {
+      forEachScriptAndErgoTreeVersion(activatedVersions, ergoTreeVersions) {
+        VersionContext.withVersions(activatedVersionInTests, ergoTreeVersionInTests) {
+          testFun_Run(testName, testFun)
+        }
+      }
+    }
+  }
+
+}

--- a/library-impl/src/main/scala/special/collection/CollsOverArrays.scala
+++ b/library-impl/src/main/scala/special/collection/CollsOverArrays.scala
@@ -293,7 +293,9 @@ class CollOverArrayBuilder extends CollBuilder {
   }
 
   @NeverInline
-  override def makeView[@specialized A, @specialized B: RType](source: Coll[A], f: A => B): Coll[B] = new CViewColl(source, f)
+  override def makeView[@specialized A, @specialized B: RType](source: Coll[A], f: A => B): Coll[B] = {
+    new CViewColl(source, f)
+  }
 
   @NeverInline
   override def makePartialView[@specialized A, @specialized B: RType](source: Coll[A], f: A => B, calculated: Array[Boolean], calculatedItems: Array[B]): Coll[B] = {
@@ -318,8 +320,9 @@ class CollOverArrayBuilder extends CollBuilder {
   }
 
   @NeverInline
-  override def xor(left: Coll[Byte], right: Coll[Byte]): Coll[Byte] =
+  override def xor(left: Coll[Byte], right: Coll[Byte]): Coll[Byte] = {
     left.zip(right).map { case (l, r) => (l ^ r).toByte }
+  }
 
   @NeverInline
   override def emptyColl[T](implicit cT: RType[T]): Coll[T] = cT match {

--- a/library-impl/src/main/scala/special/collection/CollsOverArrays.scala
+++ b/library-impl/src/main/scala/special/collection/CollsOverArrays.scala
@@ -318,7 +318,8 @@ class CollOverArrayBuilder extends CollBuilder {
   }
 
   @NeverInline
-  override def xor(left: Coll[Byte], right: Coll[Byte]): Coll[Byte] = left.zip(right).map { case (l, r) => (l ^ r).toByte }
+  override def xor(left: Coll[Byte], right: Coll[Byte]): Coll[Byte] =
+    left.zip(right).map { case (l, r) => (l ^ r).toByte }
 
   @NeverInline
   override def emptyColl[T](implicit cT: RType[T]): Coll[T] = cT match {

--- a/library/src/test/scala/special/collections/CollsTests.scala
+++ b/library/src/test/scala/special/collections/CollsTests.scala
@@ -60,24 +60,27 @@ class CollsTests extends PropSpec with PropertyChecks with Matchers with CollGen
       val pairs = xs.zip(xs)
       equalLength(pairs)
 
-      // TODO v5.0: make it work
       if (VersionContext.current.isEvaluateErgoTreeUsingJIT) {
         // problem fixed in v5.0
-//        equalLengthMapped(pairs, squared(inc))
+        equalLengthMapped(pairs, squared(inc))
       } else {
-        //      an[ClassCastException] should be thrownBy {
-        //        equalLengthMapped(pairs, squared(inc))  // due to problem with append
-        //      }
+        if (!xs.isInstanceOf[CReplColl[_]]) {
+          an[ClassCastException] should be thrownBy {
+            equalLengthMapped(pairs, squared(inc))  // due to problem with append
+          }
+        }
       }
 
       equalLength(pairs.append(pairs))
 
-      // TODO v5.0: make it work
-//      an[ClassCastException] should be thrownBy {
-//        equalLengthMapped(pairs.append(pairs), squared(inc)) // due to problem with append
-//      }
-      VersionContext.withVersions(VersionContext.JitActivationVersion, VersionContext.JitActivationVersion) {
-//        equalLengthMapped(pairs.append(pairs), squared(inc)) // problem fixed in v5.0
+      if (VersionContext.current.isEvaluateErgoTreeUsingJIT) {
+        equalLengthMapped(pairs.append(pairs), squared(inc)) // problem fixed in v5.0
+      } else {
+        if (!xs.isInstanceOf[CReplColl[_]]) {
+          an[ClassCastException] should be thrownBy {
+            equalLengthMapped(pairs.append(pairs), squared(inc)) // due to problem with append
+          }
+        }
       }
     }
   }

--- a/library/src/test/scala/special/collections/CollsTests.scala
+++ b/library/src/test/scala/special/collections/CollsTests.scala
@@ -59,21 +59,21 @@ class CollsTests extends PropSpec with PropertyChecks with Matchers with CollGen
       val pairs = xs.zip(xs)
       equalLength(pairs)
 
-      an[ClassCastException] should be thrownBy {
-        equalLengthMapped(pairs, squared(inc))  // due to problem with append
-      }
+      // TODO v5.0: make it work
+//      an[ClassCastException] should be thrownBy {
+//        equalLengthMapped(pairs, squared(inc))  // due to problem with append
+//      }
       VersionContext.withVersions(VersionContext.JitActivationVersion, VersionContext.JitActivationVersion) {
-// TODO v5.0: make it work
 //        equalLengthMapped(pairs, squared(inc))  // problem fixed in v5.0
       }
 
       equalLength(pairs.append(pairs))
 
-      an[ClassCastException] should be thrownBy {
-        equalLengthMapped(pairs.append(pairs), squared(inc)) // due to problem with append
-      }
+      // TODO v5.0: make it work
+//      an[ClassCastException] should be thrownBy {
+//        equalLengthMapped(pairs.append(pairs), squared(inc)) // due to problem with append
+//      }
       VersionContext.withVersions(VersionContext.JitActivationVersion, VersionContext.JitActivationVersion) {
-// TODO v5.0: make it work
 //        equalLengthMapped(pairs.append(pairs), squared(inc)) // problem fixed in v5.0
       }
     }

--- a/library/src/test/scala/special/collections/CollsTests.scala
+++ b/library/src/test/scala/special/collections/CollsTests.scala
@@ -257,17 +257,17 @@ class CollsTests extends PropSpec with PropertyChecks with Matchers with CollGen
 
   property("Coll.append") {
 
-    { // this shows how the problem with CollectionUtil.concatArrays manifests itself in Coll.append
+    { // this shows how the problem with CollectionUtil.concatArrays manifests itself in Coll.append (v4.x)
       val xs = builder.fromItems(1, 2)
       val pairs = xs.zip(xs)
       val ys = pairs.map(squared(inc)) // this map transforms PairOfCols to CollOverArray
 
-      // due to the problem with concatArrays
-      an[ClassCastException] should be thrownBy (ys.append(ys))
-
-      VersionContext.withVersions(VersionContext.JitActivationVersion, VersionContext.JitActivationVersion) {
-        // TODO v5.0: make it work
-        //  ys.append(ys).toArray shouldBe ys.toArray ++ ys.toArray // problem fixed in v5.0
+      if (VersionContext.current.isEvaluateErgoTreeUsingJIT) {
+        // problem fixed in v5.0
+        ys.append(ys).toArray shouldBe ys.toArray ++ ys.toArray
+      } else {
+        // due to the problem with CollectionUtil.concatArrays
+        an[ClassCastException] should be thrownBy (ys.append(ys))
       }
     }
 

--- a/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
+++ b/sigma-impl/src/main/scala/special/sigma/SigmaDslOverArrays.scala
@@ -42,7 +42,7 @@ class TestSigmaDslBuilder extends SigmaDslBuilder {
 
   @NeverInline
   override def xorOf(conditions: Coll[Boolean]): Boolean = {
-    if (VersionContext.current.ergoTreeVersion >= JitActivationVersion) {
+    if (VersionContext.current.activatedVersion >= JitActivationVersion) {
       val len = conditions.length
       if (len == 0) false
       else if (len == 1) conditions(0)

--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeContext.scala
@@ -71,33 +71,33 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
   Examined ergo code: all that leads to ErgoLikeContext creation.
   Fixed some cases in ergo where PreHeader might be null.
    */
-  assert(preHeader != null, "preHeader cannot be null")
+  require(preHeader != null, "preHeader cannot be null")
   /* NOHF PROOF:
   Added: assert(spendingTransaction != null)
   Motivation: to fail early
   Safety: According to ergo design spendingTransaction should always exist.
   Examined ergo code: all that leads to ErgoLikeContext creation.
    */
-  assert(spendingTransaction != null, "spendingTransaction cannot be null")
+  require(spendingTransaction != null, "spendingTransaction cannot be null")
   /* NOHF PROOF:
   Added: assert that box with `selfIndex` exist in boxesToSpend
   Motivation: to fail early, rather than when going into evaluation
   Safety: ergo itself uses index to identify the box
   Examined ergo code: all that leads to ErgoLikeContext creation.
  */
-  assert(boxesToSpend.isDefinedAt(selfIndex), s"Self box if defined should be among boxesToSpend")
-  assert(headers.toArray.headOption.forall(h => java.util.Arrays.equals(h.stateRoot.digest.toArray, lastBlockUtxoRoot.digest)), "Incorrect lastBlockUtxoRoot")
+  require(boxesToSpend.isDefinedAt(selfIndex), s"Self box if defined should be among boxesToSpend")
+  require(headers.toArray.headOption.forall(h => java.util.Arrays.equals(h.stateRoot.digest.toArray, lastBlockUtxoRoot.digest)), "Incorrect lastBlockUtxoRoot")
   cfor(0)(_ < headers.length, _ + 1) { i =>
-    if (i > 0) assert(headers(i - 1).parentId == headers(i).id, s"Incorrect chain: ${headers(i - 1).parentId},${headers(i).id}")
+    if (i > 0) require(headers(i - 1).parentId == headers(i).id, s"Incorrect chain: ${headers(i - 1).parentId},${headers(i).id}")
   }
-  assert(headers.toArray.headOption.forall(_.id == preHeader.parentId), s"preHeader.parentId should be id of the best header")
+  require(headers.toArray.headOption.forall(_.id == preHeader.parentId), s"preHeader.parentId should be id of the best header")
   /* NOHF PROOF:
   Added: assert that dataBoxes corresponds to spendingTransaction.dataInputs
   Motivation: to fail early, rather than when going into evaluation
   Safety: dataBoxes and spendingTransaction are supplied separately in ergo. No checks in ergo.
   Examined ergo code: all that leads to ErgoLikeContext creation.
  */
-  assert(spendingTransaction.dataInputs.length == dataBoxes.length &&
+  require(spendingTransaction.dataInputs.length == dataBoxes.length &&
     spendingTransaction.dataInputs.forall(dataInput => dataBoxes.exists(b => util.Arrays.equals(b.id, dataInput.boxId))),
     "dataBoxes do not correspond to spendingTransaction.dataInputs")
 
@@ -171,7 +171,7 @@ class ErgoLikeContext(val lastBlockUtxoRoot: AvlTreeData,
     val ergoTreeVersion = currentErgoTreeVersion.getOrElse(
         Interpreter.error(s"Undefined context property: currentErgoTreeVersion"))
     CostingDataContext(
-      dataInputs, headers, preHeader, inputs, outputs, preHeader.height, selfBox, avlTree,
+      dataInputs, headers, preHeader, inputs, outputs, preHeader.height, selfBox, selfIndex, avlTree,
       preHeader.minerPk.getEncoded, vars, activatedScriptVersion, ergoTreeVersion, isCost)
   }
 

--- a/sigmastate/src/main/scala/sigmastate/Values.scala
+++ b/sigmastate/src/main/scala/sigmastate/Values.scala
@@ -808,7 +808,7 @@ object Values {
       val dhtSerializer = ProveDHTupleSerializer(ProveDHTuple.apply)
       val dlogSerializer = ProveDlogSerializer(ProveDlog.apply)
 
-      // TODO mainnet v5.0: control maxTreeDepth same as in deserialize
+      // TODO v5.x: control maxTreeDepth same as in deserialize
       override def serialize(data: SigmaBoolean, w: SigmaByteWriter): Unit = {
         w.put(data.opCode)
         data match {
@@ -1037,7 +1037,6 @@ object Values {
   implicit class SigmaPropValueOps(val p: Value[SSigmaProp.type]) extends AnyVal {
     def isProven: Value[SBoolean.type] = SigmaPropIsProven(p)
     def propBytes: Value[SByteArray] = SigmaPropBytes(p)
-    // TODO mainnet v5.0: replace usages in tests with mkTestErgoTree
     def treeWithSegregation: ErgoTree = ErgoTree.withSegregation(p)
     def treeWithSegregation(headerFlags: Byte): ErgoTree =
       ErgoTree.withSegregation(headerFlags, p)

--- a/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -112,9 +112,6 @@ trait CompiletimeCosting extends RuntimeCosting { IR: IRContext =>
         else
           eval(mkUpcast(numValue, tRes))
 
-      case Terms.Apply(Select(col, SliceMethod.name, _), Seq(from, until)) =>
-        eval(mkSlice(col.asValue[SCollection[SType]], from.asIntValue, until.asIntValue))
-
       case Terms.Apply(Select(col, ExistsMethod.name, _), Seq(l)) if l.tpe.isFunc =>
         eval(mkExists(col.asValue[SCollection[SType]], l.asFunc))
 

--- a/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -112,12 +112,6 @@ trait CompiletimeCosting extends RuntimeCosting { IR: IRContext =>
         else
           eval(mkUpcast(numValue, tRes))
 
-      case Terms.Apply(Select(col, ExistsMethod.name, _), Seq(l)) if l.tpe.isFunc =>
-        eval(mkExists(col.asValue[SCollection[SType]], l.asFunc))
-
-      case Terms.Apply(Select(col, ForallMethod.name, _), Seq(l)) if l.tpe.isFunc =>
-        eval(mkForAll(col.asValue[SCollection[SType]], l.asFunc))
-
       case Terms.Apply(Select(col, MapMethod.name, _), Seq(l)) if l.tpe.isFunc =>
         eval(mkMapCollection(col.asValue[SCollection[SType]], l.asFunc))
 

--- a/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -75,18 +75,6 @@ trait CompiletimeCosting extends RuntimeCosting { IR: IRContext =>
           error(s"Invalid register name $regName in expression $sel", sel.sourceContext.toOption))
         eval(mkExtractRegisterAs(box.asBox, reg, SOption(valType)).asValue[SOption[valType.type]])
 
-      // opt.get =>
-      case Select(nrv: Value[SOption[SType]]@unchecked, SOption.Get, _) =>
-        eval(mkOptionGet(nrv))
-
-      // opt.getOrElse =>
-      case Terms.Apply(Select(nrv: Value[SOption[SType]]@unchecked, SOption.GetOrElse, _), Seq(arg)) =>
-        eval(mkOptionGetOrElse(nrv, arg))
-
-      // opt.isDefined =>
-      case Select(nrv: Value[SOption[SType]]@unchecked, SOption.IsDefined, _) =>
-        eval(mkOptionIsDefined(nrv))
-
       case sel @ Select(obj, field, _) if obj.tpe == SBox =>
         (obj.asValue[SBox.type], field) match {
           case (box, SBox.Value) => eval(mkExtractAmount(box))
@@ -111,12 +99,6 @@ trait CompiletimeCosting extends RuntimeCosting { IR: IRContext =>
           eval(mkDowncast(numValue, tRes))
         else
           eval(mkUpcast(numValue, tRes))
-
-//      case Terms.Apply(Select(col, MapMethod.name, _), Seq(l)) if l.tpe.isFunc =>
-//        eval(mkMapCollection(col.asValue[SCollection[SType]], l.asFunc))
-
-//      case Terms.Apply(Select(col, FoldMethod.name, _), Seq(zero, l @ Terms.Lambda(_, _, _, _))) =>
-//        eval(mkFold(col.asValue[SCollection[SType]], zero, l))
 
       case Terms.Apply(col, Seq(index)) if col.tpe.isCollection =>
         eval(mkByIndex(col.asCollection[SType], index.asValue[SInt.type], None))

--- a/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CompiletimeCosting.scala
@@ -112,22 +112,14 @@ trait CompiletimeCosting extends RuntimeCosting { IR: IRContext =>
         else
           eval(mkUpcast(numValue, tRes))
 
-      case Terms.Apply(Select(col, MapMethod.name, _), Seq(l)) if l.tpe.isFunc =>
-        eval(mkMapCollection(col.asValue[SCollection[SType]], l.asFunc))
+//      case Terms.Apply(Select(col, MapMethod.name, _), Seq(l)) if l.tpe.isFunc =>
+//        eval(mkMapCollection(col.asValue[SCollection[SType]], l.asFunc))
 
-      case Terms.Apply(Select(col, FoldMethod.name, _), Seq(zero, l @ Terms.Lambda(_, _, _, _))) =>
-        eval(mkFold(col.asValue[SCollection[SType]], zero, l))
+//      case Terms.Apply(Select(col, FoldMethod.name, _), Seq(zero, l @ Terms.Lambda(_, _, _, _))) =>
+//        eval(mkFold(col.asValue[SCollection[SType]], zero, l))
 
       case Terms.Apply(col, Seq(index)) if col.tpe.isCollection =>
         eval(mkByIndex(col.asCollection[SType], index.asValue[SInt.type], None))
-
-      case Select(input, ModQMethod.name, _) =>
-        eval(mkModQ(input.asBigInt))
-
-      case Terms.Apply(Select(l, PlusModQMethod.name, _), Seq(r)) =>
-        eval(mkPlusModQ(l.asBigInt, r.asBigInt))
-      case Terms.Apply(Select(l, MinusModQMethod.name, _), Seq(r)) =>
-        eval(mkMinusModQ(l.asBigInt, r.asBigInt))
 
       case _ =>
         super.evalNode(ctx, env, node)

--- a/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
@@ -692,7 +692,7 @@ class CostingSigmaDslBuilder extends TestSigmaDslBuilder { dsl =>
   override def substConstants[T](scriptBytes: Coll[Byte],
                                  positions: Coll[Int],
                                  newValues: Coll[T]): Coll[Byte] = {
-    val typedNewVals = newValues.toArray.map(v => TransformingSigmaBuilder.liftAny(v) match {
+    val typedNewVals = newValues.toArray.map(v => TransformingSigmaBuilder.liftToConstant(v) match {
       case Nullable(v) => v
       case _ => sys.error(s"Cannot evaluate substConstants($scriptBytes, $positions, $newValues): cannot lift value $v")
     })

--- a/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/CostingDataContext.scala
@@ -723,6 +723,7 @@ case class CostingDataContext(
                                outputs: Coll[Box],
                                height: Int,
                                selfBox: Box,
+                               private val selfIndex: Int,
                                lastBlockUtxoRootHash: AvlTree,
                                _minerPubKey: Coll[Byte],
                                vars: Coll[AnyValue],
@@ -746,17 +747,15 @@ case class CostingDataContext(
 
   @inline override def minerPubKey = _minerPubKey
 
-
-  private def findSelfBoxIndex: Int = {
-    var i = 0
-    while (i < inputs.length) {
-      if (inputs(i) eq selfBox) return i
-      i += 1
+  override def selfBoxIndex: Int = {
+    if (VersionContext.current.isEvaluateErgoTreeUsingJIT) {
+      // starting from v5.0 this is fixed
+      selfIndex
+    } else {
+      // this used to be a bug in v4.x (https://github.com/ScorexFoundation/sigmastate-interpreter/issues/603)
+      -1
     }
-    -1
   }
-
-  override val selfBoxIndex: Int = findSelfBoxIndex
 
   override def getVar[T](id: Byte)(implicit tT: RType[T]): Option[T] = {
     if (isCost) {

--- a/sigmastate/src/main/scala/sigmastate/eval/Zero.scala
+++ b/sigmastate/src/main/scala/sigmastate/eval/Zero.scala
@@ -51,8 +51,8 @@ object Zero extends ZeroLowPriority {
     case AvlTreeRType => Zero[AvlTree]
     case SigmaPropRType => sigmaPropIsZero
     case ct: CollType[a] => collIsZero(typeToZero(ct.tItem), ct.tItem)
-    case ct: OptionType[a] => optionIsZero(typeToZero(ct.tA))  // TODO cover with tests (2h)
-    case ct: PairType[a, b] => pairIsZero(typeToZero(ct.tFst), typeToZero(ct.tSnd)) // TODO cover with tests (1h)
+    case ct: OptionType[a] => optionIsZero(typeToZero(ct.tA))  // TODO cover with tests or remove in v5.x (2h)
+    case ct: PairType[a, b] => pairIsZero(typeToZero(ct.tFst), typeToZero(ct.tSnd)) // TODO cover with tests or remove in v5.x (1h)
     case _ => sys.error(s"Don't know how to compute Zero for type $t")
   }).asInstanceOf[Zero[T]]
 

--- a/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala
@@ -19,7 +19,7 @@ import scala.collection.mutable
 /** This works in tandem with ConstantSerializer, if you change one make sure to check the other.*/
 object DataSerializer {
 
-  // TODO mainnet v5.0: control maxTreeDepth same as in deserialize
+  // TODO v5.x: control maxTreeDepth same as in deserialize
   /** Use type descriptor `tpe` to deconstruct type structure and recursively serialize subcomponents.
     * Primitive types are leaves of the type tree, and they are served as basis of recursion.
     * The data value `v` is expected to conform to the type described by `tpe`.

--- a/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
+++ b/sigmastate/src/main/scala/sigmastate/serialization/ValueSerializer.scala
@@ -346,7 +346,7 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     }
   }
 
-  // TODO mainnet v5.0: control maxTreeDepth same as in deserialize
+  // TODO v5.x: control maxTreeDepth same as in deserialize
   override def serialize(v: Value[SType], w: SigmaByteWriter): Unit = serializable(v) match {
     case c: Constant[SType] =>
       w.constantExtractionStore match {

--- a/sigmastate/src/main/scala/sigmastate/trees.scala
+++ b/sigmastate/src/main/scala/sigmastate/trees.scala
@@ -1123,9 +1123,7 @@ case class Xor(override val left: Value[SByteArray],
   protected final override def eval(env: DataEnv)(implicit E: ErgoTreeEvaluator): Any = {
     val lV = left.evalTo[Coll[Byte]](env)
     val rV = right.evalTo[Coll[Byte]](env)
-    addSeqCost(Xor.costKind, lV.length) { () =>
-      Colls.xor(lV, rV)
-    }
+    Xor.xorWithCosting(lV, rV)
   }
 }
 object Xor extends TwoArgumentOperationCompanion {
@@ -1134,6 +1132,13 @@ object Xor extends TwoArgumentOperationCompanion {
   override val costKind = PerItemCost(
     baseCost = JitCost(10), perChunkCost = JitCost(2), chunkSize = 128)
   override def argInfos: Seq[ArgInfo] = XorInfo.argInfos
+
+  /** Helper method which compute xor with correct costing accumulation */
+  def xorWithCosting(ls: Coll[Byte], rs: Coll[Byte])(implicit E: ErgoTreeEvaluator): Coll[Byte] = {
+    E.addSeqCost(Xor.costKind, math.min(ls.length, rs.length), Xor.opDesc) { () =>
+      Colls.xor(ls, rs)
+    }
+  }
 }
 
 case class Exponentiate(override val left: Value[SGroupElement.type],

--- a/sigmastate/src/main/scala/sigmastate/trees.scala
+++ b/sigmastate/src/main/scala/sigmastate/trees.scala
@@ -746,8 +746,8 @@ case class SubstConstants[T <: SType](scriptBytes: Value[SByteArray], positions:
     val newValuesV = newValues.evalTo[Coll[T#WrappedType]](env)
     var res: Coll[Byte] = null
     E.addSeqCost(SubstConstants.costKind, SubstConstants.opDesc) { () =>
-      val typedNewVals: Array[SValue] = newValuesV.toArray.map { v =>
-        TransformingSigmaBuilder.liftAny(v) match {
+      val typedNewVals: Array[Constant[SType]] = newValuesV.toArray.map { v =>
+        TransformingSigmaBuilder.liftToConstant(v) match {
           case Nullable(v) => v
           case _ => sys.error(s"Cannot evaluate substConstants($scriptBytesV, $positionsV, $newValuesV): cannot lift value $v")
         }
@@ -787,7 +787,7 @@ object SubstConstants extends ValueCompanion {
     */
   def eval(scriptBytes: Array[Byte],
            positions: Array[Int],
-           newVals: Array[Value[SType]])(implicit vs: SigmaValidationSettings): (Array[Byte], Int) =
+           newVals: Array[Constant[SType]])(implicit vs: SigmaValidationSettings): (Array[Byte], Int) =
     ErgoTreeSerializer.DefaultSerializer.substituteConstants(scriptBytes, positions, newVals)
 }
 

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1436,7 +1436,7 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
         ArgInfo("index", "index of the element of this collection"),
         ArgInfo("default", "value to return when \\lst{index} is out of range"))
 
-  /** Implements evaluation of Coll.map method call ErgoTree node.
+  /** Implements evaluation of Coll.getOrElse method call ErgoTree node.
     * Called via reflection based on naming convention.
     * @see SMethod.evalMethod
     */

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1440,6 +1440,9 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
 
   val MapMethod = SMethod(this, "map",
     SFunc(Array(ThisType, SFunc(tIV, tOV)), tOVColl, Array(paramIV, paramOV)), 3, MapCollection.costKind)
+      .withIRInfo({
+        case (builder, obj, _, Seq(mapper), _) => builder.mkMapCollection(obj.asValue[SCollection[SType]], mapper.asFunc)
+      })
       .withInfo(MapCollection,
         """ Builds a new collection by applying a function to all elements of this collection.
          | Returns a new collection of type \lst{Coll[B]} resulting from applying the given function
@@ -1473,6 +1476,9 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
     this, "fold",
     SFunc(Array(ThisType, tOV, SFunc(Array(tOV, tIV), tOV)), tOV, Array(paramIV, paramOV)),
     5, Fold.costKind)
+      .withIRInfo({
+        case (builder, obj, _, Seq(z, op), _) => builder.mkFold(obj.asValue[SCollection[SType]], z, op.asFunc)
+      })
       .withInfo(Fold, "Applies a binary operator to a start value and all elements of this collection, going left to right.",
         ArgInfo("zero", "a starting value"),
         ArgInfo("op", "the binary operator"))

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -2746,6 +2746,15 @@ case object SGlobal extends SProduct with SPredefType with SMonoType {
     .withInfo(Xor, "Byte-wise XOR of two collections of bytes",
       ArgInfo("left", "left operand"), ArgInfo("right", "right operand"))
 
+  /** Implements evaluation of Global.xor method call ErgoTree node.
+    * Called via reflection based on naming convention.
+    * @see SMethod.evalMethod, Xor.eval, Xor.xorWithCosting
+    */
+  def xor_eval(mc: MethodCall, G: SigmaDslBuilder, ls: Coll[Byte], rs: Coll[Byte])
+              (implicit E: ErgoTreeEvaluator): Coll[Byte] = {
+    Xor.xorWithCosting(ls, rs)
+  }
+
   protected override def getMethods() = super.getMethods() ++ Seq(
     groupGeneratorMethod,
     xorMethod

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1485,6 +1485,10 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
 
   val SliceMethod = SMethod(this, "slice",
     SFunc(Array(ThisType, SInt, SInt), ThisType, paramIVSeq), 7, Slice.costKind)
+      .withIRInfo({
+        case (builder, obj, _, Seq(from, until), _) =>
+          builder.mkSlice(obj.asCollection[SType], from.asIntValue, until.asIntValue)
+      })
       .withInfo(Slice,
         """Selects an interval of elements.  The returned collection is made up
          |  of all elements \lst{x} which satisfy the invariant:

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1301,15 +1301,24 @@ object SOption extends STypeCompanion {
   /** The following SMethod instances are descriptors of methods defined in `Option` type. */
   val IsDefinedMethod = SMethod(
     this, IsDefined, SFunc(ThisType, SBoolean), 2, OptionIsDefined.costKind)
+      .withIRInfo({
+        case (builder, obj, _, args, _) if args.isEmpty => builder.mkOptionIsDefined(obj.asValue[SOption[SType]])
+      })
       .withInfo(OptionIsDefined,
         "Returns \\lst{true} if the option is an instance of \\lst{Some}, \\lst{false} otherwise.")
 
   val GetMethod = SMethod(this, Get, SFunc(ThisType, tT), 3, OptionGet.costKind)
+      .withIRInfo({
+        case (builder, obj, _, args, _) if args.isEmpty => builder.mkOptionGet(obj.asValue[SOption[SType]])
+      })
       .withInfo(OptionGet,
       """Returns the option's value. The option must be nonempty. Throws exception if the option is empty.""")
 
   lazy val GetOrElseMethod = SMethod(
     this, GetOrElse, SFunc(Array(ThisType, tT), tT, Array[STypeParam](tT)), 4, OptionGetOrElse.costKind)
+      .withIRInfo(irBuilder = {
+        case (builder, obj, _, Seq(d), _) => builder.mkOptionGetOrElse(obj.asValue[SOption[SType]], d)
+      })
       .withInfo(OptionGetOrElse,
         """Returns the option's value if the option is nonempty, otherwise
          |return the result of evaluating \lst{default}.

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1460,6 +1460,9 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
 
   val ExistsMethod = SMethod(this, "exists",
     SFunc(Array(ThisType, tPredicate), SBoolean, paramIVSeq), 4, Exists.costKind)
+      .withIRInfo({
+        case (builder, obj, _, Seq(c), _) => builder.mkExists(obj.asValue[SCollection[SType]], c.asFunc)
+      })
       .withInfo(Exists,
         """Tests whether a predicate holds for at least one element of this collection.
          |Returns \lst{true} if the given predicate \lst{p} is satisfied by at least one element of this collection, otherwise \lst{false}
@@ -1476,6 +1479,9 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
 
   val ForallMethod = SMethod(this, "forall",
     SFunc(Array(ThisType, tPredicate), SBoolean, paramIVSeq), 6, ForAll.costKind)
+      .withIRInfo({
+        case (builder, obj, _, Seq(c), _) => builder.mkForAll(obj.asValue[SCollection[SType]], c.asFunc)
+      })
       .withInfo(ForAll,
         """Tests whether a predicate holds for all elements of this collection.
          |Returns \lst{true} if this collection is empty or the given predicate \lst{p}

--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1545,7 +1545,7 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
     * 2) new collection is allocated for each item
     * 3) each collection is then appended to the resulting collection */
   val FlatMapMethod_CostKind = PerItemCost(
-    baseCost = JitCost(30), perChunkCost = JitCost(5), chunkSize = 8)
+    baseCost = JitCost(60), perChunkCost = JitCost(10), chunkSize = 8)
 
   val FlatMapMethod = SMethod(this, "flatMap",
     SFunc(Array(ThisType, SFunc(tIV, tOVColl)), tOVColl, Array(paramIV, paramOV)),
@@ -1637,9 +1637,13 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
             if isValidPropertyAccess(varId, lambdaBody) =>
         // ok, do nothing
       case _ =>
-        ErgoTreeEvaluator.error(
-          s"Unsupported lambda in flatMap: allowed usage `xs.flatMap(x => x.property)`: $mc")
+        throwInvalidFlatmap(mc)
     }
+  }
+
+  def throwInvalidFlatmap(mc: MethodCall) = {
+    ErgoTreeEvaluator.error(
+      s"Unsupported lambda in flatMap: allowed usage `xs.flatMap(x => x.property)`: $mc")
   }
 
   /** Implements evaluation of Coll.flatMap method call ErgoTree node.
@@ -1648,7 +1652,9 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
     */
   def flatMap_eval[A, B](mc: MethodCall, xs: Coll[A], f: A => Coll[B])
                         (implicit E: ErgoTreeEvaluator): Coll[B] = {
-    checkValidFlatmap(mc)
+    if (!VersionContext.current.isEvaluateErgoTreeUsingJIT) {
+      checkValidFlatmap(mc)
+    }
     val m = mc.method
     var res: Coll[B] = null
     E.addSeqCost(m.costKind.asInstanceOf[PerItemCost], m.opDesc) { () =>

--- a/sigmastate/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/sigmastate/src/main/scala/sigmastate/utxo/transformers.scala
@@ -271,7 +271,7 @@ case class ByIndex[V <: SType](input: Value[SCollection[V]],
     default match {
       case Some(d) =>
         val dV = d.evalTo[V#WrappedType](env)
-        Value.checkType(d, dV) // necessary because cast to V#WrappedType is erased
+        Value.checkType(d.tpe, dV) // necessary because cast to V#WrappedType is erased
         addCost(ByIndex.costKind)
         inputV.getOrElse(indexV, dV)
       case _ =>

--- a/sigmastate/src/main/scala/sigmastate/utxo/transformers.scala
+++ b/sigmastate/src/main/scala/sigmastate/utxo/transformers.scala
@@ -271,7 +271,7 @@ case class ByIndex[V <: SType](input: Value[SCollection[V]],
     default match {
       case Some(d) =>
         val dV = d.evalTo[V#WrappedType](env)
-        Value.checkType(d.tpe, dV) // necessary because cast to V#WrappedType is erased
+        Value.checkType(d, dV) // necessary because cast to V#WrappedType is erased
         addCost(ByIndex.costKind)
         inputV.getOrElse(indexV, dV)
       case _ =>

--- a/sigmastate/src/test/scala/sigmastate/CrossVersionProps.scala
+++ b/sigmastate/src/test/scala/sigmastate/CrossVersionProps.scala
@@ -9,27 +9,11 @@ import scala.util.DynamicVariable
 
 trait CrossVersionProps extends PropSpecLike with TestsBase {
 
-  val printVersions: Boolean = false
-
   /** Number of times each test property is warmed up (i.e. executed before final execution). */
   def perTestWarmUpIters: Int = 0
 
   private[sigmastate] val _warmupProfiler = new DynamicVariable[Option[Profiler]](None)
   def warmupProfiler: Option[Profiler] = _warmupProfiler.value
-
-  protected def testFun_Run(testName: String, testFun: => Any): Unit = {
-    def msg = s"""property("$testName")(ActivatedVersion = $activatedVersionInTests; ErgoTree version = $ergoTreeVersionInTests)"""
-    if (printVersions) println(msg)
-    try testFun
-    catch {
-      case t: Throwable =>
-        if (!printVersions) {
-          // wasn't printed, print it now
-          println(msg)
-        }
-        throw t
-    }
-  }
 
   override protected def property(testName: String, testTags: Tag*)
                                  (testFun: => Any)

--- a/sigmastate/src/test/scala/sigmastate/ErgoTreeSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ErgoTreeSpecification.scala
@@ -597,7 +597,7 @@ class ErgoTreeSpecification extends SigmaDslTesting {
     val xs = Coll(Array.tabulate[Byte](size)(i => i.toByte):_*)
 
     val (y, details) = oldF(xs)
-    assert(details.actualTimeNano.get < 10000000)
+    assert(details.actualTimeNano.get < 1000000000 /* 1 sec */)
 
     if (expected.isDefined) {
       val e = expected.get(xs)

--- a/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/ScriptVersionSwitchSpecification.scala
@@ -30,7 +30,7 @@ class ScriptVersionSwitchSpecification extends SigmaDslTesting {
 
   implicit def IR = createIR()
 
-  val b1 = CostingBox(
+  lazy val b1 = CostingBox(
     false,
     new ErgoBox(
       1L,

--- a/sigmastate/src/test/scala/sigmastate/TestsBase.scala
+++ b/sigmastate/src/test/scala/sigmastate/TestsBase.scala
@@ -14,76 +14,12 @@ import spire.syntax.all.cfor
 
 import scala.util.DynamicVariable
 
-trait TestsBase extends Matchers {
-
-  val activatedVersions: Seq[Byte] =
-    (0 to VersionContext.MaxSupportedScriptVersion).map(_.toByte).toArray[Byte]
-
-  private[sigmastate] val _currActivatedVersion = new DynamicVariable[Byte](0)
-  def activatedVersionInTests: Byte = _currActivatedVersion.value
-
-  /** Checks if the current activated script version used in tests corresponds to v4.x. */
-  def isActivatedVersion4: Boolean = activatedVersionInTests < VersionContext.JitActivationVersion
-
-  val ergoTreeVersions: Seq[Byte] =
-    (0 to VersionContext.MaxSupportedScriptVersion).map(_.toByte).toArray[Byte]
-
-  private[sigmastate] val _currErgoTreeVersion = new DynamicVariable[Byte](0)
-
-  /** Current ErgoTree version assigned dynamically using [[CrossVersionProps]]. */
-  def ergoTreeVersionInTests: Byte = _currErgoTreeVersion.value
+trait TestsBase extends Matchers with VersionTesting {
 
   /** Current ErgoTree header flags assigned dynamically using [[CrossVersionProps]] and
     * ergoTreeVersionInTests.
     */
   def ergoTreeHeaderInTests: Byte = ErgoTree.headerWithVersion(ergoTreeVersionInTests)
-
-  /** Executes the given block for each combination of _currActivatedVersion and
-    * _currErgoTreeVersion assigned to dynamic variables.
-    */
-  def forEachScriptAndErgoTreeVersion
-        (activatedVers: Seq[Byte], ergoTreeVers: Seq[Byte])
-        (block: => Unit): Unit = {
-    cfor(0)(_ < activatedVers.length, _ + 1) { i =>
-      val activatedVersion = activatedVers(i)
-      // setup each activated version
-      _currActivatedVersion.withValue(activatedVersion) {
-
-        cfor(0)(
-          i => i < ergoTreeVers.length && ergoTreeVers(i) <= activatedVersion,
-          _ + 1) { j =>
-          val treeVersion = ergoTreeVers(j)
-          // for each tree version up to currently activated, set it up and execute block
-          _currErgoTreeVersion.withValue(treeVersion)(block)
-        }
-
-      }
-    }
-  }
-
-
-  /** Helper method which executes the given `block` once for each `activatedVers`.
-    * The method sets the dynamic variable activatedVersionInTests with is then available
-    * in the block.
-    */
-  def forEachActivatedScriptVersion(activatedVers: Seq[Byte])(block: => Unit): Unit = {
-    cfor(0)(_ < activatedVers.length, _ + 1) { i =>
-      val activatedVersion = activatedVers(i)
-      _currActivatedVersion.withValue(activatedVersion)(block)
-    }
-  }
-
-  /** Helper method which executes the given `block` once for each `ergoTreeVers`.
-    * The method sets the dynamic variable ergoTreeVersionInTests with is then available
-    * in the block.
-    */
-  def forEachErgoTreeVersion(ergoTreeVers: Seq[Byte])(block: => Unit): Unit = {
-    cfor(0)(_ < ergoTreeVers.length, _ + 1) { i =>
-      val version = ergoTreeVers(i)
-      _currErgoTreeVersion.withValue(version)(block)
-    }
-  }
-
   /** Obtains [[ErgoTree]] which corresponds to True proposition using current
     * ergoTreeHeaderInTests. */
   def TrueTree: ErgoTree = ErgoScriptPredef.TrueProp(ergoTreeHeaderInTests)

--- a/sigmastate/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
+++ b/sigmastate/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
@@ -172,7 +172,7 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests
         val compiledProp = IR.buildTree(asRep[Context => SType#WrappedType](calcF))
         checkExpected(compiledProp, expectedTree, "Compiled Tree actual: %s, expected: %s")
 
-        val ergoTree = compiledProp.treeWithSegregation
+        val ergoTree = mkTestErgoTree(compiledProp)
         val compiledTreeBytes = DefaultSerializer.serializeErgoTree(ergoTree)
         checkExpected(DefaultSerializer.deserializeErgoTree(compiledTreeBytes), Some(ergoTree),
           "(de)serialization round trip actual: %s, expected: %s")

--- a/sigmastate/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
+++ b/sigmastate/src/test/scala/sigmastate/eval/ErgoScriptTestkit.scala
@@ -69,7 +69,7 @@ trait ErgoScriptTestkit extends ContractsTestkit with LangTests
   lazy val backerPubKey = backerProver.dlogSecrets.head.publicImage
   lazy val projectPubKey = projectProver.dlogSecrets.head.publicImage
 
-  val boxToSpend = testBox(10, TrueTree, 0,
+  lazy val boxToSpend = testBox(10, TrueTree, 0,
     additionalRegisters = Map(ErgoBox.R4 -> BigIntArrayConstant(bigIntegerArr1)))
   lazy val tx1Output1 = testBox(minToRaise, projectPubKey, 0)
   lazy val tx1Output2 = testBox(1, projectPubKey, 0)

--- a/sigmastate/src/test/scala/sigmastate/eval/EvaluationTest.scala
+++ b/sigmastate/src/test/scala/sigmastate/eval/EvaluationTest.scala
@@ -104,12 +104,12 @@ class EvaluationTest extends BaseCtxTests
     val pk2 = DLogProverInput.random().publicImage
     val script1 = script(pk1)
     val script2 = script(pk2)
-    val inputBytes = DefaultSerializer.serializeErgoTree(script1.treeWithSegregation)
+    val inputBytes = DefaultSerializer.serializeErgoTree(mkTestErgoTree(script1))
     val positions = IntArrayConstant(Array[Int](2))
     // in ergo we have only byte array of a serialized group element
     val newVals = ConcreteCollection(Array[SigmaPropValue](CreateProveDlog(DecodePoint(pk2.pkBytes))), SSigmaProp)
 
-    val expectedBytes = DefaultSerializer.serializeErgoTree(script2.treeWithSegregation)
+    val expectedBytes = DefaultSerializer.serializeErgoTree(mkTestErgoTree(script2))
     val ctx = newErgoContext(height = 1, boxToSpend)
     reduce(emptyEnv, "SubstConst",
       EQ(SubstConstants(inputBytes, positions, newVals), expectedBytes),

--- a/sigmastate/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/sigmastate/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -652,11 +652,11 @@ class SigmaTyperTest extends PropSpec with PropertyChecks with Matchers with Lan
     val pk2 = DLogProverInput.random().publicImage
     val script1 = script(pk1)
     val script2 = script(pk2)
-    val inputBytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(script1.treeWithSegregation)
+    val inputBytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(mkTestErgoTree(script1))
     val positions = IntArrayConstant(Array[Int](2))
     val newVals = ConcreteCollection(Array[SigmaPropValue](SigmaPropConstant(pk2)), SSigmaProp)
 
-    val expectedBytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(script2.treeWithSegregation)
+    val expectedBytes = ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(mkTestErgoTree(script2))
 
     val customEnv: ScriptEnv = Map(
       "scriptBytes" -> Colls.fromArray(inputBytes),

--- a/sigmastate/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
+++ b/sigmastate/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
@@ -1,9 +1,8 @@
 package sigmastate.serialization
 
 import java.math.BigInteger
-
 import org.ergoplatform.ErgoBox
-import sigmastate.Values.{ShortConstant, BigIntConstant, ConstantPlaceholder, Value, SigmaPropValue, IntConstant, ErgoTree, ByteConstant}
+import sigmastate.Values.{ShortConstant, BigIntConstant, ConstantPlaceholder, SigmaPropValue, IntConstant, ErgoTree, ByteConstant}
 import sigmastate._
 import sigmastate.eval.{IRContext, CBigInt}
 import sigmastate.helpers.SigmaTestingCommons
@@ -146,5 +145,29 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification
       parsedTree._hasDeserialize.isDefined shouldBe true
       parsedTree.hasDeserialize shouldBe hasDeserialize
     }
+  }
+
+  property("getPositionsBackref") {
+    def test(positions: Array[Int], expected: Array[Int]) = {
+      val backrefs = ErgoTreeSerializer.DefaultSerializer.getPositionsBackref(positions, expected.length)
+      backrefs shouldBe expected
+    }
+
+    test(positions = Array(), expected = Array()) // no positions, no constants
+    test(positions = Array(), expected = Array(-1)) // no positions, 1 constant
+    test(positions = Array(0), expected = Array())  // 1 position, no constants
+    test(positions = Array(1), expected = Array(-1)) // 1 position, but out of range
+    test(positions = Array(0), expected = Array(0))  // 1 position, 1 constant
+    test(positions = Array(-1), expected = Array())  // 1 invalid (out of range) position, no constants
+    test(positions = Array(-2), expected = Array(-1))  // 1 invalid position, 1 constants
+
+    test(positions = Array(0, 0), expected = Array(0))  // duplicate positions, 1 constant
+    test(positions = Array(-1, 0), expected = Array(1))  // invalid positions ignored
+    test(positions = Array(-1, 0, 0), expected = Array(1))  // only first of the duplicates used
+     
+    test(positions = Array(), expected = Array(-1, -1, -1, -1, -1))  // no positions => no backrefs
+
+    test(positions = Array(1, 2), expected = Array(-1, 0, 1, -1, -1))
+    test(positions = Array(1, 2, 4), expected = Array(-1, 0, 1, -1, 2))
   }
 }

--- a/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
+++ b/sigmastate/src/test/scala/special/sigma/ContractsTestkit.scala
@@ -70,7 +70,7 @@ trait ContractsTestkit {
                   currErgoTreeVersion: Byte, vars: Array[AnyValue]) =
     new CostingDataContext(
       noInputs.toColl, noHeaders, dummyPreHeader,
-      inputs.toColl, outputs.toColl, height, self, tree,
+      inputs.toColl, outputs.toColl, height, self, inputs.indexOf(self), tree,
       minerPk.toColl, vars.toColl, activatedScriptVersion, currErgoTreeVersion, false)
 
   def newContext(height: Int, self: Box, activatedScriptVersion: Byte, currErgoTreeVersion: Byte, vars: AnyValue*): CostingDataContext = {

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -5563,60 +5563,66 @@ class SigmaDslSpecification extends SigmaDslTesting
     }
   }
 
-  property("Coll[Box] methods equivalence") {
-    val samples = genSamples[Coll[Box]](collOfN[Box](5), MinSuccessful(20))
-    val b1 = CostingBox(
-      false,
-      new ErgoBox(
-        1L,
-        new ErgoTree(
-          0.toByte,
-          Vector(),
-          Right(
-            SigmaPropConstant(
-              CSigmaProp(
-                ProveDHTuple(
-                  Helpers.decodeECPoint("02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b"),
-                  Helpers.decodeECPoint("027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e419"),
-                  Helpers.decodeECPoint("0257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281"),
-                  Helpers.decodeECPoint("033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd5")
-                )
+  def sampleCollBoxes = genSamples[Coll[Box]](collOfN[Box](5), MinSuccessful(20))
+
+  def create_b1 = CostingBox(
+    false,
+    new ErgoBox(
+      1L,
+      new ErgoTree(
+        0.toByte,
+        Vector(),
+        Right(
+          SigmaPropConstant(
+            CSigmaProp(
+              ProveDHTuple(
+                Helpers.decodeECPoint("02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b"),
+                Helpers.decodeECPoint("027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e419"),
+                Helpers.decodeECPoint("0257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281"),
+                Helpers.decodeECPoint("033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd5")
               )
             )
           )
+        )
+      ),
+      Coll(),
+      Map(
+        ErgoBox.R4 -> ByteArrayConstant(
+          Helpers.decodeBytes(
+            "7200004cccdac3008001bc80ffc7ff9633bca3e501801380ff007900019d7f0001a8c9dfff5600d964011617ca00583f989c7f80007fee7f99b07f7f870067dc315180828080307fbdf400"
+          )
         ),
-        Coll(),
-        Map(
-          ErgoBox.R4 -> ByteArrayConstant(
-            Helpers.decodeBytes(
-              "7200004cccdac3008001bc80ffc7ff9633bca3e501801380ff007900019d7f0001a8c9dfff5600d964011617ca00583f989c7f80007fee7f99b07f7f870067dc315180828080307fbdf400"
-            )
-          ),
-          ErgoBox.R7 -> LongConstant(0L),
-          ErgoBox.R6 -> FalseLeaf,
-          ErgoBox.R5 -> ByteArrayConstant(Helpers.decodeBytes("7f"))
-        ),
-        ModifierId @@ ("7dffff48ab0000c101a2eac9ff17017f6180aa7fc6f2178000800179499380a5"),
-        21591.toShort,
-        638768
-      )
+        ErgoBox.R7 -> LongConstant(0L),
+        ErgoBox.R6 -> FalseLeaf,
+        ErgoBox.R5 -> ByteArrayConstant(Helpers.decodeBytes("7f"))
+      ),
+      ModifierId @@ ("7dffff48ab0000c101a2eac9ff17017f6180aa7fc6f2178000800179499380a5"),
+      21591.toShort,
+      638768
     )
-    val b2 = CostingBox(
-      false,
-      new ErgoBox(
-        1000000000L,
-        new ErgoTree(
-          0.toByte,
-          Vector(),
-          Right(BoolToSigmaProp(OR(ConcreteCollection(Array(FalseLeaf, AND(ConcreteCollection(Array(FalseLeaf, FalseLeaf), SBoolean))), SBoolean))))
-        ),
-        Coll(),
-        Map(),
-        ModifierId @@ ("008677ffff7ff36dff00f68031140400007689ff014c9201ce8000a9ffe6ceff"),
-        32767.toShort,
-        32827
-      )
+  )
+
+  def create_b2 = CostingBox(
+    false,
+    new ErgoBox(
+      1000000000L,
+      new ErgoTree(
+        0.toByte,
+        Vector(),
+        Right(BoolToSigmaProp(OR(ConcreteCollection(Array(FalseLeaf, AND(ConcreteCollection(Array(FalseLeaf, FalseLeaf), SBoolean))), SBoolean))))
+      ),
+      Coll(),
+      Map(),
+      ModifierId @@ ("008677ffff7ff36dff00f68031140400007689ff014c9201ce8000a9ffe6ceff"),
+      32767.toShort,
+      32827
     )
+  )
+
+  property("Coll.filter equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
 
     verifyCases(
       {
@@ -5628,15 +5634,21 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       },
       existingFeature({ (x: Coll[Box]) => x.filter({ (b: Box) => b.value > 1 }) },
-        "{ (x: Coll[Box]) => x.filter({(b: Box) => b.value > 1 }) }",
-        FuncValue(
-          Vector((1, SCollectionType(SBox))),
-          Filter(
-            ValUse(1, SCollectionType(SBox)),
-            FuncValue(Vector((3, SBox)), GT(ExtractAmount(ValUse(3, SBox)), LongConstant(1L)))
-          )
-        )),
+      "{ (x: Coll[Box]) => x.filter({(b: Box) => b.value > 1 }) }",
+      FuncValue(
+        Vector((1, SCollectionType(SBox))),
+        Filter(
+          ValUse(1, SCollectionType(SBox)),
+          FuncValue(Vector((3, SBox)), GT(ExtractAmount(ValUse(3, SBox)), LongConstant(1L)))
+        )
+      )),
       preGeneratedSamples = Some(samples))
+  }
+
+  property("Coll[Box] methods equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
 
     verifyCases(
       {
@@ -6655,7 +6667,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       preGeneratedSamples = Some(samples))
   }
 
-  property("Coll append method equivalence") {
+  property("Coll.append equivalence") {
     if (lowerMethodCallsInTests) {
       verifyCases(
       {
@@ -6690,7 +6702,15 @@ class SigmaDslSpecification extends SigmaDslTesting
           )
         )))
     } else {
-      // TODO mainnet v5.0: add test case with `SCollection.append` MethodCall
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[Int](), Coll[Int]()) -> Expected(Success(Coll[Int]()), 37765) ),
+          existingFeature(
+            { (x: (Coll[Int], Coll[Int])) => x._1.append(x._2) },
+            "{ (x: (Coll[Int], Coll[Int])) => x._1.append(x._2) }"
+            )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.append(scalan.Base$Ref)")
+      )
     }
   }
 

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -5127,6 +5127,8 @@ class SigmaDslSpecification extends SigmaDslTesting
           newDetails = CostDetails.ZeroCost,
           newCost = newC,
           newVersionedResults = Seq(
+            0 -> (ExpectedResult(Success(newV), Some(newC)) -> None),
+            1 -> (ExpectedResult(Success(newV), Some(newC)) -> None),
             2 -> (ExpectedResult(Success(newV), Some(newC)) -> None)
           ))
         val newCost = 1786

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -102,18 +102,20 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   import TestData._
 
-  prepareSamples[BigInt]
-  prepareSamples[GroupElement]
-  prepareSamples[AvlTree]
-  prepareSamples[Box]
-  prepareSamples[PreHeader]
-  prepareSamples[Header]
-  prepareSamples[(BigInt, BigInt)]
-  prepareSamples[(GroupElement, GroupElement)]
-  prepareSamples[(AvlTree, AvlTree)]
-  prepareSamples[(Box, Box)]
-  prepareSamples[(PreHeader, PreHeader)]
-  prepareSamples[(Header, Header)]
+  override protected def beforeAll(): Unit = {
+    prepareSamples[BigInt]
+    prepareSamples[GroupElement]
+    prepareSamples[AvlTree]
+    prepareSamples[Box]
+    prepareSamples[PreHeader]
+    prepareSamples[Header]
+    prepareSamples[(BigInt, BigInt)]
+    prepareSamples[(GroupElement, GroupElement)]
+    prepareSamples[(AvlTree, AvlTree)]
+    prepareSamples[(Box, Box)]
+    prepareSamples[(PreHeader, PreHeader)]
+    prepareSamples[(Header, Header)]
+  }
 
   ///=====================================================
   ///              Boolean type operations
@@ -5323,13 +5325,25 @@ class SigmaDslSpecification extends SigmaDslTesting
           ((Helpers.decodeBytes("01"), Helpers.decodeBytes("01")), success(Helpers.decodeBytes("00"))),
           ((Helpers.decodeBytes("0100"), Helpers.decodeBytes("0101")), success(Helpers.decodeBytes("0001"))),
           ((Helpers.decodeBytes("01"), Helpers.decodeBytes("0101")), success(Helpers.decodeBytes("00"))),
-          ((Helpers.decodeBytes("0100"), Helpers.decodeBytes("01")), Expected(new ArrayIndexOutOfBoundsException("1"))),
+          ((Helpers.decodeBytes("0100"), Helpers.decodeBytes("01")) ->
+            Expected(Failure(new ArrayIndexOutOfBoundsException("1")),
+              cost = 0,
+              newDetails = CostDetails.ZeroCost,
+              newCost = 1789,
+              newVersionedResults = Seq(
+                VersionContext.JitActivationVersion.toInt -> (
+                  ExpectedResult(Success(Helpers.decodeBytes("00")), Some(1789)),
+                  None)
+              )
+            )),
           ((Helpers.decodeBytes("800136fe89afff802acea67128a0ff007fffe3498c8001806080012b"),
               Helpers.decodeBytes("648018010a5d5800f5b400a580e7b4809b0cd273ff1230bfa800017f7fdb002749b3ac2b86ff")),
               success(Helpers.decodeBytes("e4812eff83f2a780df7aa6d4a8474b80e4f3313a7392313fc8800054")))
         )
       },
-      existingFeature((x: (Coll[Byte], Coll[Byte])) => SigmaDsl.xor(x._1, x._2),
+      changedFeature(
+        (x: (Coll[Byte], Coll[Byte])) => SigmaDsl.xor(x._1, x._2),
+        (x: (Coll[Byte], Coll[Byte])) => SigmaDsl.xor(x._1, x._2),
         "{ (x: (Coll[Byte], Coll[Byte])) => xor(x._1, x._2) }",
         FuncValue(
           Vector((1, STuple(Vector(SByteArray, SByteArray)))),

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -6622,7 +6622,8 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   property("Coll slice method equivalence") {
     val samples = genSamples(collWithRangeGen, DefaultMinSuccessful)
-    verifyCases(
+    if (lowerMethodCallsInTests) {
+      verifyCases(
       // (coll, (from, until))
       {
         def success[T](v: T) = Expected(Success(v), 36964)
@@ -6664,7 +6665,17 @@ class SigmaDslSpecification extends SigmaDslTesting
             )
           )
         )),
-      preGeneratedSamples = Some(samples))
+        preGeneratedSamples = Some(samples))
+    } else {
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[Int](), (-1, 0)) -> Expected(Success(Coll[Int]()), 37765) ),
+          existingFeature((x: (Coll[Int], (Int, Int))) => x._1.slice(x._2._1, x._2._2),
+            "{ (x: (Coll[Int], (Int, Int))) => x._1.slice(x._2._1, x._2._2) }"
+          )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.slice(scalan.Base$Ref,scalan.Base$Ref)")
+      )
+    }
   }
 
   property("Coll.append equivalence") {

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -62,6 +62,15 @@ class SigmaDslSpecification extends SigmaDslTesting
   with CrossVersionProps
   with BeforeAndAfterAll { suite =>
 
+  /** Use VersionContext so that each property in this suite runs under correct
+    * parameters.
+    */
+  protected override def testFun_Run(testName: String, testFun: => Any): Unit = {
+    VersionContext.withVersions(activatedVersionInTests, ergoTreeVersionInTests) {
+      super.testFun_Run(testName, testFun)
+    }
+  }
+
   implicit override val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 30)
 
   val evalSettingsInTests = ErgoTreeEvaluator.DefaultEvalSettings.copy(
@@ -4282,6 +4291,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       ),
       height = 11,
       selfBox = input.copy(),  // in 3.x, 4.x implementation selfBox is never the same instance as input (see toSigmaContext)
+      selfIndex = 0,
       lastBlockUtxoRootHash = CAvlTree(
         AvlTreeData(
           ADDigest @@ (ErgoAlgos.decodeUnsafe("54d23dd080006bdb56800100356080935a80ffb77e90b800057f00661601807f17")),
@@ -4481,10 +4491,18 @@ class SigmaDslSpecification extends SigmaDslTesting
         )),
       preGeneratedSamples = Some(samples))
 
-    // TODO v5.0: fix selfBoxIndex for ET v2
     verifyCases(
-      Seq((ctx, Expected(Success(-1), cost = 36318))),
-      existingFeature({ (x: Context) => x.selfBoxIndex },
+      Seq(
+        (ctx, Expected(
+          Success(-1), cost = 36318,
+          newDetails = CostDetails.ZeroCost,
+          newCost = 1786,
+          newVersionedResults = Seq(
+            2 -> (ExpectedResult(Success(0), Some(1786)) -> None)
+          )))
+      ),
+      changedFeature({ (x: Context) => x.selfBoxIndex },
+        { (x: Context) => x.selfBoxIndex }, // see versioning in selfBoxIndex implementation
         "{ (x: Context) => x.selfBoxIndex }",
         FuncValue(
           Vector((1, SContext)),
@@ -4497,9 +4515,15 @@ class SigmaDslSpecification extends SigmaDslTesting
         )),
       preGeneratedSamples = Some(samples))
 
-    // TODO v5.0 (2h): see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/603
+    // test vectors to reproduce v4.x bug (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/603)
     samples.foreach { c =>
-      ctx.selfBoxIndex shouldBe -1
+      if (VersionContext.current.isEvaluateErgoTreeUsingJIT) {
+        // fixed in v5.0
+        c.selfBoxIndex should not be(-1)
+      } else {
+        // should be reproduced in v4.x
+        c.selfBoxIndex shouldBe -1
+      }
     }
 
     verifyCases(

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -5645,7 +5645,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       preGeneratedSamples = Some(samples))
   }
 
-  property("Coll[Box] methods equivalence") {
+  property("Coll.flatMap equivalence") {
     val samples = sampleCollBoxes
     val b1 = create_b1
     val b2 = create_b2
@@ -5664,19 +5664,25 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       },
       existingFeature({ (x: Coll[Box]) => x.flatMap({ (b: Box) => b.propositionBytes }) },
-        "{ (x: Coll[Box]) => x.flatMap({(b: Box) => b.propositionBytes }) }",
-        FuncValue(
-          Vector((1, SCollectionType(SBox))),
-          MethodCall.typed[Value[SCollection[SByte.type]]](
-            ValUse(1, SCollectionType(SBox)),
-            SCollection.getMethodByName("flatMap").withConcreteTypes(
-              Map(STypeVar("IV") -> SBox, STypeVar("OV") -> SByte)
-            ),
-            Vector(FuncValue(Vector((3, SBox)), ExtractScriptBytes(ValUse(3, SBox)))),
-            Map()
-          )
-        )),
+      "{ (x: Coll[Box]) => x.flatMap({(b: Box) => b.propositionBytes }) }",
+      FuncValue(
+        Vector((1, SCollectionType(SBox))),
+        MethodCall.typed[Value[SCollection[SByte.type]]](
+          ValUse(1, SCollectionType(SBox)),
+          SCollection.getMethodByName("flatMap").withConcreteTypes(
+            Map(STypeVar("IV") -> SBox, STypeVar("OV") -> SByte)
+          ),
+          Vector(FuncValue(Vector((3, SBox)), ExtractScriptBytes(ValUse(3, SBox)))),
+          Map()
+        )
+      )),
       preGeneratedSamples = Some(samples))
+  }
+
+  property("Coll.zip equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
 
     verifyCases(
       {
@@ -5688,20 +5694,25 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       },
       existingFeature({ (x: Coll[Box]) => x.zip(x) },
-        "{ (x: Coll[Box]) => x.zip(x) }",
-        FuncValue(
-          Vector((1, SCollectionType(SBox))),
-          MethodCall.typed[Value[SCollection[STuple]]](
-            ValUse(1, SCollectionType(SBox)),
-            SCollection.getMethodByName("zip").withConcreteTypes(
-              Map(STypeVar("IV") -> SBox, STypeVar("OV") -> SBox)
-            ),
-            Vector(ValUse(1, SCollectionType(SBox))),
-            Map()
-          )
-        )),
+      "{ (x: Coll[Box]) => x.zip(x) }",
+      FuncValue(
+        Vector((1, SCollectionType(SBox))),
+        MethodCall.typed[Value[SCollection[STuple]]](
+          ValUse(1, SCollectionType(SBox)),
+          SCollection.getMethodByName("zip").withConcreteTypes(
+            Map(STypeVar("IV") -> SBox, STypeVar("OV") -> SBox)
+          ),
+          Vector(ValUse(1, SCollectionType(SBox))),
+          Map()
+        )
+      )),
       preGeneratedSamples = Some(samples))
+  }
 
+  property("Coll.size equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
     verifyCases(
       {
         def success[T](v: T) = Expected(Success(v), 35954)
@@ -5712,10 +5723,15 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       },
       existingFeature({ (x: Coll[Box]) => x.size },
-        "{ (x: Coll[Box]) => x.size }",
-        FuncValue(Vector((1, SCollectionType(SBox))), SizeOf(ValUse(1, SCollectionType(SBox))))),
+      "{ (x: Coll[Box]) => x.size }",
+      FuncValue(Vector((1, SCollectionType(SBox))), SizeOf(ValUse(1, SCollectionType(SBox))))),
       preGeneratedSamples = Some(samples))
+  }
 
+  property("Coll.indices equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
     verifyCases(
       {
         def success[T](v: T) = Expected(Success(v), 36036)
@@ -5726,28 +5742,36 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       },
       existingFeature({ (x: Coll[Box]) => x.indices },
-        "{ (x: Coll[Box]) => x.indices }",
-        FuncValue(
-          Vector((1, SCollectionType(SBox))),
-          MethodCall.typed[Value[SCollection[SInt.type]]](
-            ValUse(1, SCollectionType(SBox)),
-            SCollection.getMethodByName("indices").withConcreteTypes(Map(STypeVar("IV") -> SBox)),
-            Vector(),
-            Map()
-          )
-        )),
+      "{ (x: Coll[Box]) => x.indices }",
+      FuncValue(
+        Vector((1, SCollectionType(SBox))),
+        MethodCall.typed[Value[SCollection[SInt.type]]](
+          ValUse(1, SCollectionType(SBox)),
+          SCollection.getMethodByName("indices").withConcreteTypes(Map(STypeVar("IV") -> SBox)),
+          Vector(),
+          Map()
+        )
+      )),
       preGeneratedSamples = Some(samples))
 
-    verifyCases(
-      {
-        def success[T](v: T, c: Int) = Expected(Success(v), c)
-        Seq(
-          (Coll[Box](), success(true, 37909)),
-          (Coll[Box](b1), success(false, 37969)),
-          (Coll[Box](b1, b2), success(false, 38029))
-        )
-      },
-      existingFeature({ (x: Coll[Box]) => x.forall({ (b: Box) => b.value > 1 }) },
+  }
+
+  property("Coll.forall equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
+
+    def success[T](v: T, c: Int) = Expected(Success(v), c)
+    if (lowerMethodCallsInTests) {
+      verifyCases(
+        {
+          Seq(
+            (Coll[Box](), success(true, 37909)),
+            (Coll[Box](b1), success(false, 37969)),
+            (Coll[Box](b1, b2), success(false, 38029))
+          )
+        },
+        existingFeature({ (x: Coll[Box]) => x.forall({ (b: Box) => b.value > 1 }) },
         "{ (x: Coll[Box]) => x.forall({(b: Box) => b.value > 1 }) }",
         FuncValue(
           Vector((1, SCollectionType(SBox))),
@@ -5756,18 +5780,36 @@ class SigmaDslSpecification extends SigmaDslTesting
             FuncValue(Vector((3, SBox)), GT(ExtractAmount(ValUse(3, SBox)), LongConstant(1L)))
           )
         )),
-      preGeneratedSamples = Some(samples))
+        preGeneratedSamples = Some(samples))
+    } else {
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[Box](), success(true, 37909)) ),
+          existingFeature(
+            { (x: Coll[Box]) => x.forall({ (b: Box) => b.value > 1 }) },
+            "{ (x: Coll[Box]) => x.forall({(b: Box) => b.value > 1 }) }"
+          )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.forall(scalan.Base$Ref)")
+      )
+    }
+  }
+  
+  property("Coll.exists equivalence") {
+    val samples = sampleCollBoxes
+    val b1 = create_b1
+    val b2 = create_b2
 
-    verifyCases(
-      {
-        def success[T](v: T, c: Int) = Expected(Success(v), c)
-        Seq(
-          (Coll[Box](), success(false, 38455)),
-          (Coll[Box](b1), success(false, 38515)),
-          (Coll[Box](b1, b2), success(true, 38575))
-        )
-      },
-      existingFeature({ (x: Coll[Box]) => x.exists({ (b: Box) => b.value > 1 }) },
+    def success[T](v: T, c: Int) = Expected(Success(v), c)
+    if (lowerMethodCallsInTests) {
+      verifyCases(
+        {
+          Seq(
+            (Coll[Box](), success(false, 38455)),
+            (Coll[Box](b1), success(false, 38515)),
+            (Coll[Box](b1, b2), success(true, 38575))
+          )
+        },
+        existingFeature({ (x: Coll[Box]) => x.exists({ (b: Box) => b.value > 1 }) },
         "{ (x: Coll[Box]) => x.exists({(b: Box) => b.value > 1 }) }",
         FuncValue(
           Vector((1, SCollectionType(SBox))),
@@ -5776,77 +5818,119 @@ class SigmaDslSpecification extends SigmaDslTesting
             FuncValue(Vector((3, SBox)), GT(ExtractAmount(ValUse(3, SBox)), LongConstant(1L)))
           )
         )),
-      preGeneratedSamples = Some(samples))
+        preGeneratedSamples = Some(samples))
+    } else {
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[Box](), success(false, 38455)) ),
+          existingFeature(
+            { (x: Coll[Box]) => x.exists({ (b: Box) => b.value > 1 }) },
+            "{ (x: Coll[Box]) => x.exists({(b: Box) => b.value > 1 }) }"
+          )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.exists(scalan.Base$Ref)")
+      )
+    }
   }
 
   property("Coll exists with nested If") {
     val o = NumericOps.BigIntIsExactOrdering
-    verifyCases(
-    {
-      def success[T](v: T, c: Int) = Expected(Success(v), c)
-      Seq(
-        (Coll[BigInt](), success(false, 38955)),
-        (Coll[BigInt](BigIntZero), success(false, 39045)),
-        (Coll[BigInt](BigIntOne), success(true, 39045)),
-        (Coll[BigInt](BigIntZero, BigIntOne), success(true, 39135)),
-        (Coll[BigInt](BigIntZero, BigInt10), success(false, 39135))
-      )
-    },
-    existingFeature(
-      { (x: Coll[BigInt]) => x.exists({ (b: BigInt) =>
-          if (o.gt(b, BigIntZero)) o.lt(b, BigInt10) else false
-        })
-      },
-      "{ (x: Coll[BigInt]) => x.exists({(b: BigInt) => if (b > 0) b < 10 else false }) }",
-      FuncValue(
-        Array((1, SCollectionType(SBigInt))),
-        Exists(
-          ValUse(1, SCollectionType(SBigInt)),
-          FuncValue(
-            Array((3, SBigInt)),
-            If(
-              GT(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("0", 16)))),
-              LT(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("a", 16)))),
-              FalseLeaf
-            )
+    def success[T](v: T, c: Int) = Expected(Success(v), c)
+    if (lowerMethodCallsInTests) {
+      verifyCases(
+        {
+          Seq(
+            (Coll[BigInt](), success(false, 38955)),
+            (Coll[BigInt](BigIntZero), success(false, 39045)),
+            (Coll[BigInt](BigIntOne), success(true, 39045)),
+            (Coll[BigInt](BigIntZero, BigIntOne), success(true, 39135)),
+            (Coll[BigInt](BigIntZero, BigInt10), success(false, 39135))
           )
-        )
-      )))
+        },
+        existingFeature(
+          { (x: Coll[BigInt]) => x.exists({ (b: BigInt) =>
+              if (o.gt(b, BigIntZero)) o.lt(b, BigInt10) else false
+            })
+          },
+          "{ (x: Coll[BigInt]) => x.exists({(b: BigInt) => if (b > 0) b < 10 else false }) }",
+          FuncValue(
+            Array((1, SCollectionType(SBigInt))),
+            Exists(
+              ValUse(1, SCollectionType(SBigInt)),
+              FuncValue(
+                Array((3, SBigInt)),
+                If(
+                  GT(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("0", 16)))),
+                  LT(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("a", 16)))),
+                  FalseLeaf
+                )
+              )
+            )
+          )))
+    } else {
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[BigInt](), success(false, 38955)) ),
+          existingFeature(
+            { (x: Coll[BigInt]) => x.exists({ (b: BigInt) =>
+              if (o.gt(b, BigIntZero)) o.lt(b, BigInt10) else false
+            })
+            },
+            "{ (x: Coll[BigInt]) => x.exists({(b: BigInt) => if (b > 0) b < 10 else false }) }"
+          )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.exists(scalan.Base$Ref)")
+      )
+    }
   }
 
   property("Coll forall with nested If") {
     val o = NumericOps.BigIntIsExactOrdering
-    verifyCases(
-    {
-      def success[T](v: T, c: Int) = Expected(Success(v), c)
-      Seq(
-        (Coll[BigInt](), success(true, 38412)),
-        (Coll[BigInt](BigIntMinusOne), success(false, 38502)),
-        (Coll[BigInt](BigIntOne), success(true, 38502)),
-        (Coll[BigInt](BigIntZero, BigIntOne), success(true, 38592)),
-        (Coll[BigInt](BigIntZero, BigInt11), success(false, 38592))
-      )
-    },
-    existingFeature(
-      { (x: Coll[BigInt]) => x.forall({ (b: BigInt) =>
-          if (o.gteq(b, BigIntZero)) o.lteq(b, BigInt10) else false
-        })
-      },
-      "{ (x: Coll[BigInt]) => x.forall({(b: BigInt) => if (b >= 0) b <= 10 else false }) }",
-      FuncValue(
-        Array((1, SCollectionType(SBigInt))),
-        ForAll(
-          ValUse(1, SCollectionType(SBigInt)),
-          FuncValue(
-            Array((3, SBigInt)),
-            If(
-              GE(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("0", 16)))),
-              LE(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("a", 16)))),
-              FalseLeaf
+    def success[T](v: T, c: Int) = Expected(Success(v), c)
+    if (lowerMethodCallsInTests) {
+      verifyCases(
+        {
+          Seq(
+            (Coll[BigInt](), success(true, 38412)),
+            (Coll[BigInt](BigIntMinusOne), success(false, 38502)),
+            (Coll[BigInt](BigIntOne), success(true, 38502)),
+            (Coll[BigInt](BigIntZero, BigIntOne), success(true, 38592)),
+            (Coll[BigInt](BigIntZero, BigInt11), success(false, 38592))
+          )
+        },
+        existingFeature(
+          { (x: Coll[BigInt]) => x.forall({ (b: BigInt) =>
+            if (o.gteq(b, BigIntZero)) o.lteq(b, BigInt10) else false
+          })
+          },
+          "{ (x: Coll[BigInt]) => x.forall({(b: BigInt) => if (b >= 0) b <= 10 else false }) }",
+        FuncValue(
+          Array((1, SCollectionType(SBigInt))),
+          ForAll(
+            ValUse(1, SCollectionType(SBigInt)),
+            FuncValue(
+              Array((3, SBigInt)),
+              If(
+                GE(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("0", 16)))),
+                LE(ValUse(3, SBigInt), BigIntConstant(CBigInt(new BigInteger("a", 16)))),
+                FalseLeaf
+              )
             )
           )
-        )
-      )))
+        )))
+    } else {
+      assertExceptionThrown(
+        verifyCases(
+          Seq( (Coll[BigInt](), success(true, 38412)) ),
+          existingFeature(
+            { (x: Coll[BigInt]) => x.forall({ (b: BigInt) =>
+              if (o.gteq(b, BigIntZero)) o.lteq(b, BigInt10) else false
+            })
+            },
+            "{ (x: Coll[BigInt]) => x.forall({(b: BigInt) => if (b >= 0) b <= 10 else false }) }"
+          )),
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.forall(scalan.Base$Ref)")
+      )
+    }
+
   }
 
   val collWithRangeGen = for {

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -7545,29 +7545,30 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Random headers access and comparison (originaly from spam tests)") {
     val (_, _, _, ctx, _, _) = contextData()
 
-    verifyCases(
-      Seq(
-        ctx -> Expected(
-          Failure(new NoSuchElementException("None.get")),
-          cost = 37694,
-          newDetails = CostDetails.ZeroCost,
-          newCost = 1796,
-          newVersionedResults = Seq(
-            0 -> (ExpectedResult(Success(true), Some(1796)) -> None),
-            1 -> (ExpectedResult(Success(true), Some(1796)) -> None),
-            2 -> (ExpectedResult(Success(true), Some(1796)) -> None)
+    if (lowerMethodCallsInTests) {
+      verifyCases(
+        Seq(
+          ctx -> Expected(
+            Failure(new NoSuchElementException("None.get")),
+            cost = 37694,
+            newDetails = CostDetails.ZeroCost,
+            newCost = 1796,
+            newVersionedResults = Seq(
+              0 -> (ExpectedResult(Success(true), Some(1796)) -> None),
+              1 -> (ExpectedResult(Success(true), Some(1796)) -> None),
+              2 -> (ExpectedResult(Success(true), Some(1796)) -> None)
+            )
           )
-        )
-      ),
-      changedFeature(
+        ),
+        changedFeature(
         { (x: Context) =>
           Option.empty[Int].get
           true
         },
         { (x: Context) =>
           val headers = x.headers
-          val ids = headers.map({(h: Header) => h.id })
-          val parentIds = headers.map({(h: Header) => h.parentId })
+          val ids = headers.map({ (h: Header) => h.id })
+          val parentIds = headers.map({ (h: Header) => h.parentId })
           headers.indices.slice(0, headers.size - 1).forall({ (i: Int) =>
             val parentId = parentIds(i)
             val id = ids(i + 1)
@@ -7575,16 +7576,16 @@ class SigmaDslSpecification extends SigmaDslTesting
           })
         },
         """{
-          |(x: Context) =>
-          |  val headers = x.headers
-          |  val ids = headers.map({(h: Header) => h.id })
-          |  val parentIds = headers.map({(h: Header) => h.parentId })
-          |  headers.indices.slice(0, headers.size - 1).forall({ (i: Int) =>
-          |    val parentId = parentIds(i)
-          |    val id = ids(i + 1)
-          |    parentId == id
-          |  })
-          |}""".stripMargin,
+         |(x: Context) =>
+         |  val headers = x.headers
+         |  val ids = headers.map({(h: Header) => h.id })
+         |  val parentIds = headers.map({(h: Header) => h.parentId })
+         |  headers.indices.slice(0, headers.size - 1).forall({ (i: Int) =>
+         |    val parentId = parentIds(i)
+         |    val id = ids(i + 1)
+         |    parentId == id
+         |  })
+         |}""".stripMargin,
         FuncValue(
           Array((1, SContext)),
           BlockValue(
@@ -7657,9 +7658,10 @@ class SigmaDslSpecification extends SigmaDslTesting
         ),
         allowDifferentErrors = true,
         allowNewToSucceed = true
-      ),
-      preGeneratedSamples = Some(mutable.WrappedArray.empty)
-    )
+        ),
+        preGeneratedSamples = Some(mutable.WrappedArray.empty)
+      )
+    }
   }
 
   override protected def afterAll(): Unit = {

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -6782,7 +6782,7 @@ class SigmaDslSpecification extends SigmaDslTesting
           existingFeature((x: (Coll[Int], (Int, Int))) => x._1.slice(x._2._1, x._2._2),
             "{ (x: (Coll[Int], (Int, Int))) => x._1.slice(x._2._1, x._2._2) }"
           )),
-        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.slice(scalan.Base$Ref,scalan.Base$Ref)")
+        rootCauseLike[NoSuchMethodException]("sigmastate.eval.CostingRules$CollCoster.slice")
       )
     }
   }

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -2578,163 +2578,217 @@ class SigmaDslSpecification extends SigmaDslTesting
       36337)(x => (cloneColl(x._1), x._2))
   }
 
-  property("GroupElement methods equivalence") {
+  property("GroupElement.getEncoded equivalence") {
     verifyCases(
-      {
-        val cost = TracedCost(
-          Array(
-            FixedCostItem(Apply),
-            FixedCostItem(FuncValue),
-            FixedCostItem(GetVar),
-            FixedCostItem(OptionGet),
-            FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
-            FixedCostItem(ValUse),
-            FixedCostItem(PropertyCall),
-            MethodCallCostItem(TracedCost(Array(FixedCostItem(SGroupElement.GetEncodedMethod, FixedCost(JitCost(3))))))
-          )
+    {
+      val cost = TracedCost(
+        Array(
+          FixedCostItem(Apply),
+          FixedCostItem(FuncValue),
+          FixedCostItem(GetVar),
+          FixedCostItem(OptionGet),
+          FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
+          FixedCostItem(ValUse),
+          FixedCostItem(PropertyCall),
+          MethodCallCostItem(TracedCost(Array(FixedCostItem(SGroupElement.GetEncodedMethod, FixedCost(JitCost(3))))))
         )
-        def success[T](v: T) = Expected(Success(v), 37905, cost)
-        Seq(
-          (ge1, success(Helpers.decodeBytes(ge1str))),
-          (ge2, success(Helpers.decodeBytes(ge2str))),
-          (ge3, success(Helpers.decodeBytes(ge3str))),
-          (SigmaDsl.groupGenerator,
-              success(Helpers.decodeBytes("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
-          (SigmaDsl.groupIdentity,
-              success(Helpers.decodeBytes("000000000000000000000000000000000000000000000000000000000000000000")))
-        )
-      },
-      existingFeature((x: GroupElement) => x.getEncoded,
-        "{ (x: GroupElement) => x.getEncoded }",
-        FuncValue(
-          Vector((1, SGroupElement)),
-          MethodCall(ValUse(1, SGroupElement), SGroupElement.getMethodByName("getEncoded"), Vector(), Map())
-        )))
+      )
+      def success[T](v: T) = Expected(Success(v), 37905, cost)
+      Seq(
+        (ge1, success(Helpers.decodeBytes(ge1str))),
+        (ge2, success(Helpers.decodeBytes(ge2str))),
+        (ge3, success(Helpers.decodeBytes(ge3str))),
+        (SigmaDsl.groupGenerator,
+          success(Helpers.decodeBytes("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
+        (SigmaDsl.groupIdentity,
+          success(Helpers.decodeBytes("000000000000000000000000000000000000000000000000000000000000000000")))
+      )
+    },
+    existingFeature((x: GroupElement) => x.getEncoded,
+      "{ (x: GroupElement) => x.getEncoded }",
+      FuncValue(
+        Vector((1, SGroupElement)),
+        MethodCall(ValUse(1, SGroupElement), SGroupElement.getMethodByName("getEncoded"), Vector(), Map())
+      )))
+  }
 
+  property("decodePoint(GroupElement.getEncoded) equivalence") {
     verifyCases(
-      {
-        val cost = TracedCost(
-          Array(
-            FixedCostItem(Apply),
-            FixedCostItem(FuncValue),
-            FixedCostItem(GetVar),
-            FixedCostItem(OptionGet),
-            FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
-            FixedCostItem(ValUse),
-            FixedCostItem(PropertyCall),
-            MethodCallCostItem(TracedCost(Array(FixedCostItem(MethodDesc(SGroupElement.GetEncodedMethod), FixedCost(JitCost(3)))))),
-            FixedCostItem(DecodePoint),
-            FixedCostItem(ValUse)
+    {
+      val cost = TracedCost(
+        Array(
+          FixedCostItem(Apply),
+          FixedCostItem(FuncValue),
+          FixedCostItem(GetVar),
+          FixedCostItem(OptionGet),
+          FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
+          FixedCostItem(ValUse),
+          FixedCostItem(PropertyCall),
+          MethodCallCostItem(TracedCost(Array(FixedCostItem(MethodDesc(SGroupElement.GetEncodedMethod), FixedCost(JitCost(3)))))),
+          FixedCostItem(DecodePoint),
+          FixedCostItem(ValUse)
+        )
+      )
+      def success[T](v: T) = Expected(Success(v), 38340, cost)
+      Seq(
+        (ge1, success(true)),
+        (ge2, success(true)),
+        (ge3, success(true)),
+        (SigmaDsl.groupGenerator, success(true)),
+        (SigmaDsl.groupIdentity, success(true))
+      )
+    },
+    existingFeature({ (x: GroupElement) => decodePoint(x.getEncoded) == x },
+    "{ (x: GroupElement) => decodePoint(x.getEncoded) == x }",
+    FuncValue(
+      Vector((1, SGroupElement)),
+      EQ(
+        DecodePoint(
+          MethodCall.typed[Value[SCollection[SByte.type]]](
+            ValUse(1, SGroupElement),
+            SGroupElement.getMethodByName("getEncoded"),
+            Vector(),
+            Map()
           )
+        ),
+        ValUse(1, SGroupElement)
+      )
+    )))
+  }
+
+  property("GroupElement.negate equivalence") {
+    verifyCases(
+    {
+      val cost = TracedCost(
+        Array(
+          FixedCostItem(Apply),
+          FixedCostItem(FuncValue),
+          FixedCostItem(GetVar),
+          FixedCostItem(OptionGet),
+          FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
+          FixedCostItem(ValUse),
+          FixedCostItem(PropertyCall),
+          MethodCallCostItem(TracedCost(Array(FixedCostItem(MethodDesc(SGroupElement.NegateMethod), FixedCost(JitCost(1))))))
         )
-        def success[T](v: T) = Expected(Success(v), 38340, cost)
-        Seq(
-          (ge1, success(true)),
-          (ge2, success(true)),
-          (ge3, success(true)),
-          (SigmaDsl.groupGenerator, success(true)),
-          (SigmaDsl.groupIdentity, success(true))
+      )
+      def success[T](v: T) = Expected(Success(v), 36292, cost)
+      Seq(
+        (ge1, success(Helpers.decodeGroupElement("02358d53f01276211f92d0aefbd278805121d4ff6eb534b777af1ee8abae5b2056"))),
+        (ge2, success(Helpers.decodeGroupElement("03dba7b94b111f3894e2f9120b577da595ec7d58d488485adf73bf4e153af63575"))),
+        (ge3, success(Helpers.decodeGroupElement("0390449814f5671172dd696a61b8aa49aaa4c87013f56165e27d49944e98bc414d"))),
+        (SigmaDsl.groupGenerator, success(Helpers.decodeGroupElement("0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
+        (SigmaDsl.groupIdentity, success(Helpers.decodeGroupElement("000000000000000000000000000000000000000000000000000000000000000000")))
+      )
+    },
+    existingFeature({ (x: GroupElement) => x.negate },
+    "{ (x: GroupElement) => x.negate }",
+    FuncValue(
+      Vector((1, SGroupElement)),
+      MethodCall(ValUse(1, SGroupElement), SGroupElement.getMethodByName("negate"), Vector(), Map())
+    )))
+  }
+
+  property("GroupElement.exp equivalence") {
+    val cases = {
+      val cost = TracedCost(
+        Array(
+          FixedCostItem(Apply),
+          FixedCostItem(FuncValue),
+          FixedCostItem(GetVar),
+          FixedCostItem(OptionGet),
+          FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
+          FixedCostItem(ValUse),
+          FixedCostItem(SelectField),
+          FixedCostItem(ValUse),
+          FixedCostItem(SelectField),
+          FixedCostItem(Exponentiate)
         )
-      },
-      existingFeature({ (x: GroupElement) => decodePoint(x.getEncoded) == x },
-        "{ (x: GroupElement) => decodePoint(x.getEncoded) == x }",
-        FuncValue(
-          Vector((1, SGroupElement)),
-          EQ(
-            DecodePoint(
-              MethodCall.typed[Value[SCollection[SByte.type]]](
-                ValUse(1, SGroupElement),
-                SGroupElement.getMethodByName("getEncoded"),
-                Vector(),
-                Map()
+      )
+      def success[T](v: T) = Expected(Success(v), 41484, cost)
+      Seq(
+        ((ge1, CBigInt(new BigInteger("-25c80b560dd7844e2efd10f80f7ee57d", 16))),
+          success(Helpers.decodeGroupElement("023a850181b7b73f92a5bbfa0bfc78f5bbb6ff00645ddde501037017e1a2251e2e"))),
+        ((ge2, CBigInt(new BigInteger("2488741265082fb02b09f992be3dd8d60d2bbe80d9e2630", 16))),
+          success(Helpers.decodeGroupElement("032045b928fb7774a4cd9ef5fa8209f4e493cd4cc5bd536b52746a53871bf73431"))),
+        ((ge3, CBigInt(new BigInteger("-33e8fbdb13d2982e92583445e1fdcb5901a178a7aa1e100", 16))),
+          success(Helpers.decodeGroupElement("036128efaf14d8ac2812a662f6494dc617b87986a3dc6b4a59440048a7ac7d2729"))),
+        ((ge3, CBigInt(new BigInteger("1", 16))),
+          success(ge3))
+      )
+    }
+    val scalaFunc = { (x: (GroupElement, BigInt)) => x._1.exp(x._2) }
+    val script = "{ (x: (GroupElement, BigInt)) => x._1.exp(x._2) }"
+    if (lowerMethodCallsInTests) {
+      verifyCases(cases,
+        existingFeature(
+          scalaFunc, script,
+          FuncValue(
+            Vector((1, STuple(Vector(SGroupElement, SBigInt)))),
+            Exponentiate(
+              SelectField.typed[Value[SGroupElement.type]](
+                ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
+                1.toByte
+              ),
+              SelectField.typed[Value[SBigInt.type]](
+                ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
+                2.toByte
               )
-            ),
-            ValUse(1, SGroupElement)
-          )
-        )))
-
-    verifyCases(
-      {
-        val cost = TracedCost(
-          Array(
-            FixedCostItem(Apply),
-            FixedCostItem(FuncValue),
-            FixedCostItem(GetVar),
-            FixedCostItem(OptionGet),
-            FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
-            FixedCostItem(ValUse),
-            FixedCostItem(PropertyCall),
-            MethodCallCostItem(TracedCost(Array(FixedCostItem(MethodDesc(SGroupElement.NegateMethod), FixedCost(JitCost(1))))))
-          )
-        )
-        def success[T](v: T) = Expected(Success(v), 36292, cost)
+            )
+          )))
+    } else {
+      verifyCases(
         Seq(
-          (ge1, success(Helpers.decodeGroupElement("02358d53f01276211f92d0aefbd278805121d4ff6eb534b777af1ee8abae5b2056"))),
-          (ge2, success(Helpers.decodeGroupElement("03dba7b94b111f3894e2f9120b577da595ec7d58d488485adf73bf4e153af63575"))),
-          (ge3, success(Helpers.decodeGroupElement("0390449814f5671172dd696a61b8aa49aaa4c87013f56165e27d49944e98bc414d"))),
-          (SigmaDsl.groupGenerator, success(Helpers.decodeGroupElement("0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
-          (SigmaDsl.groupIdentity, success(Helpers.decodeGroupElement("000000000000000000000000000000000000000000000000000000000000000000")))
-        )
-      },
-      existingFeature({ (x: GroupElement) => x.negate },
-        "{ (x: GroupElement) => x.negate }",
-        FuncValue(
-          Vector((1, SGroupElement)),
-          MethodCall(ValUse(1, SGroupElement), SGroupElement.getMethodByName("negate"), Vector(), Map())
-        )))
+          ((ge1, CBigInt(new BigInteger("-25c80b560dd7844e2efd10f80f7ee57d", 16))),
+            Expected(
+              // in v4.x exp method cannot be called via MethodCall ErgoTree node
+              Failure(new NoSuchMethodException("sigmastate.eval.CostingRules$GroupElementCoster.exp(scalan.Base$Ref)")),
+              cost = 41484,
+              CostDetails.ZeroCost,
+              newCost = 0,
+              newVersionedResults = {
+                // in v5.0 MethodCall ErgoTree node is allowed
+                val res = ExpectedResult(
+                  Success(Helpers.decodeGroupElement("023a850181b7b73f92a5bbfa0bfc78f5bbb6ff00645ddde501037017e1a2251e2e")),
+                  Some(1786)
+                )
+                Seq( // expected result for each version
+                  0 -> ( res -> None ),
+                  1 -> ( res -> None ),
+                  2 -> ( res -> None )
+                )
+              }
+            )
+            )
+        ),
+        changedFeature(
+          scalaFunc, scalaFunc, ""/*can't be compiled in v4.x*/,
+          FuncValue(
+            Vector((1, STuple(Vector(SGroupElement, SBigInt)))),
+            MethodCall(
+              SelectField.typed[Value[SGroupElement.type]](
+                ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
+                1.toByte
+              ),
+              SGroupElement.getMethodByName("exp"),
+              Vector(
+                SelectField.typed[Value[SBigInt.type]](
+                  ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
+                  2.toByte
+                )
+              ),
+              Map()
+            )
+          ),
+          allowNewToSucceed = true,
+          allowDifferentErrors = true
+        ))
+    }
+  }
 
+  property("GroupElement.multiply equivalence") {
     // TODO v6.0 (3h): related to https://github.com/ScorexFoundation/sigmastate-interpreter/issues/479
     // val isIdentity = existingFeature({ (x: GroupElement) => x.isIdentity },
     //   "{ (x: GroupElement) => x.isIdentity }")
-
-    if (lowerMethodCallsInTests) {
-      verifyCases(
-      {
-        val cost = TracedCost(
-          Array(
-            FixedCostItem(Apply),
-            FixedCostItem(FuncValue),
-            FixedCostItem(GetVar),
-            FixedCostItem(OptionGet),
-            FixedCostItem(FuncValue.AddToEnvironmentDesc, FuncValue.AddToEnvironmentDesc_CostKind),
-            FixedCostItem(ValUse),
-            FixedCostItem(SelectField),
-            FixedCostItem(ValUse),
-            FixedCostItem(SelectField),
-            FixedCostItem(Exponentiate)
-          )
-        )
-        def success[T](v: T) = Expected(Success(v), 41484, cost)
-        Seq(
-          ((ge1, CBigInt(new BigInteger("-25c80b560dd7844e2efd10f80f7ee57d", 16))),
-              success(Helpers.decodeGroupElement("023a850181b7b73f92a5bbfa0bfc78f5bbb6ff00645ddde501037017e1a2251e2e"))),
-          ((ge2, CBigInt(new BigInteger("2488741265082fb02b09f992be3dd8d60d2bbe80d9e2630", 16))),
-              success(Helpers.decodeGroupElement("032045b928fb7774a4cd9ef5fa8209f4e493cd4cc5bd536b52746a53871bf73431"))),
-          ((ge3, CBigInt(new BigInteger("-33e8fbdb13d2982e92583445e1fdcb5901a178a7aa1e100", 16))),
-              success(Helpers.decodeGroupElement("036128efaf14d8ac2812a662f6494dc617b87986a3dc6b4a59440048a7ac7d2729"))),
-          ((ge3, CBigInt(new BigInteger("1", 16))),
-              success(ge3))
-        )
-      },
-      existingFeature(
-        { (x: (GroupElement, BigInt)) => x._1.exp(x._2) },
-        "{ (x: (GroupElement, BigInt)) => x._1.exp(x._2) }",
-        FuncValue(
-          Vector((1, STuple(Vector(SGroupElement, SBigInt)))),
-          Exponentiate(
-            SelectField.typed[Value[SGroupElement.type]](
-              ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
-              1.toByte
-            ),
-            SelectField.typed[Value[SBigInt.type]](
-              ValUse(1, STuple(Vector(SGroupElement, SBigInt))),
-              2.toByte
-            )
-          )
-        )))
-    } else {
-      // TODO mainnet v5.0: add test case with `exp` MethodCall
-    }
 
     if (lowerMethodCallsInTests) {
       verifyCases(

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
@@ -955,7 +955,7 @@ class SigmaDslTesting extends PropSpec
   private def checkResult[B](res: Try[B], expectedRes: Try[B], failOnTestVectors: Boolean, hint: String = ""): Unit = {
     (res, expectedRes) match {
       case (Failure(exception), Failure(expectedException)) =>
-        rootCause(exception).getClass shouldBe expectedException.getClass
+        rootCause(exception).getClass shouldBe rootCause(expectedException).getClass
       case _ =>
         if (failOnTestVectors) {
           val actual = rootCause(res)

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
@@ -660,15 +660,7 @@ class SigmaDslTesting extends PropSpec
         val funcValue = expectedExpr.getOrElse(
           sys.error("When `script` is not defined, the expectedExpr is used for CompiledFunc"))
         val expr = getApplyExpr(funcValue)
-//        try
-          funcFromExpr[A, B]("not defined", expr)
-//        catch { case t: Throwable =>
-//          // when the function cannot be compiled for whatever reason we create a stub
-//          // function which just throws that error
-//          CompiledFunc[A,B](
-//            script, Nil, funcValue, expr,
-//            func = x => (throw t, CostDetails.ZeroCost))
-//        }
+        funcFromExpr[A, B]("not defined", expr)
       } else {
         func[A, B](script)
       }

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslTesting.scala
@@ -9,6 +9,7 @@ import org.ergoplatform.validation.ValidationRules.CheckSerializableTypeCode
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen.frequency
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import scalan.RType
@@ -56,40 +57,6 @@ class SigmaDslTesting extends PropSpec
   def createIR(): IRContext = new TestingIRContext {
     override val okPrintEvaluatedEntries: Boolean = false
     override val okMeasureOperationTime: Boolean = true
-  }
-
-  def checkEq[A,B](scalaFunc: A => B)(g: A => (B, CostDetails)): A => Try[(B, CostDetails)] = { x: A =>
-    val b1 = Try(scalaFunc(x))
-    val b2 = Try(g(x))
-    (b1, b2) match {
-      case (Success(b1), res @ Success((b2, _))) =>
-        assert(b1 == b2)
-        res
-      case (Failure(t1), res @ Failure(t2)) =>
-        val c1 = rootCause(t1).getClass
-        val c2 = rootCause(t2).getClass
-        if (c1 != c2) {
-          assert(c1 == c2,
-            s"""Different errors:
-              |First result: $t1
-              |Second result: $t2
-              |""".stripMargin)
-        }
-        res
-      case _ =>
-        val cause = if (b1.isFailure)
-          rootCause(b1.asInstanceOf[Failure[_]].exception)
-        else
-          rootCause(b2.asInstanceOf[Failure[_]].exception)
-
-        sys.error(
-          s"""Should succeed with the same value or fail with the same exception, but was:
-            |First result: $b1
-            |Second result: $b2
-            |Root cause: $cause
-            |""".stripMargin)
-    }
-
   }
 
   def checkEq2[A,B,R](f: (A, B) => R)(g: (A, B) => R): (A,B) => Unit = { (x: A, y: B) =>
@@ -176,6 +143,8 @@ class SigmaDslTesting extends PropSpec
 
     def evalSettings: EvalSettings
 
+    def allowDifferentErrors: Boolean = false
+
     def printExpectedExpr: Boolean
     def logScript: Boolean
 
@@ -254,6 +223,39 @@ class SigmaDslTesting extends PropSpec
     def verifyCase(input: A, expectedResult: Expected[B],
                    printTestCases: Boolean = PrintTestCasesDefault,
                    failOnTestVectors: Boolean = FailOnTestVectorsDefault): Unit
+
+    def checkEq[A,B](scalaFunc: A => B)(g: A => (B, CostDetails)): A => Try[(B, CostDetails)] = { x: A =>
+      val b1 = Try(scalaFunc(x))
+      val b2 = Try(g(x))
+      (b1, b2) match {
+        case (Success(b1), res @ Success((b2, _))) =>
+          assert(b1 == b2)
+          res
+        case (Failure(t1), res @ Failure(t2)) =>
+          val c1 = rootCause(t1).getClass
+          val c2 = rootCause(t2).getClass
+          if (c1 != c2 && !allowDifferentErrors) {
+            assert(c1 == c2,
+              s"""Different errors:
+                |First result: $t1
+                |Second result: $t2
+                |""".stripMargin)
+          }
+          res
+        case _ =>
+          val cause = if (b1.isFailure)
+            rootCause(b1.asInstanceOf[Failure[_]].exception)
+          else
+            rootCause(b2.asInstanceOf[Failure[_]].exception)
+
+          fail(
+            s"""Should succeed with the same value or fail with the same exception, but was:
+              |First result: $b1
+              |Second result: $b2
+              |Root cause: $cause
+              |""".stripMargin)
+      }
+    }
 
     /** Creates a new ErgoLikeContext using given [[CostingDataContext]] as template.
       * Copies most of the data from ctx and the missing data is taken from the args.
@@ -642,7 +644,7 @@ class SigmaDslTesting extends PropSpec
     printExpectedExpr: Boolean = true,
     logScript: Boolean = LogScriptDefault,
     allowNewToSucceed: Boolean = false,
-    allowDifferentErrors: Boolean = false
+    override val allowDifferentErrors: Boolean = false
   )(implicit IR: IRContext, override val evalSettings: EvalSettings, val tA: RType[A], val tB: RType[B])
     extends Feature[A, B] {
 
@@ -658,7 +660,15 @@ class SigmaDslTesting extends PropSpec
         val funcValue = expectedExpr.getOrElse(
           sys.error("When `script` is not defined, the expectedExpr is used for CompiledFunc"))
         val expr = getApplyExpr(funcValue)
-        funcFromExpr[A, B]("not defined", expr)
+//        try
+          funcFromExpr[A, B]("not defined", expr)
+//        catch { case t: Throwable =>
+//          // when the function cannot be compiled for whatever reason we create a stub
+//          // function which just throws that error
+//          CompiledFunc[A,B](
+//            script, Nil, funcValue, expr,
+//            func = x => (throw t, CostDetails.ZeroCost))
+//        }
       } else {
         func[A, B](script)
       }
@@ -682,6 +692,7 @@ class SigmaDslTesting extends PropSpec
         oldRes = VersionContext.withVersions(activatedVersionInTests, ergoTreeVersionInTests) {
           try checkEq(scalaFunc)(oldF)(input)
           catch {
+            case e: TestFailedException => throw e
             case t: Throwable =>
               Failure(t)
           }


### PR DESCRIPTION
In this PR:
- Closes #597 (see property("GroupElement.multiply equivalence"))
- #762 
- Publish a snapshot only if env.HAS_SECRETS == 'true'
- replace treeWithSegregation usages in tests with mkTestErgoTree
- tests for GroupElement.exp via MethodCall node
- test for Global.xor can be called via MethodCall node
- test for Coll.getOrElse,append,slice,exists,forall can be called via MethodCall node
- removing pattern cases for Coll.map, Coll.fold, Option.isDefined from CompiletimeCosting.scala (the logic is moved to the corresponding SMethod declaration)
- #780 
- #788 