### PR TITLE
Finalize v5.0: fix flatMap (part 2)

### DIFF
--- a/sigmastate/src/main/scala/sigmastate/types.scala
+++ b/sigmastate/src/main/scala/sigmastate/types.scala
@@ -1688,9 +1688,6 @@ object SCollection extends STypeCompanion with MethodByNameUnapply {
     */
   def flatMap_eval[A, B](mc: MethodCall, xs: Coll[A], f: A => Coll[B])
                         (implicit E: ErgoTreeEvaluator): Coll[B] = {
-    if (!VersionContext.current.isJitActivated) {
-      checkValidFlatmap(mc)
-    }
     val m = mc.method
     var res: Coll[B] = null
     E.addSeqCost(m.costKind.asInstanceOf[PerItemCost], m.opDesc) { () =>

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -6005,10 +6005,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       val f = changedFeature(
         { (x: Coll[GroupElement]) => SCollection.throwInvalidFlatmap(null) },
         { (x: Coll[GroupElement]) =>
-          if (VersionContext.current.isJitActivated)
             x.flatMap({ (b: GroupElement) => b.getEncoded.indices })
-          else
-            SCollection.throwInvalidFlatmap(null)
         },
         "", // NOTE, the script for this test case cannot be compiled
         FuncValue(

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -6003,9 +6003,10 @@ class SigmaDslSpecification extends SigmaDslTesting
               ))
       )
       val f = changedFeature(
-        { (x: Coll[GroupElement]) => SCollection.throwInvalidFlatmap(null) },
-        { (x: Coll[GroupElement]) =>
-            x.flatMap({ (b: GroupElement) => b.getEncoded.indices })
+        scalaFunc = { (x: Coll[GroupElement]) => SCollection.throwInvalidFlatmap(null) },
+        scalaFuncNew = { (x: Coll[GroupElement]) =>
+          // NOTE, v5.0 interpreter accepts any lambda in flatMap
+          x.flatMap({ (b: GroupElement) => b.getEncoded.indices })
         },
         "", // NOTE, the script for this test case cannot be compiled
         FuncValue(


### PR DESCRIPTION
Removed constraint on lambda of flatMap (any lambda will be supported in v5.0).