### PR TITLE
Finalize v5.0: Fix cost of deserialize operation

### DIFF
--- a/sigmastate/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
+++ b/sigmastate/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
@@ -300,7 +300,7 @@ class ErgoAddressSpecification extends SigmaDslTesting
             script = scriptVarId -> ByteArrayConstant(scriptBytes),
             costLimit = deliberatelySmallLimit),
           rootCauseLike[CostLimitException](
-            s"Estimated execution cost 164 exceeds the limit $deliberatelySmallLimit")
+            s"Estimated execution cost 88 exceeds the limit $deliberatelySmallLimit")
         )
       }
     }
@@ -308,37 +308,7 @@ class ErgoAddressSpecification extends SigmaDslTesting
     // when limit is low
     if (isActivatedVersion4) {
       // choose limit less than addr.script.complexity == 2277 + script complexity == 164
-      val deliberatelySmallLimit = 2300
-
-      assertExceptionThrown(
-        {
-          testPay2SHAddress(addr,
-            script = scriptVarId -> ByteArrayConstant(scriptBytes),
-            costLimit = deliberatelySmallLimit)
-        },
-        rootCauseLike[CostLimitException](
-          s"Estimated execution cost 2441 exceeds the limit $deliberatelySmallLimit")
-      )
-    } else {
-      // v5.0
-      val deliberatelySmallLimit = 100
-
-      assertExceptionThrown(
-      {
-        testPay2SHAddress(addr,
-          script = scriptVarId -> ByteArrayConstant(scriptBytes),
-          costLimit = deliberatelySmallLimit)
-      },
-      rootCauseLike[CostLimitException](
-        s"Estimated execution cost 164 exceeds the limit $deliberatelySmallLimit")
-      )
-
-    }
-
-    // when limit is even lower than tree complexity
-    if (isActivatedVersion4) {
-      // choose limit less than addr.script.complexity == 2277
-      val deliberatelySmallLimit = 2000
+      val deliberatelySmallLimit = 1000
 
       assertExceptionThrown(
         {
@@ -351,7 +321,7 @@ class ErgoAddressSpecification extends SigmaDslTesting
       )
     } else {
       // v5.0
-      val deliberatelySmallLimit = 100
+      val deliberatelySmallLimit = 10
 
       assertExceptionThrown(
       {
@@ -360,7 +330,37 @@ class ErgoAddressSpecification extends SigmaDslTesting
           costLimit = deliberatelySmallLimit)
       },
       rootCauseLike[CostLimitException](
-        s"Estimated execution cost 164 exceeds the limit $deliberatelySmallLimit")
+        s"Estimated execution cost 88 exceeds the limit $deliberatelySmallLimit")
+      )
+
+    }
+
+    // when limit is even lower than tree complexity
+    if (isActivatedVersion4) {
+      // choose limit less than addr.script.complexity == 2277
+      val deliberatelySmallLimit = 1000
+
+      assertExceptionThrown(
+        {
+          testPay2SHAddress(addr,
+            script = scriptVarId -> ByteArrayConstant(scriptBytes),
+            costLimit = deliberatelySmallLimit)
+        },
+        rootCauseLike[CostLimitException](
+          s"Estimated execution cost 2277 exceeds the limit $deliberatelySmallLimit")
+      )
+    } else {
+      // v5.0
+      val deliberatelySmallLimit = 10
+
+      assertExceptionThrown(
+      {
+        testPay2SHAddress(addr,
+          script = scriptVarId -> ByteArrayConstant(scriptBytes),
+          costLimit = deliberatelySmallLimit)
+      },
+      rootCauseLike[CostLimitException](
+        s"Estimated execution cost 88 exceeds the limit $deliberatelySmallLimit")
       )
 
     }

--- a/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
+++ b/sigmastate/src/test/scala/special/sigma/SigmaDslSpecification.scala
@@ -255,7 +255,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         FixedCostItem(BinXor)
       )
     )
-    val newCost = 1788
+    val newCost = 1768
     def success(b: Boolean) = Expected(Success(b), 36518, newDetails, newCost)
     val cases = Seq(
       (true, true) -> success(false),
@@ -283,7 +283,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
     )
     val expectedCost = 36518
-    val newCost = 1788
+    val newCost = 1768
     val cases = Seq(
       (true, true) -> Expected(Success(false), expectedCost, newDetails, newCost)
     )
@@ -321,7 +321,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         FixedCostItem(BinXor)
       )
     )
-    def success(b: Boolean) = Expected(Success(b), 36865, newDetails, 1789)
+    def success(b: Boolean) = Expected(Success(b), 36865, newDetails, 1769)
     val cases = Seq(
       (1095564593, true) -> success(true),
       (-901834021, true) -> success(true),
@@ -358,10 +358,10 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
     )
     val cases = Seq(
-      (false, true) -> Expected(Success(false), 38241, newDetails1, 1786),
-      (false, false) -> Expected(Success(false), 38241, newDetails1, 1786),
-      (true, true) -> Expected(Success(true), 38241, newDetails2, 1788),
-      (true, false) -> Expected(Success(false), 38241, newDetails2, 1788)
+      (false, true) -> Expected(Success(false), 38241, newDetails1, 1766),
+      (false, false) -> Expected(Success(false), 38241, newDetails1, 1766),
+      (true, true) -> Expected(Success(true), 38241, newDetails2, 1768),
+      (true, false) -> Expected(Success(false), 38241, newDetails2, 1768)
     )
     verifyCases(cases, eq)
   }
@@ -392,10 +392,10 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     val cost = 38241
     val cases = Seq(
-      (true, false) -> Expected(Success(true), cost, newDetails1, 1786),
-      (true, true) -> Expected(Success(true), cost, newDetails1, 1786),
-      (false, false) -> Expected(Success(false), cost, newDetails2, 1788),
-      (false, true) -> Expected(Success(true), cost, newDetails2, 1788)
+      (true, false) -> Expected(Success(true), cost, newDetails1, 1766),
+      (true, true) -> Expected(Success(true), cost, newDetails1, 1766),
+      (false, false) -> Expected(Success(false), cost, newDetails2, 1768),
+      (false, true) -> Expected(Success(true), cost, newDetails2, 1768)
     )
     verifyCases(cases, eq)
   }
@@ -440,7 +440,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        (true, Expected(Success(true), 38467, newDetails1, 1785)),
+        (true, Expected(Success(true), 38467, newDetails1, 1765)),
         (false, Expected(new ArithmeticException("/ by zero")))
       ),
       existingFeature((x: Boolean) => x || (1 / 0 == 1),
@@ -456,7 +456,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq(
         (true, Expected(new ArithmeticException("/ by zero"))),
-        (false, Expected(Success(false), 38467, newDetails2, 1785))
+        (false, Expected(Success(false), 38467, newDetails2, 1765))
       ),
       existingFeature((x: Boolean) => x && (1 / 0 == 1),
         "{ (x: Boolean) => x && (1 / 0 == 1) }",
@@ -470,8 +470,8 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (false, Expected(Success(false), 40480, newDetails2, 1785)),
-        (true, Expected(Success(true), 40480, newDetails3, 1788))
+        (false, Expected(Success(false), 40480, newDetails2, 1765)),
+        (true, Expected(Success(true), 40480, newDetails3, 1768))
       ),
       existingFeature((x: Boolean) => x && (x || (1 / 0 == 1)),
         "{ (x: Boolean) => x && (x || (1 / 0 == 1)) }",
@@ -488,8 +488,8 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (false, Expected(Success(false), 42493, newDetails2, 1785)),
-        (true, Expected(Success(true), 42493, newDetails4, 1790))
+        (false, Expected(Success(false), 42493, newDetails2, 1765)),
+        (true, Expected(Success(true), 42493, newDetails4, 1770))
       ),
       existingFeature((x: Boolean) => x && (x && (x || (1 / 0 == 1))),
         "{ (x: Boolean) => x && (x && (x || (1 / 0 == 1))) }",
@@ -509,8 +509,8 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (false, Expected(Success(false), 44506, newDetails2, 1785)),
-        (true, Expected(Success(true), 44506, newDetails5, 1793))
+        (false, Expected(Success(false), 44506, newDetails2, 1765)),
+        (true, Expected(Success(true), 44506, newDetails5, 1773))
       ),
       existingFeature((x: Boolean) => x && (x && (x && (x || (1 / 0 == 1)))),
         "{ (x: Boolean) => x && (x && (x && (x || (1 / 0 == 1)))) }",
@@ -544,7 +544,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq(
         (false, Expected(new ArithmeticException("/ by zero"))),
-        (true, Expected(Success(true), 43281, newDetails6, 1793))
+        (true, Expected(Success(true), 43281, newDetails6, 1773))
       ),
       existingFeature((x: Boolean) => !(!x && (1 / 0 == 1)) && (x || (1 / 0 == 1)),
         "{ (x: Boolean) => !(!x && (1 / 0 == 1)) && (x || (1 / 0 == 1)) }",
@@ -573,7 +573,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        (true, Expected(Success(true), 40480, newDetails7, 1788)),
+        (true, Expected(Success(true), 40480, newDetails7, 1768)),
         (false, Expected(new ArithmeticException("/ by zero")))
       ),
       existingFeature((x: Boolean) => (x || (1 / 0 == 1)) && x,
@@ -599,7 +599,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        (true, Expected(Success(true), 43149, newDetails8, 1790)),
+        (true, Expected(Success(true), 43149, newDetails8, 1770)),
         (false, Expected(new ArithmeticException("/ by zero")))
       ),
       existingFeature((x: Boolean) => (x || (1 / 0 == 1)) && (x || (1 / 0 == 1)),
@@ -631,7 +631,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        (true, Expected(Success(true), 45950, newDetails9, 1795)),
+        (true, Expected(Success(true), 45950, newDetails9, 1775)),
         (false, Expected(new ArithmeticException("/ by zero")))
       ),
       existingFeature(
@@ -681,7 +681,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq(
         (false, Expected(new ArithmeticException("/ by zero"))),
-        (true, Expected(Success(true), 48862, newDetails10, 1800))
+        (true, Expected(Success(true), 48862, newDetails10, 1780))
       ),
       existingFeature(
         (x: Boolean) => (!(!x && (1 / 0 == 1)) || (1 / 0 == 0)) && (!(!x && (1 / 0 == 1)) || (1 / 0 == 1)),
@@ -724,7 +724,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def expect(v: Byte) = Expected(Success(v), 35798, TracedCost(traceBase), 1783)
+        def expect(v: Byte) = Expected(Success(v), 35798, TracedCost(traceBase), 1763)
         Seq(
           (0.toByte, expect(0.toByte)),
           (1.toByte, expect(1.toByte)),
@@ -741,7 +741,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def expected(v: Short) = Expected(Success(v), 35902, upcastCostDetails(SShort), 1784)
+        def expected(v: Short) = Expected(Success(v), 35902, upcastCostDetails(SShort), 1764)
         Seq(
           (0.toByte, expected(0.toShort)),
           (1.toByte, expected(1.toShort)),
@@ -758,7 +758,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def expected(v: Int) = Expected(Success(v), 35902, upcastCostDetails(SInt), 1784)
+        def expected(v: Int) = Expected(Success(v), 35902, upcastCostDetails(SInt), 1764)
         Seq(
           (0.toByte, expected(0)),
           (1.toByte, expected(1)),
@@ -775,7 +775,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def expected(v: Long) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1784)
+        def expected(v: Long) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1764)
         Seq(
           (0.toByte, expected(0L)),
           (1.toByte, expected(1L)),
@@ -792,7 +792,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def expected(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1787)
+        def expected(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1767)
         Seq(
           (0.toByte, expected(CBigInt(new BigInteger("0", 16)))),
           (1.toByte, expected(CBigInt(new BigInteger("1", 16)))),
@@ -810,7 +810,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactIntegral.ByteIsExactIntegral
     verifyCases(
       {
-        def success[T](v: (T, (T, (T, (T, T))))) = Expected(Success(v), 39654, arithOpsCostDetails(SByte), 1808)
+        def success[T](v: (T, (T, (T, (T, T))))) = Expected(Success(v), 39654, arithOpsCostDetails(SByte), 1788)
         Seq(
           ((-128.toByte, -128.toByte), Expected(new ArithmeticException("Byte overflow"))),
           ((-128.toByte, 0.toByte), Expected(new ArithmeticException("/ by zero"))),
@@ -904,9 +904,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       ))
   }
 
-  def swapArgs[A](cases: Seq[((A, A), Expected[Boolean])], cost: Int, newCostDetails: CostDetails) =
+  def swapArgs[A](cases: Seq[((A, A), Expected[Boolean])], cost: Int, newCost: Int, newCostDetails: CostDetails) =
     cases.map { case ((x, y), res) =>
-      ((y, x), Expected(res.value, cost, newCostDetails, 1788))
+      ((y, x), Expected(res.value, cost, newCostDetails, newCost))
     }
 
   def newCasesFrom[A, R](
@@ -922,9 +922,9 @@ class SigmaDslSpecification extends SigmaDslTesting
     }    
 
   def newCasesFrom2[A, R](cases: Seq[(A, A)])
-                        (getExpectedRes: (A, A) => R, cost: Int, newCostDetails: CostDetails) =
+                        (getExpectedRes: (A, A) => R, cost: Int, newCost: Int, newCostDetails: CostDetails) =
     cases.map { case (x, y) =>
-      ((x, y), Expected(Success(getExpectedRes(x, y)), cost = cost, expectedDetails = newCostDetails, expectedNewCost = 1786))
+      ((x, y), Expected(Success(getExpectedRes(x, y)), cost = cost, expectedDetails = newCostDetails, expectedNewCost = newCost))
     }
 
   def verifyOp[A: Ordering: Arbitrary]
@@ -957,7 +957,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   property("Byte LT, GT, NEQ") {
     val o = ExactOrdering.ByteIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SByte), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SByte), 1768)
     val LT_cases: Seq[((Byte, Byte), Expected[Boolean])] = Seq(
       (-128.toByte, -128.toByte) -> expect(false),
       (-128.toByte, -127.toByte) -> expect(true),
@@ -998,16 +998,16 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LT_cases, "<", LT.apply)(_ < _)
 
     verifyOp(
-      swapArgs(LT_cases, cost = 36342, newCostDetails = binaryRelationCostDetails(GT, SByte)),
+      swapArgs(LT_cases, cost = 36342, newCost = 1768, newCostDetails = binaryRelationCostDetails(GT, SByte)),
       ">", GT.apply)(_ > _)
 
-    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCostDetails = costNEQ(constNeqCost))
+    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCost = 1766, newCostDetails = costNEQ(constNeqCost))
     verifyOp(neqCases, "!=", NEQ.apply)(_ != _)
   }
 
   property("Byte LE, GE") {
     val o = ExactOrdering.ByteIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SByte), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SByte), 1768)
     val LE_cases: Seq[((Byte, Byte), Expected[Boolean])] = Seq(
       (-128.toByte, -128.toByte) -> expect(true),
       (-128.toByte, -127.toByte) -> expect(true),
@@ -1049,7 +1049,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LE_cases, "<=", LE.apply)(_ <= _)
 
     verifyOp(
-      swapArgs(LE_cases, cost = 36336, newCostDetails = binaryRelationCostDetails(GE, SByte)),
+      swapArgs(LE_cases, cost = 36336, newCost = 1768, newCostDetails = binaryRelationCostDetails(GE, SByte)),
       ">=", GE.apply)(_ >= _)
   }
 
@@ -1084,7 +1084,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1764)
         Seq(
           (Short.MinValue, Expected(new ArithmeticException("Byte overflow"))),
           (-21626.toShort, Expected(new ArithmeticException("Byte overflow"))),
@@ -1103,7 +1103,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1783)
+        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1763)
         Seq(
           (-32768.toShort, success(-32768.toShort)),
           (-27798.toShort, success(-27798.toShort)),
@@ -1120,7 +1120,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SInt), 1784)
+        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SInt), 1764)
         Seq(
           (-32768.toShort, success(-32768)),
           (-21064.toShort, success(-21064)),
@@ -1137,7 +1137,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1784)
+        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1764)
         Seq(
           (-32768.toShort, success(-32768L)),
           (-23408.toShort, success(-23408L)),
@@ -1154,7 +1154,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1787)
+        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1767)
         Seq(
           (-32768.toShort, success(CBigInt(new BigInteger("-8000", 16)))),
           (-26248.toShort, success(CBigInt(new BigInteger("-6688", 16)))),
@@ -1172,7 +1172,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactIntegral.ShortIsExactIntegral
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SShort), 1808)
+        def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SShort), 1788)
         Seq(
           ((-32768.toShort, 1.toShort), Expected(new ArithmeticException("Short overflow"))),
           ((-32768.toShort, 4006.toShort), Expected(new ArithmeticException("Short overflow"))),
@@ -1264,7 +1264,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   property("Short LT, GT, NEQ") {
     val o = ExactOrdering.ShortIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SShort), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SShort), 1768)
     val LT_cases: Seq[((Short, Short), Expected[Boolean])] = Seq(
       (Short.MinValue, Short.MinValue) -> expect(false),
       (Short.MinValue, (Short.MinValue + 1).toShort) -> expect(true),
@@ -1304,15 +1304,15 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyOp(LT_cases, "<", LT.apply)(_ < _)
 
-    verifyOp(swapArgs(LT_cases, cost = 36342, newCostDetails = binaryRelationCostDetails(GT, SShort)), ">", GT.apply)(_ > _)
+    verifyOp(swapArgs(LT_cases, cost = 36342, newCost = 1768, newCostDetails = binaryRelationCostDetails(GT, SShort)), ">", GT.apply)(_ > _)
 
-    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCostDetails = costNEQ(constNeqCost))
+    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCost = 1766, newCostDetails = costNEQ(constNeqCost))
     verifyOp(neqCases, "!=", NEQ.apply)(_ != _)
   }
 
   property("Short LE, GE") {
     val o = ExactOrdering.ShortIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SShort), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SShort), 1768)
     val LE_cases: Seq[((Short, Short), Expected[Boolean])] = Seq(
       (Short.MinValue, Short.MinValue) -> expect(true),
       (Short.MinValue, (Short.MinValue + 1).toShort) -> expect(true),
@@ -1354,7 +1354,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LE_cases, "<=", LE.apply)(_ <= _)
 
     verifyOp(
-      swapArgs(LE_cases, cost = 36336, newCostDetails = binaryRelationCostDetails(GE, SShort)),
+      swapArgs(LE_cases, cost = 36336, newCost = 1768, newCostDetails = binaryRelationCostDetails(GE, SShort)),
       ">=", GE.apply)(_ >= _)
   }
 
@@ -1388,7 +1388,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1764)
         Seq(
           (Int.MinValue, Expected(new ArithmeticException("Byte overflow"))),
           (-2014394379, Expected(new ArithmeticException("Byte overflow"))),
@@ -1407,7 +1407,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SShort), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SShort), 1764)
         Seq(
           (Int.MinValue, Expected(new ArithmeticException("Short overflow"))),
           (Short.MinValue - 1, Expected(new ArithmeticException("Short overflow"))),
@@ -1426,7 +1426,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1783)
+        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1763)
         Seq(
           (Int.MinValue, success(Int.MinValue)),
           (-1, success(-1)),
@@ -1441,7 +1441,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1784)
+        def success[T](v: T) = Expected(Success(v), 35902, upcastCostDetails(SLong), 1764)
         Seq(
           (Int.MinValue, success(Int.MinValue.toLong)),
           (-1, success(-1L)),
@@ -1456,7 +1456,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1787)
+        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1767)
         Seq(
           (Int.MinValue, success(CBigInt(new BigInteger("-80000000", 16)))),
           (-1937187314, success(CBigInt(new BigInteger("-737721f2", 16)))),
@@ -1474,7 +1474,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactNumeric.IntIsExactNumeric
     verifyCases(
     {
-      def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SInt), 1808)
+      def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SInt), 1788)
       Seq(
         ((Int.MinValue, 449583993), Expected(new ArithmeticException("integer overflow"))),
         ((-1589633733, 2147483647), Expected(new ArithmeticException("integer overflow"))),
@@ -1566,7 +1566,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   property("Int LT, GT, NEQ") {
     val o = ExactOrdering.IntIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SInt), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SInt), 1768)
     val LT_cases: Seq[((Int, Int), Expected[Boolean])] = Seq(
       (Int.MinValue, Int.MinValue) -> expect(false),
       (Int.MinValue, (Int.MinValue + 1).toInt) -> expect(true),
@@ -1607,16 +1607,16 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LT_cases, "<", LT.apply)(_ < _)
 
     verifyOp(
-      swapArgs(LT_cases, cost = 36342, newCostDetails = binaryRelationCostDetails(GT, SInt)),
+      swapArgs(LT_cases, cost = 36342, newCost = 1768, newCostDetails = binaryRelationCostDetails(GT, SInt)),
       ">", GT.apply)(_ > _)
 
-    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCostDetails = costNEQ(constNeqCost))
+    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCost = 1766, newCostDetails = costNEQ(constNeqCost))
     verifyOp(neqCases, "!=", NEQ.apply)(_ != _)
   }
 
   property("Int LE, GE") {
     val o = ExactOrdering.IntIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SInt), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SInt), 1768)
     val LE_cases: Seq[((Int, Int), Expected[Boolean])] = Seq(
       (Int.MinValue, Int.MinValue) -> expect(true),
       (Int.MinValue, (Int.MinValue + 1).toInt) -> expect(true),
@@ -1658,7 +1658,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LE_cases, "<=", LE.apply)(_ <= _)
 
     verifyOp(
-      swapArgs(LE_cases, cost = 36336, newCostDetails = binaryRelationCostDetails(GE, SInt)),
+      swapArgs(LE_cases, cost = 36336, newCost = 1768, newCostDetails = binaryRelationCostDetails(GE, SInt)),
       ">=", GE.apply)(_ >= _)
   }
 
@@ -1695,7 +1695,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Long.toByte method") {
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SByte), 1764)
         Seq(
           (Long.MinValue, Expected(new ArithmeticException("Byte overflow"))),
           (Byte.MinValue.toLong - 1, Expected(new ArithmeticException("Byte overflow"))),
@@ -1716,7 +1716,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Long.toShort method") {
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SShort), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SShort), 1764)
         Seq(
           (Long.MinValue, Expected(new ArithmeticException("Short overflow"))),
           (Short.MinValue.toLong - 1, Expected(new ArithmeticException("Short overflow"))),
@@ -1737,7 +1737,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Long.toInt method") {
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SInt), 1784)
+        def success[T](v: T) = Expected(Success(v), 35976, downcastCostDetails(SInt), 1764)
         Seq(
           (Long.MinValue, Expected(new ArithmeticException("Int overflow"))),
           (Int.MinValue.toLong - 1, Expected(new ArithmeticException("Int overflow"))),
@@ -1758,7 +1758,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Long.toLong method") {
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1783)
+        def success[T](v: T) = Expected(Success(v), 35798, TracedCost(traceBase), 1763)
         Seq(
           (Long.MinValue, success(Long.MinValue)),
           (-1L, success(-1L)),
@@ -1775,7 +1775,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("Long.toBigInt method") {
     verifyCases(
       {
-        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1787)
+        def success(v: BigInt) = Expected(Success(v), 35932, upcastCostDetails(SBigInt), 1767)
         Seq(
           (Long.MinValue, success(CBigInt(new BigInteger("-8000000000000000", 16)))),
           (-1074651039980347209L, success(CBigInt(new BigInteger("-ee9ed6d57885f49", 16)))),
@@ -1796,7 +1796,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactNumeric.LongIsExactNumeric
     verifyCases(
     {
-      def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SLong), 1808)
+      def success[T](v: T) = Expected(Success(v), 39654, arithOpsCostDetails(SLong), 1788)
       Seq(
         ((Long.MinValue, -4677100190307931395L), Expected(new ArithmeticException("long overflow"))),
         ((Long.MinValue, -1L), Expected(new ArithmeticException("long overflow"))),
@@ -1886,7 +1886,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
   property("Long LT, GT, NEQ") {
     val o = ExactOrdering.LongIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SLong), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SLong), 1768)
     val LT_cases: Seq[((Long, Long), Expected[Boolean])] = Seq(
       (Long.MinValue, Long.MinValue) -> expect(false),
       (Long.MinValue, (Long.MinValue + 1).toLong) -> expect(true),
@@ -1927,16 +1927,16 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LT_cases, "<", LT.apply)(_ < _)
 
     verifyOp(
-      swapArgs(LT_cases, cost = 36342, newCostDetails = binaryRelationCostDetails(GT, SLong)),
+      swapArgs(LT_cases, cost = 36342, newCost = 1768, newCostDetails = binaryRelationCostDetails(GT, SLong)),
       ">", GT.apply)(_ > _)
 
-    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCostDetails = costNEQ(constNeqCost))
+    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCost = 1766, newCostDetails = costNEQ(constNeqCost))
     verifyOp(neqCases, "!=", NEQ.apply)(_ != _)
   }
 
   property("Long LE, GE") {
     val o = ExactOrdering.LongIsExactOrdering
-    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SLong), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SLong), 1768)
     val LE_cases: Seq[((Long, Long), Expected[Boolean])] = Seq(
       (Long.MinValue, Long.MinValue) -> expect(true),
       (Long.MinValue, (Long.MinValue + 1).toLong) -> expect(true),
@@ -1978,7 +1978,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LE_cases, "<=", LE.apply)(_ <= _)
 
     verifyOp(
-      swapArgs(LE_cases, cost = 36336, newCostDetails = binaryRelationCostDetails(GE, SLong)),
+      swapArgs(LE_cases, cost = 36336, newCost = 1768, newCostDetails = binaryRelationCostDetails(GE, SLong)),
       ">=", GE.apply)(_ >= _)
   }
 
@@ -2009,7 +2009,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("BigInt methods equivalence") {
     verifyCases(
       {
-        def success(v: BigInt) = Expected(Success(v), 35798, TracedCost(traceBase), 1784)
+        def success(v: BigInt) = Expected(Success(v), 35798, TracedCost(traceBase), 1764)
         Seq(
           (CBigInt(new BigInteger("-85102d7f884ca0e8f56193b46133acaf7e4681e1757d03f191ae4f445c8e0", 16)), success(
             CBigInt(new BigInteger("-85102d7f884ca0e8f56193b46133acaf7e4681e1757d03f191ae4f445c8e0", 16))
@@ -2032,7 +2032,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
     {
       def success(v: (BigInt, (BigInt, (BigInt, (BigInt, BigInt))))) =
-        Expected(Success(v), 39774, arithOpsCostDetails(SBigInt), 1813)
+        Expected(Success(v), 39774, arithOpsCostDetails(SBigInt), 1793)
       Seq(
         ((CBigInt(new BigInteger("-8683d1cd99d5fcf0e6eff6295c285c36526190e13dbde008c49e5ae6fddc1c", 16)),
             CBigInt(new BigInteger("-2ef55db3f245feddacf0182e299dd", 16))),
@@ -2156,7 +2156,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("BigInt LT, GT, NEQ") {
     val o = NumericOps.BigIntIsExactOrdering
 
-    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SBigInt), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36328, binaryRelationCostDetails(LT, SBigInt), 1768)
     
     val LT_cases: Seq[((BigInt, BigInt), Expected[Boolean])] = Seq(
       (BigIntMinValue, BigIntMinValue) -> expect(false),
@@ -2200,11 +2200,11 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LT_cases, "<", LT.apply)(o.lt(_, _))
 
     verifyOp(
-      swapArgs(LT_cases, cost = 36342, newCostDetails = binaryRelationCostDetails(GT, SBigInt)),
+      swapArgs(LT_cases, cost = 36342, newCost = 1768, newCostDetails = binaryRelationCostDetails(GT, SBigInt)),
       ">", GT.apply)(o.gt(_, _))
 
     val constBigIntCost = Array[CostItem](FixedCostItem(NamedDesc("EQ_BigInt"), FixedCost(JitCost(5))))
-    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCostDetails = costNEQ(constBigIntCost))
+    val neqCases = newCasesFrom2(LT_cases.map(_._1))(_ != _, cost = 36337, newCost = 1766, newCostDetails = costNEQ(constBigIntCost))
     verifyOp(neqCases, "!=", NEQ.apply)(_ != _)
   }
 
@@ -2215,7 +2215,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val BigIntMaxValue = CBigInt(new BigInteger("7F" + "ff" * 31, 16))
     val BigIntOverlimit = CBigInt(new BigInteger("7F" + "ff" * 33, 16))
 
-    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SBigInt), 1788)
+    def expect(v: Boolean) = Expected(Success(v), 36337, binaryRelationCostDetails(LE, SBigInt), 1768)
     
     val LE_cases: Seq[((BigInt, BigInt), Expected[Boolean])] = Seq(
       (BigIntMinValue, BigIntMinValue) -> expect(true),
@@ -2260,7 +2260,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyOp(LE_cases, "<=", LE.apply)(o.lteq(_, _))
 
     verifyOp(
-      swapArgs(LE_cases, cost = 36336, newCostDetails = binaryRelationCostDetails(GE, SBigInt)),
+      swapArgs(LE_cases, cost = 36336, newCost = 1768, newCostDetails = binaryRelationCostDetails(GE, SBigInt)),
       ">=", GE.apply)(o.gteq(_, _))
   }
 
@@ -2341,11 +2341,11 @@ class SigmaDslSpecification extends SigmaDslTesting
   }
 
   property("NEQ of pre-defined types") {
-    verifyNeq(ge1, ge2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_GroupElement"), FixedCost(JitCost(172)))), 1803)(_.asInstanceOf[CGroupElement].copy())
-    verifyNeq(t1, t2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_AvlTree"), FixedCost(JitCost(6)))), 1787)(_.asInstanceOf[CAvlTree].copy())
-    verifyNeq(b1, b2, 36417, Array[CostItem](), 1787)(_.asInstanceOf[CostingBox].copy())
-    verifyNeq(preH1, preH2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_PreHeader"), FixedCost(JitCost(4)))), 1786)(_.asInstanceOf[CPreHeader].copy())
-    verifyNeq(h1, h2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6)))), 1787)(_.asInstanceOf[CHeader].copy())
+    verifyNeq(ge1, ge2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_GroupElement"), FixedCost(JitCost(172)))), 1783)(_.asInstanceOf[CGroupElement].copy())
+    verifyNeq(t1, t2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_AvlTree"), FixedCost(JitCost(6)))), 1767)(_.asInstanceOf[CAvlTree].copy())
+    verifyNeq(b1, b2, 36417, Array[CostItem](), 1767)(_.asInstanceOf[CostingBox].copy())
+    verifyNeq(preH1, preH2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_PreHeader"), FixedCost(JitCost(4)))), 1766)(_.asInstanceOf[CPreHeader].copy())
+    verifyNeq(h1, h2, 36337, Array[CostItem](FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6)))), 1767)(_.asInstanceOf[CHeader].copy())
   }
 
   property("NEQ of tuples of numerics") {
@@ -2353,14 +2353,14 @@ class SigmaDslSpecification extends SigmaDslTesting
       FixedCostItem(NamedDesc("EQ_Tuple"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_Prim"), FixedCost(JitCost(3)))
     )
-    verifyNeq((0.toByte, 1.toByte), (1.toByte, 1.toByte), 36337, tuplesNeqCost, 1787)(_.copy())
-    verifyNeq((0.toShort, 1.toByte), (1.toShort, 1.toByte), 36337, tuplesNeqCost, 1787)(_.copy())
-    verifyNeq((0, 1.toByte), (1, 1.toByte), 36337, tuplesNeqCost, 1787)(_.copy())
-    verifyNeq((0.toLong, 1.toByte), (1.toLong, 1.toByte), 36337, tuplesNeqCost, 1787)(_.copy())
+    verifyNeq((0.toByte, 1.toByte), (1.toByte, 1.toByte), 36337, tuplesNeqCost, 1767)(_.copy())
+    verifyNeq((0.toShort, 1.toByte), (1.toShort, 1.toByte), 36337, tuplesNeqCost, 1767)(_.copy())
+    verifyNeq((0, 1.toByte), (1, 1.toByte), 36337, tuplesNeqCost, 1767)(_.copy())
+    verifyNeq((0.toLong, 1.toByte), (1.toLong, 1.toByte), 36337, tuplesNeqCost, 1767)(_.copy())
     verifyNeq((0.toBigInt, 1.toByte), (1.toBigInt, 1.toByte), 36337, Array(
       FixedCostItem(NamedDesc("EQ_Tuple"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_BigInt"), FixedCost(JitCost(5)))
-    ), 1787)(_.copy())
+    ), 1767)(_.copy())
   }
 
   property("NEQ of tuples of pre-defined types") {
@@ -2369,30 +2369,30 @@ class SigmaDslSpecification extends SigmaDslTesting
       FixedCostItem(NamedDesc("EQ_GroupElement"), FixedCost(JitCost(172))),
       FixedCostItem(NamedDesc("EQ_GroupElement"), FixedCost(JitCost(172)))
     )
-    verifyNeq((ge1, ge1), (ge1, ge2), 36337, groupNeqCost, 1821)(_.copy())
+    verifyNeq((ge1, ge1), (ge1, ge2), 36337, groupNeqCost, 1801)(_.copy())
 
     val treeNeqCost = Array(
       FixedCostItem(NamedDesc("EQ_Tuple"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_AvlTree"), FixedCost(JitCost(6))),
       FixedCostItem(NamedDesc("EQ_AvlTree"), FixedCost(JitCost(6)))
     )
-    verifyNeq((t1, t1), (t1, t2), 36337, treeNeqCost, 1788)(_.copy())
+    verifyNeq((t1, t1), (t1, t2), 36337, treeNeqCost, 1768)(_.copy())
 
-    verifyNeq((b1, b1), (b1, b2), 36497, Array[CostItem](), 1788)(_.copy())
+    verifyNeq((b1, b1), (b1, b2), 36497, Array[CostItem](), 1768)(_.copy())
     
     val preHeaderNeqCost = Array(
       FixedCostItem(NamedDesc("EQ_Tuple"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_PreHeader"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_PreHeader"), FixedCost(JitCost(4)))
     )
-    verifyNeq((preH1, preH1), (preH1, preH2), 36337, preHeaderNeqCost, 1787)(_.copy())
+    verifyNeq((preH1, preH1), (preH1, preH2), 36337, preHeaderNeqCost, 1767)(_.copy())
 
     val headerNeqCost = Array(
       FixedCostItem(NamedDesc("EQ_Tuple"), FixedCost(JitCost(4))),
       FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6))),
       FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6)))
     )
-    verifyNeq((h1, h1), (h1, h2), 36337, headerNeqCost, 1788)(_.copy())
+    verifyNeq((h1, h1), (h1, h2), 36337, headerNeqCost, 1768)(_.copy())
   }
   
   property("NEQ of nested tuples") {
@@ -2476,15 +2476,15 @@ class SigmaDslSpecification extends SigmaDslTesting
       FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6))),
       FixedCostItem(NamedDesc("EQ_Header"), FixedCost(JitCost(6)))
     )
-    verifyNeq((ge1, (t1, t1)), (ge1, (t1, t2)), 36337, nestedTuplesNeqCost1, 1805)(_.copy())
-    verifyNeq((ge1, (t1, (b1, b1))), (ge1, (t1, (b1, b2))), 36497, nestedTuplesNeqCost2, 1806)(_.copy())
-    verifyNeq((ge1, (t1, (b1, (preH1, preH1)))), (ge1, (t1, (b1, (preH1, preH2)))), 36417, nestedTuplesNeqCost3, 1807)(_.copy())
-    verifyNeq((ge1, (t1, (b1, (preH1, (h1, h1))))), (ge1, (t1, (b1, (preH1, (h1, h2))))), 36427, nestedTuplesNeqCost4, 1808)(_.copy())
+    verifyNeq((ge1, (t1, t1)), (ge1, (t1, t2)), 36337, nestedTuplesNeqCost1, 1785)(_.copy())
+    verifyNeq((ge1, (t1, (b1, b1))), (ge1, (t1, (b1, b2))), 36497, nestedTuplesNeqCost2, 1786)(_.copy())
+    verifyNeq((ge1, (t1, (b1, (preH1, preH1)))), (ge1, (t1, (b1, (preH1, preH2)))), 36417, nestedTuplesNeqCost3, 1787)(_.copy())
+    verifyNeq((ge1, (t1, (b1, (preH1, (h1, h1))))), (ge1, (t1, (b1, (preH1, (h1, h2))))), 36427, nestedTuplesNeqCost4, 1788)(_.copy())
 
-    verifyNeq(((ge1, t1), t1), ((ge1, t1), t2), 36337, nestedTuplesNeqCost5, 1805)(_.copy())
-    verifyNeq((((ge1, t1), b1), b1), (((ge1, t1), b1), b2), 36497, nestedTuplesNeqCost6, 1806)(_.copy())
-    verifyNeq((((ge1, t1), b1), (preH1, preH1)), (((ge1, t1), b1), (preH1, preH2)), 36417, nestedTuplesNeqCost7, 1807)(_.copy())
-    verifyNeq((((ge1, t1), b1), (preH1, (h1, h1))), (((ge1, t1), b1), (preH1, (h1, h2))), 36427, nestedTuplesNeqCost8, 1808)(_.copy())
+    verifyNeq(((ge1, t1), t1), ((ge1, t1), t2), 36337, nestedTuplesNeqCost5, 1785)(_.copy())
+    verifyNeq((((ge1, t1), b1), b1), (((ge1, t1), b1), b2), 36497, nestedTuplesNeqCost6, 1786)(_.copy())
+    verifyNeq((((ge1, t1), b1), (preH1, preH1)), (((ge1, t1), b1), (preH1, preH2)), 36417, nestedTuplesNeqCost7, 1787)(_.copy())
+    verifyNeq((((ge1, t1), b1), (preH1, (h1, h1))), (((ge1, t1), b1), (preH1, (h1, h2))), 36427, nestedTuplesNeqCost8, 1788)(_.copy())
   }
 
   property("NEQ of collections of pre-defined types") {
@@ -2496,63 +2496,63 @@ class SigmaDslSpecification extends SigmaDslTesting
       SeqCostItem(NamedDesc("EQ_COA_Box"), PerItemCost(JitCost(15), JitCost(5), 1), 0)
     )
     implicit val evalSettings = suite.evalSettings.copy(isMeasureOperationTime = false)
-    verifyNeq(Coll[Byte](), Coll(1.toByte), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[Byte](), Coll(1.toByte), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[Byte](0, 1), Coll(1.toByte, 1.toByte), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_Byte"), PerItemCost(JitCost(15), JitCost(2), 128), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
-    verifyNeq(Coll[Short](), Coll(1.toShort), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[Short](), Coll(1.toShort), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[Short](0), Coll(1.toShort), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_Short"), PerItemCost(JitCost(15), JitCost(2), 96), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
-    verifyNeq(Coll[Int](), Coll(1), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[Int](), Coll(1), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[Int](0), Coll(1), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_Int"), PerItemCost(JitCost(15), JitCost(2), 64), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
-    verifyNeq(Coll[Long](), Coll(1.toLong), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[Long](), Coll(1.toLong), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[Long](0), Coll(1.toLong), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_Long"), PerItemCost(JitCost(15), JitCost(2), 48), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
     prepareSamples[Coll[BigInt]]
-    verifyNeq(Coll[BigInt](), Coll(1.toBigInt), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[BigInt](), Coll(1.toBigInt), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[BigInt](0.toBigInt), Coll(1.toBigInt), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_BigInt"), PerItemCost(JitCost(15), JitCost(7), 5), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
     prepareSamples[Coll[GroupElement]]
-    verifyNeq(Coll[GroupElement](), Coll(ge1), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[GroupElement](), Coll(ge1), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[GroupElement](ge1), Coll(ge2), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_GroupElement"), PerItemCost(JitCost(15), JitCost(5), 1), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
     prepareSamples[Coll[AvlTree]]
-    verifyNeq(Coll[AvlTree](), Coll(t1), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[AvlTree](), Coll(t1), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[AvlTree](t1), Coll(t2), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_AvlTree"), PerItemCost(JitCost(15), JitCost(5), 2), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
     { // since SBox.isConstantSize = false, the cost is different among cases
@@ -2561,11 +2561,11 @@ class SigmaDslSpecification extends SigmaDslTesting
       val y = Coll(b1)
       val copied_x = cloneColl(x)
       verifyOp(Seq(
-          (x, x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1788),
-          (x, copied_x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1788),
-          (copied_x, x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1788),
-          (x, y) -> Expected(Success(true), 36377, costNEQ(collNeqCost1), 1786),
-          (y, x) -> Expected(Success(true), 36377, costNEQ(collNeqCost1), 1786)
+          (x, x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1768),
+          (x, copied_x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1768),
+          (copied_x, x) -> Expected(Success(false), 36337, costNEQ(collNeqCost2), 1768),
+          (x, y) -> Expected(Success(true), 36377, costNEQ(collNeqCost1), 1766),
+          (y, x) -> Expected(Success(true), 36377, costNEQ(collNeqCost1), 1766)
         ),
         "!=", NEQ.apply)(_ != _, generateCases = false)
 
@@ -2573,26 +2573,26 @@ class SigmaDslSpecification extends SigmaDslTesting
         Array(
           FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
           SeqCostItem(NamedDesc("EQ_COA_Box"), PerItemCost(JitCost(15), JitCost(5), 1), 1)),
-        1788
+        1768
       )(cloneColl(_), generateCases = false)
     }
 
     prepareSamples[Coll[PreHeader]]
-    verifyNeq(Coll[PreHeader](), Coll(preH1), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[PreHeader](), Coll(preH1), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[PreHeader](preH1), Coll(preH2), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_PreHeader"), PerItemCost(JitCost(15), JitCost(3), 1), 1)),
-      1788
+      1768
     )(cloneColl(_))
 
     prepareSamples[Coll[Header]]
-    verifyNeq(Coll[Header](), Coll(h1), 36337, collNeqCost1, 1786)(cloneColl(_))
+    verifyNeq(Coll[Header](), Coll(h1), 36337, collNeqCost1, 1766)(cloneColl(_))
     verifyNeq(Coll[Header](h1), Coll(h2), 36337,
       Array(
         FixedCostItem(NamedDesc("MatchType"), FixedCost(JitCost(1))),
         SeqCostItem(NamedDesc("EQ_COA_Header"), PerItemCost(JitCost(15), JitCost(5), 1), 1)),
-      1788
+      1768
     )(cloneColl(_))
   }
 
@@ -2616,10 +2616,10 @@ class SigmaDslSpecification extends SigmaDslTesting
       SeqCostItem(NamedDesc("EQ_COA_Int"), PerItemCost(JitCost(15), JitCost(2), 64), 1),
       SeqCostItem(NamedDesc("EQ_Coll"), PerItemCost(JitCost(10), JitCost(2), 1), 1)
     )
-    verifyNeq(Coll[Coll[Int]](), Coll(Coll[Int]()), 36337, nestedNeq1, 1786)(cloneColl(_))
-    verifyNeq(Coll(Coll[Int]()), Coll(Coll[Int](1)), 36337, nestedNeq2, 1787)(cloneColl(_))
-    verifyNeq(Coll(Coll[Int](1)), Coll(Coll[Int](2)), 36337, nestedNeq3, 1789)(cloneColl(_))
-    verifyNeq(Coll(Coll[Int](1)), Coll(Coll[Int](1, 2)), 36337, nestedNeq2, 1787)(cloneColl(_))
+    verifyNeq(Coll[Coll[Int]](), Coll(Coll[Int]()), 36337, nestedNeq1, 1766)(cloneColl(_))
+    verifyNeq(Coll(Coll[Int]()), Coll(Coll[Int](1)), 36337, nestedNeq2, 1767)(cloneColl(_))
+    verifyNeq(Coll(Coll[Int](1)), Coll(Coll[Int](2)), 36337, nestedNeq3, 1769)(cloneColl(_))
+    verifyNeq(Coll(Coll[Int](1)), Coll(Coll[Int](1, 2)), 36337, nestedNeq2, 1767)(cloneColl(_))
 
     prepareSamples[Coll[(Int, BigInt)]]
     prepareSamples[Coll[Coll[(Int, BigInt)]]]
@@ -2662,8 +2662,8 @@ class SigmaDslSpecification extends SigmaDslTesting
       SeqCostItem(NamedDesc("EQ_Coll"), PerItemCost(JitCost(10), JitCost(2), 1), 1),
       SeqCostItem(NamedDesc("EQ_Coll"), PerItemCost(JitCost(10), JitCost(2), 1), 1)
     )
-    verifyNeq(Coll(Coll((1, 10.toBigInt))), Coll(Coll((1, 11.toBigInt))), 36337, nestedNeq4, 1790)(cloneColl(_))
-    verifyNeq(Coll(Coll(Coll((1, 10.toBigInt)))), Coll(Coll(Coll((1, 11.toBigInt)))), 36337, nestedNeq5, 1791)(cloneColl(_))
+    verifyNeq(Coll(Coll((1, 10.toBigInt))), Coll(Coll((1, 11.toBigInt))), 36337, nestedNeq4, 1770)(cloneColl(_))
+    verifyNeq(Coll(Coll(Coll((1, 10.toBigInt)))), Coll(Coll(Coll((1, 11.toBigInt)))), 36337, nestedNeq5, 1771)(cloneColl(_))
     verifyNeq(
       (Coll(
          (Coll(
@@ -2677,14 +2677,14 @@ class SigmaDslSpecification extends SigmaDslTesting
        ), preH1),
       36337,
       nestedNeq6,
-      1794
+      1774
     )(x => (cloneColl(x._1), x._2))
   }
 
   property("GroupElement.getEncoded equivalence") {
     verifyCases(
     {
-      def success[T](v: T) = Expected(Success(v), 37905, methodCostDetails(SGroupElement.GetEncodedMethod, 250), 1810)
+      def success[T](v: T) = Expected(Success(v), 37905, methodCostDetails(SGroupElement.GetEncodedMethod, 250), 1790)
       Seq(
         (ge1, success(Helpers.decodeBytes(ge1str))),
         (ge2, success(Helpers.decodeBytes(ge2str))),
@@ -2715,7 +2715,7 @@ class SigmaDslSpecification extends SigmaDslTesting
           FixedCostItem(NamedDesc("EQ_GroupElement"), FixedCost(JitCost(172)))
         )
       )
-      def success[T](v: T) = Expected(Success(v), 38340, costDetails, 1857)
+      def success[T](v: T) = Expected(Success(v), 38340, costDetails, 1837)
       Seq(
         (ge1, success(true)),
         (ge2, success(true)),
@@ -2745,7 +2745,7 @@ class SigmaDslSpecification extends SigmaDslTesting
   property("GroupElement.negate equivalence") {
     verifyCases(
     {
-      def success[T](v: T) = Expected(Success(v), 36292, methodCostDetails(SGroupElement.NegateMethod, 45), 1805)
+      def success[T](v: T) = Expected(Success(v), 36292, methodCostDetails(SGroupElement.NegateMethod, 45), 1785)
       Seq(
         (ge1, success(Helpers.decodeGroupElement("02358d53f01276211f92d0aefbd278805121d4ff6eb534b777af1ee8abae5b2056"))),
         (ge2, success(Helpers.decodeGroupElement("03dba7b94b111f3894e2f9120b577da595ec7d58d488485adf73bf4e153af63575"))),
@@ -2772,7 +2772,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
     )
     val cases = {  
-      def success[T](v: T) = Expected(Success(v), 41484, costDetails, 1893)
+      def success[T](v: T) = Expected(Success(v), 41484, costDetails, 1873)
       Seq(
         ((ge1, CBigInt(new BigInteger("-25c80b560dd7844e2efd10f80f7ee57d", 16))),
           success(Helpers.decodeGroupElement("023a850181b7b73f92a5bbfa0bfc78f5bbb6ff00645ddde501037017e1a2251e2e"))),
@@ -2880,7 +2880,7 @@ class SigmaDslSpecification extends SigmaDslTesting
             FixedCostItem(MultiplyGroup)
           )
         )
-        def success[T](v: T) = Expected(Success(v), 36457, costDetails, 1807)
+        def success[T](v: T) = Expected(Success(v), 36457, costDetails, 1787)
         Seq(
           ((ge1, Helpers.decodeGroupElement("03e132ca090614bd6c9f811e91f6daae61f16968a1e6c694ed65aacd1b1092320e")),
               success(Helpers.decodeGroupElement("02bc48937b4a66f249a32dfb4d2efd0743dc88d46d770b8c5d39fd03325ba211df"))),
@@ -2985,7 +2985,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     }
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36182, methodCostDetails(SAvlTree.digestMethod, 15), 1787)
+        def success[T](v: T) = Expected(Success(v), 36182, methodCostDetails(SAvlTree.digestMethod, 15), 1767)
         Seq(
           (t1, success(Helpers.decodeBytes("000183807f66b301530120ff7fc6bd6601ff01ff7f7d2bedbbffff00187fe89094"))),
           (t2, success(Helpers.decodeBytes("ff000d937f80ffd731ed802d24358001ff8080ff71007f00ad37e0a7ae43fff95b"))),
@@ -2998,7 +2998,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36260, methodCostDetails(SAvlTree.enabledOperationsMethod, 15), 1785)
+        def success[T](v: T) = Expected(Success(v), 36260, methodCostDetails(SAvlTree.enabledOperationsMethod, 15), 1765)
         Seq(
           (t1, success(6.toByte)),
           (t2, success(0.toByte)),
@@ -3011,7 +3011,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, methodCostDetails(SAvlTree.keyLengthMethod, 15), 1785)
+        def success[T](v: T) = Expected(Success(v), 36136, methodCostDetails(SAvlTree.keyLengthMethod, 15), 1765)
         Seq(
           (t1, success(1)),
           (t2, success(32)),
@@ -3026,9 +3026,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, newCost: Int) = Expected(Success(v), 37151, methodCostDetails(SAvlTree.valueLengthOptMethod, 15), newCost)
         Seq(
-          (t1, success(Some(1), 1786)),
-          (t2, success(Some(64), 1786)),
-          (t3, success(None, 1785))
+          (t1, success(Some(1), 1766)),
+          (t2, success(Some(64), 1766)),
+          (t3, success(None, 1765))
         )
       },
       existingFeature((t: AvlTree) => t.valueLengthOpt,
@@ -3037,7 +3037,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36479, methodCostDetails(SAvlTree.isInsertAllowedMethod, 15), 1785)
+        def success[T](v: T) = Expected(Success(v), 36479, methodCostDetails(SAvlTree.isInsertAllowedMethod, 15), 1765)
         Seq(
           (t1, success(false)),
           (t2, success(false)),
@@ -3050,7 +3050,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36096, methodCostDetails(SAvlTree.isUpdateAllowedMethod, 15), 1785)
+        def success[T](v: T) = Expected(Success(v), 36096, methodCostDetails(SAvlTree.isUpdateAllowedMethod, 15), 1765)
         Seq(
           (t1, success(true)),
           (t2, success(false)),
@@ -3063,7 +3063,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36502, methodCostDetails(SAvlTree.isRemoveAllowedMethod, 15), 1785)
+        def success[T](v: T) = Expected(Success(v), 36502, methodCostDetails(SAvlTree.isRemoveAllowedMethod, 15), 1765)
         Seq(
           (t1, success(true)),
           (t2, success(false)),
@@ -3318,7 +3318,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         )
       )
 
-      getMany.checkExpected(input, Expected(Success(expRes), 38991, costDetails, 1865))
+      getMany.checkExpected(input, Expected(Success(expRes), 38991, costDetails, 1845))
     }
 
     val key = Colls.fromArray(Array[Byte](-16,-128,99,86,1,-128,-36,-83,109,72,-124,-114,1,-32,15,127,-30,125,127,1,-102,-53,-53,-128,-107,0,64,8,1,127,22,1))
@@ -3396,8 +3396,8 @@ class SigmaDslSpecification extends SigmaDslTesting
       // positive test
       {
         val input = (tree, (key, proof))
-        contains.checkExpected(input, Expected(Success(okContains), 37850, costDetails(105 + additionalDetails), 1810))
-        get.checkExpected(input, Expected(Success(valueOpt), 38372, costDetails(105 + additionalDetails), 1810 + additionalCost))
+        contains.checkExpected(input, Expected(Success(okContains), 37850, costDetails(105 + additionalDetails), 1790))
+        get.checkExpected(input, Expected(Success(valueOpt), 38372, costDetails(105 + additionalDetails), 1790 + additionalCost))
       }
 
       val keys = Colls.fromItems(key)
@@ -3405,14 +3405,14 @@ class SigmaDslSpecification extends SigmaDslTesting
 
       {
         val input = (tree, (keys, proof))
-        getMany.checkExpected(input, Expected(Success(expRes), 38991, costDetails(105 + additionalDetails), 1811 + additionalCost))
+        getMany.checkExpected(input, Expected(Success(expRes), 38991, costDetails(105 + additionalDetails), 1791 + additionalCost))
       }
 
       {
         val input = (tree, digest)
         val (res, _) = updateDigest.checkEquality(input).getOrThrow
         res.digest shouldBe digest
-        updateDigest.checkExpected(input, Expected(Success(res), 36341, updateDigestCostDetails, 1791))
+        updateDigest.checkExpected(input, Expected(Success(res), 36341, updateDigestCostDetails, 1771))
       }
 
       val newOps = 1.toByte
@@ -3421,7 +3421,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         val input = (tree, newOps)
         val (res,_) = updateOperations.checkEquality(input).getOrThrow
         res.enabledOperations shouldBe newOps
-        updateOperations.checkExpected(input, Expected(Success(res), 36341, updateOperationsCostDetails, 1791))
+        updateOperations.checkExpected(input, Expected(Success(res), 36341, updateOperationsCostDetails, 1771))
       }
 
       // negative tests: invalid proof
@@ -3431,7 +3431,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         val input = (tree, (key, invalidProof))
         val (res, _) = contains.checkEquality(input).getOrThrow
         res shouldBe false
-        contains.checkExpected(input, Expected(Success(res), 37850, costDetails(105 + additionalDetails), 1810))
+        contains.checkExpected(input, Expected(Success(res), 37850, costDetails(105 + additionalDetails), 1790))
       }
 
       {
@@ -3584,7 +3584,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         val input = (preInsertTree, (kvs, insertProof))
         val (res, _) = insert.checkEquality(input).getOrThrow
         res.isDefined shouldBe true
-        insert.checkExpected(input, Expected(Success(res), 38501, costDetails2, 1816))
+        insert.checkExpected(input, Expected(Success(res), 38501, costDetails2, 1796))
       }
 
       { // negative: readonly tree
@@ -3592,7 +3592,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         val input = (readonlyTree, (kvs, insertProof))
         val (res, _) = insert.checkEquality(input).getOrThrow
         res.isDefined shouldBe false
-        insert.checkExpected(input, Expected(Success(res), 38501, costDetails1, 1792))
+        insert.checkExpected(input, Expected(Success(res), 38501, costDetails1, 1772))
       }
 
       { // negative: invalid key
@@ -3602,7 +3602,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         val input = (tree, (invalidKvs, insertProof))
         val (res, _) = insert.checkEquality(input).getOrThrow
         res.isDefined shouldBe true // TODO v6.0: should it really be true? (looks like a bug)
-        insert.checkExpected(input, Expected(Success(res), 38501, costDetails2, 1816))
+        insert.checkExpected(input, Expected(Success(res), 38501, costDetails2, 1796))
       }
 
       { // negative: invalid proof
@@ -3733,7 +3733,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       val endTree = preUpdateTree.updateDigest(endDigest)
       val input = (preUpdateTree, (kvs, updateProof))
       val res = Some(endTree)
-      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1825))
+      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1805))
     }
 
     { // positive: update to the same value (identity operation)
@@ -3741,13 +3741,13 @@ class SigmaDslSpecification extends SigmaDslTesting
       val keys = Colls.fromItems((key -> value))
       val input = (tree, (keys, updateProof))
       val res = Some(tree)
-      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1825))
+      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1805))
     }
 
     { // negative: readonly tree
       val readonlyTree = createTree(preUpdateDigest)
       val input = (readonlyTree, (kvs, updateProof))
-      update.checkExpected(input, Expected(Success(None), cost, costDetails1, 1792))
+      update.checkExpected(input, Expected(Success(None), cost, costDetails1, 1772))
     }
 
     { // negative: invalid key
@@ -3755,7 +3755,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       val invalidKey = key.map(x => (-x).toByte) // any other different from key
       val invalidKvs = Colls.fromItems((invalidKey -> newValue))
       val input = (tree, (invalidKvs, updateProof))
-      update.checkExpected(input, Expected(Success(None), cost, costDetails3, 1821))
+      update.checkExpected(input, Expected(Success(None), cost, costDetails3, 1801))
     }
 
     { // negative: invalid value (different from the value in the proof)
@@ -3765,14 +3765,14 @@ class SigmaDslSpecification extends SigmaDslTesting
       val input = (tree, (invalidKvs, updateProof))
       val (res, _) = update.checkEquality(input).getOrThrow
       res.isDefined shouldBe true  // TODO v6.0: should it really be true? (looks like a bug)
-      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1825))
+      update.checkExpected(input, Expected(Success(res), cost, costDetails2, 1805))
     }
 
     { // negative: invalid proof
       val tree = createTree(preUpdateDigest, updateAllowed = true)
       val invalidProof = updateProof.map(x => (-x).toByte) // any other different from proof
       val input = (tree, (kvs, invalidProof))
-      update.checkExpected(input, Expected(Success(None), cost, costDetails3, 1821))
+      update.checkExpected(input, Expected(Success(None), cost, costDetails3, 1801))
     }
   }
 
@@ -3883,7 +3883,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       val endTree = preRemoveTree.updateDigest(endDigest)
       val input = (preRemoveTree, (Colls.fromArray(keysToRemove), removeProof))
       val res = Some(endTree)
-      remove.checkExpected(input, Expected(Success(res), 38270, costDetails1, 1852))
+      remove.checkExpected(input, Expected(Success(res), 38270, costDetails1, 1832))
     }
 
     {
@@ -3901,13 +3901,13 @@ class SigmaDslSpecification extends SigmaDslTesting
         val endTree = preRemoveTree.updateDigest(endDigest)
         val input = (preRemoveTree, (keys, removeProof))
         val res = Some(endTree)
-        remove.checkExpected(input, Expected(Success(res), cost, costDetails2, 1826))
+        remove.checkExpected(input, Expected(Success(res), cost, costDetails2, 1806))
       }
 
       { // negative: readonly tree
         val readonlyTree = createTree(preRemoveDigest)
         val input = (readonlyTree, (keys, removeProof))
-        remove.checkExpected(input, Expected(Success(None), cost, costDetails3, 1792))
+        remove.checkExpected(input, Expected(Success(None), cost, costDetails3, 1772))
       }
 
       { // negative: invalid key
@@ -3915,14 +3915,14 @@ class SigmaDslSpecification extends SigmaDslTesting
         val invalidKey = key.map(x => (-x).toByte) // any other different from `key`
         val invalidKeys = Colls.fromItems(invalidKey)
         val input = (tree, (invalidKeys, removeProof))
-        remove.checkExpected(input, Expected(Success(None), cost, costDetails4, 1822))
+        remove.checkExpected(input, Expected(Success(None), cost, costDetails4, 1802))
       }
 
       { // negative: invalid proof
         val tree = createTree(preRemoveDigest, removeAllowed = true)
         val invalidProof = removeProof.map(x => (-x).toByte) // any other different from `removeProof`
         val input = (tree, (keys, invalidProof))
-        remove.checkExpected(input, Expected(Success(None), cost, costDetails4, 1822))
+        remove.checkExpected(input, Expected(Success(None), cost, costDetails4, 1802))
       }
     }
   }
@@ -3931,7 +3931,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(LongToByteArray), FixedCost(JitCost(17))))
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36007, costDetails, 1787)
+        def success[T](v: T) = Expected(Success(v), 36007, costDetails, 1767)
         Seq(
           (-9223372036854775808L, success(Helpers.decodeBytes("8000000000000000"))),
           (-1148502660425090565L, success(Helpers.decodeBytes("f00fb2ea55c579fb"))),
@@ -3951,7 +3951,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ByteArrayToBigInt), FixedCost(JitCost(30))))
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36536, costDetails, 1787)
+        def success[T](v: T) = Expected(Success(v), 36536, costDetails, 1767)
         Seq(
           (Helpers.decodeBytes(""),
               Expected(new NumberFormatException("Zero length BigInteger"))),
@@ -3962,9 +3962,9 @@ class SigmaDslSpecification extends SigmaDslTesting
           (Helpers.decodeBytes("ff"),
               success(CBigInt(new BigInteger("-1", 16)))),
           (Helpers.decodeBytes("80d6c201"),
-              Expected(Success(CBigInt(new BigInteger("-7f293dff", 16))), 36539, costDetails, 1787)),
+              Expected(Success(CBigInt(new BigInteger("-7f293dff", 16))), 36539, costDetails, 1767)),
           (Helpers.decodeBytes("70d6c20170d6c201"),
-              Expected(Success(CBigInt(new BigInteger("70d6c20170d6c201", 16))), 36543, costDetails, 1787)),
+              Expected(Success(CBigInt(new BigInteger("70d6c20170d6c201", 16))), 36543, costDetails, 1767)),
           (Helpers.decodeBytes(
             "80e0ff7f02807fff72807f0a00ff7fb7c57f75c11ba2802970fd250052807fc37f6480ffff007fff18eeba44"
           ), Expected(new ArithmeticException("BigInteger out of 256 bit range")))
@@ -3979,7 +3979,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ByteArrayToLong), FixedCost(JitCost(16))))
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36092, costDetails, 1785)
+        def success[T](v: T) = Expected(Success(v), 36092, costDetails, 1765)
         Seq(
           (Helpers.decodeBytes(""), Expected(new IllegalArgumentException("array too small: 0 < 8"))),
           (Helpers.decodeBytes("81"), Expected(new IllegalArgumentException("array too small: 1 < 8"))),
@@ -4010,7 +4010,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractId), FixedCost(JitCost(12))))
-        def success[T](v: T) = Expected(Success(v), 35984, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 35984, costDetails, 1766)
         Seq(
           (b1, success(Helpers.decodeBytes("5ee78f30ae4e770e44900a46854e9fecb6b12e8112556ef1cd19aef633b4421e"))),
           (b2, success(Helpers.decodeBytes("3a0089be265460e29ca47d26e5b55a6f3e3ffaf5b4aed941410a2437913848ad")))
@@ -4023,7 +4023,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractAmount), FixedCost(JitCost(8))))
-        def success[T](v: T) = Expected(Success(v), 35882, costDetails, 1784)
+        def success[T](v: T) = Expected(Success(v), 35882, costDetails, 1764)
         Seq(
           (b1, success(9223372036854775807L)),
           (b2, success(12345L))
@@ -4036,7 +4036,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractScriptBytes), FixedCost(JitCost(10))))
-        def success[T](v: T) = Expected(Success(v), 35938, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 35938, costDetails, 1766)
         Seq(
           (b1, success(Helpers.decodeBytes(
             "100108cd0297c44a12f4eb99a85d298fa3ba829b5b42b9f63798c980ece801cc663cc5fc9e7300"
@@ -4051,7 +4051,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractBytes), FixedCost(JitCost(12))))
-        def success[T](v: T) = Expected(Success(v), 36012, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 36012, costDetails, 1766)
         Seq(
           (b1, success(Helpers.decodeBytes(
             "ffffffffffffffff7f100108cd0297c44a12f4eb99a85d298fa3ba829b5b42b9f63798c980ece801cc663cc5fc9e73009fac29026e789ab7b2fffff12280a6cd01557f6fb22b7f80ff7aff8e1f7f15973d7f000180ade204a3ff007f00057600808001ff8f8000019000ffdb806fff7cc0b6015eb37fa600f4030201000e067fc87f7f01ff218301ae8000018008637f0021fb9e00018055486f0b514121016a00ff718080bcb001"
@@ -4068,7 +4068,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractBytesWithNoRef), FixedCost(JitCost(12))))
-        def success[T](v: T) = Expected(Success(v), 35954, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 35954, costDetails, 1766)
         Seq(
           (b1, success(Helpers.decodeBytes(
             "ffffffffffffffff7f100108cd0297c44a12f4eb99a85d298fa3ba829b5b42b9f63798c980ece801cc663cc5fc9e73009fac29026e789ab7b2fffff12280a6cd01557f6fb22b7f80ff7aff8e1f7f15973d7f000180ade204a3ff007f00057600808001ff8f8000019000ffdb806fff7cc0b6015eb37fa600f4030201000e067fc87f7f01ff"
@@ -4085,7 +4085,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         val costDetails = CostDetails(traceBase :+ FixedCostItem(CompanionDesc(ExtractCreationInfo), FixedCost(JitCost(16))))
-        def success[T](v: T) = Expected(Success(v), 36074, costDetails, 1787)
+        def success[T](v: T) = Expected(Success(v), 36074, costDetails, 1767)
         Seq(
           (b1, success((
               677407,
@@ -4108,8 +4108,8 @@ class SigmaDslSpecification extends SigmaDslTesting
         b1 -> Expected(Success(Coll[(Coll[Byte], Long)](
           (Helpers.decodeBytes("6e789ab7b2fffff12280a6cd01557f6fb22b7f80ff7aff8e1f7f15973d7f0001"), 10000000L),
           (Helpers.decodeBytes("a3ff007f00057600808001ff8f8000019000ffdb806fff7cc0b6015eb37fa600"), 500L)
-          ).map(identity)), 36167, methodCostDetails(SBox.tokensMethod, 15), 1792),
-        b2 -> Expected(Success(Coll[(Coll[Byte], Long)]().map(identity)), 36157, methodCostDetails(SBox.tokensMethod, 15), 1786)
+          ).map(identity)), 36167, methodCostDetails(SBox.tokensMethod, 15), 1772),
+        b2 -> Expected(Success(Coll[(Coll[Byte], Long)]().map(identity)), 36157, methodCostDetails(SBox.tokensMethod, 15), 1766)
       ),
       existingFeature({ (x: Box) => x.tokens },
         "{ (x: Box) => x.tokens }",
@@ -4188,11 +4188,11 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (box1, Expected(Success(1024.toShort), 37190, expCostDetails1, 1794)),
+        (box1, Expected(Success(1024.toShort), 37190, expCostDetails1, 1774)),
         (box2, Expected(
           new InvalidType("Cannot getReg[Short](5): invalid type of value TestValue(1048576) at id=5")
         )),
-        (box3, Expected(Success(0.toShort), 37190, expCostDetails2, 1792))
+        (box3, Expected(Success(0.toShort), 37190, expCostDetails2, 1772))
       ),
       existingFeature(
         { (x: Box) =>
@@ -4317,10 +4317,10 @@ class SigmaDslSpecification extends SigmaDslTesting
   
     verifyCases(
       Seq(
-        (box1, Expected(Success(1024), cost = 39782, expCostDetails3, 1805)),
-        (box2, Expected(Success(1024 * 1024), cost = 39782, expCostDetails4, 1806)),
-        (box3, Expected(Success(0), cost = 39782, expCostDetails5, 1799)),
-        (box4, Expected(Success(-1), cost = 39782, expCostDetails2, 1792))
+        (box1, Expected(Success(1024), cost = 39782, expCostDetails3, 1785)),
+        (box2, Expected(Success(1024 * 1024), cost = 39782, expCostDetails4, 1786)),
+        (box3, Expected(Success(0), cost = 39782, expCostDetails5, 1779)),
+        (box4, Expected(Success(-1), cost = 39782, expCostDetails2, 1772))
       ),
       existingFeature(
         { (x: Box) =>
@@ -4414,7 +4414,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        (box1, Expected(Success(1.toByte), cost = 36253, expCostDetails, 1790)),
+        (box1, Expected(Success(1.toByte), cost = 36253, expCostDetails, 1770)),
         (box2, Expected(new InvalidType("Cannot getReg[Byte](4): invalid type of value Value(Coll(1)) at id=4")))
       ),
       existingFeature((x: Box) => x.R4[Byte].get,
@@ -4426,7 +4426,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (box1, Expected(Success(1024.toShort), cost = 36253, expCostDetails, 1790)),
+        (box1, Expected(Success(1024.toShort), cost = 36253, expCostDetails, 1770)),
         (box2, Expected(new NoSuchElementException("None.get")))
       ),
       existingFeature((x: Box) => x.R5[Short].get,
@@ -4438,7 +4438,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (box1, Expected(Success(1024 * 1024), cost = 36253, expCostDetails, 1790))
+        (box1, Expected(Success(1024 * 1024), cost = 36253, expCostDetails, 1770))
       ),
       existingFeature((x: Box) => x.R6[Int].get,
         "{ (x: Box) => x.R6[Int].get }",
@@ -4449,7 +4449,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (box1, Expected(Success(1024.toLong), cost = 36253, expCostDetails, 1790))
+        (box1, Expected(Success(1024.toLong), cost = 36253, expCostDetails, 1770))
       ),
       existingFeature((x: Box) => x.R7[Long].get,
         "{ (x: Box) => x.R7[Long].get }",
@@ -4460,7 +4460,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        (box1, Expected(Success(CBigInt(BigInteger.valueOf(222L))), cost = 36253, expCostDetails, 1790))
+        (box1, Expected(Success(CBigInt(BigInteger.valueOf(222L))), cost = 36253, expCostDetails, 1770))
       ),
       existingFeature((x: Box) => x.R8[BigInt].get,
         "{ (x: Box) => x.R8[BigInt].get }",
@@ -4483,7 +4483,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         )),
         cost = 36253,
         expCostDetails,
-        1790)
+        1770)
       )),
       existingFeature((x: Box) => x.R9[AvlTree].get,
         "{ (x: Box) => x.R9[AvlTree].get }",
@@ -4555,35 +4555,35 @@ class SigmaDslSpecification extends SigmaDslTesting
     
 
     verifyCases(
-      Seq((preH1, Expected(Success(0.toByte), cost = 37022, methodCostDetails(SPreHeader.versionMethod, 10), 1785))),
+      Seq((preH1, Expected(Success(0.toByte), cost = 37022, methodCostDetails(SPreHeader.versionMethod, 10), 1765))),
       existingPropTest("version", { (x: PreHeader) => x.version }))
 
     verifyCases(
       Seq((preH1, Expected(Success(
         Helpers.decodeBytes("7fff7fdd6f62018bae0001006d9ca888ff7f56ff8006573700a167f17f2c9f40")),
-        cost = 36121, methodCostDetails(SPreHeader.parentIdMethod, 10), 1786))),
+        cost = 36121, methodCostDetails(SPreHeader.parentIdMethod, 10), 1766))),
       existingPropTest("parentId", { (x: PreHeader) => x.parentId }))
 
     verifyCases(
-      Seq((preH1, Expected(Success(6306290372572472443L), cost = 36147, methodCostDetails(SPreHeader.timestampMethod, 10), 1785))),
+      Seq((preH1, Expected(Success(6306290372572472443L), cost = 36147, methodCostDetails(SPreHeader.timestampMethod, 10), 1765))),
       existingPropTest("timestamp", { (x: PreHeader) => x.timestamp }))
 
     verifyCases(
-      Seq((preH1, Expected(Success(-3683306095029417063L), cost = 36127, methodCostDetails(SPreHeader.nBitsMethod, 10), 1785))),
+      Seq((preH1, Expected(Success(-3683306095029417063L), cost = 36127, methodCostDetails(SPreHeader.nBitsMethod, 10), 1765))),
       existingPropTest("nBits", { (x: PreHeader) => x.nBits }))
 
     verifyCases(
-      Seq((preH1, Expected(Success(1), cost = 36136, methodCostDetails(SPreHeader.heightMethod, 10), 1785))),
+      Seq((preH1, Expected(Success(1), cost = 36136, methodCostDetails(SPreHeader.heightMethod, 10), 1765))),
       existingPropTest("height", { (x: PreHeader) => x.height }))
 
     verifyCases(
       Seq((preH1, Expected(Success(
         Helpers.decodeGroupElement("026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b")),
-        cost = 36255, methodCostDetails(SPreHeader.minerPkMethod, 10), 1802))),
+        cost = 36255, methodCostDetails(SPreHeader.minerPkMethod, 10), 1782))),
       existingPropTest("minerPk", { (x: PreHeader) => x.minerPk }))
 
     verifyCases(
-      Seq((preH1, Expected(Success(Helpers.decodeBytes("ff8087")), cost = 36249, methodCostDetails(SPreHeader.votesMethod,10), 1786))),
+      Seq((preH1, Expected(Success(Helpers.decodeBytes("ff8087")), cost = 36249, methodCostDetails(SPreHeader.votesMethod,10), 1766))),
       existingPropTest("votes", { (x: PreHeader) => x.votes }))
   }
 
@@ -4591,81 +4591,81 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("957f008001808080ffe4ffffc8f3802401df40006aa05e017fa8d3f6004c804a")),
-        cost = 36955, methodCostDetails(SHeader.idMethod, 10), 1786))),
+        cost = 36955, methodCostDetails(SHeader.idMethod, 10), 1766))),
       existingPropTest("id", { (x: Header) => x.id }))
 
     verifyCases(
-      Seq((h1, Expected(Success(0.toByte), cost = 36124, methodCostDetails(SHeader.versionMethod, 10), 1785))),
+      Seq((h1, Expected(Success(0.toByte), cost = 36124, methodCostDetails(SHeader.versionMethod, 10), 1765))),
       existingPropTest("version", { (x: Header) => x.version }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("0180dd805b0000ff5400b997fd7f0b9b00de00fb03c47e37806a8186b94f07ff")),
-        cost = 36097, methodCostDetails(SHeader.parentIdMethod, 10), 1786))),
+        cost = 36097, methodCostDetails(SHeader.parentIdMethod, 10), 1766))),
       existingPropTest("parentId", { (x: Header) => x.parentId }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("01f07f60d100ffb970c3007f60ff7f24d4070bb8fffa7fca7f34c10001ffe39d")),
-        cost = 36111, methodCostDetails(SHeader.ADProofsRootMethod, 10), 1786))),
+        cost = 36111, methodCostDetails(SHeader.ADProofsRootMethod, 10), 1766))),
       existingPropTest("ADProofsRoot", { (x: Header) => x.ADProofsRoot}))
 
     verifyCases(
-      Seq((h1, Expected(Success(CAvlTree(createAvlTreeData())), cost = 36092, methodCostDetails(SHeader.stateRootMethod, 10), 1785))),
+      Seq((h1, Expected(Success(CAvlTree(createAvlTreeData())), cost = 36092, methodCostDetails(SHeader.stateRootMethod, 10), 1765))),
       existingPropTest("stateRoot", { (x: Header) => x.stateRoot }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("804101ff01000080a3ffbd006ac080098df132a7017f00649311ec0e00000100")),
-        cost = 36094, methodCostDetails(SHeader.transactionsRootMethod, 10), 1786))),
+        cost = 36094, methodCostDetails(SHeader.transactionsRootMethod, 10), 1766))),
       existingPropTest("transactionsRoot", { (x: Header) => x.transactionsRoot }))
 
     verifyCases(
-      Seq((h1, Expected(Success(1L), cost = 36151, methodCostDetails(SHeader.timestampMethod, 10), 1785))),
+      Seq((h1, Expected(Success(1L), cost = 36151, methodCostDetails(SHeader.timestampMethod, 10), 1765))),
       existingPropTest("timestamp", { (x: Header) => x.timestamp }))
 
     verifyCases(
-      Seq((h1, Expected(Success(-1L), cost = 36125, methodCostDetails(SHeader.nBitsMethod, 10), 1785))),
+      Seq((h1, Expected(Success(-1L), cost = 36125, methodCostDetails(SHeader.nBitsMethod, 10), 1765))),
       existingPropTest("nBits", { (x: Header) => x.nBits }))
 
     verifyCases(
-      Seq((h1, Expected(Success(1), cost = 36134, methodCostDetails(SHeader.heightMethod, 10), 1785))),
+      Seq((h1, Expected(Success(1), cost = 36134, methodCostDetails(SHeader.heightMethod, 10), 1765))),
       existingPropTest("height", { (x: Header) => x.height }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("e57f80885601b8ff348e01808000bcfc767f2dd37f0d01015030ec018080bc62")),
-        cost = 36133, methodCostDetails(SHeader.extensionRootMethod, 10), 1786))),
+        cost = 36133, methodCostDetails(SHeader.extensionRootMethod, 10), 1766))),
       existingPropTest("extensionRoot", { (x: Header) => x.extensionRoot }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeGroupElement("039bdbfa0b49cc6bef58297a85feff45f7bbeb500a9d2283004c74fcedd4bd2904")),
-        cost = 36111, methodCostDetails(SHeader.minerPkMethod, 10), 1802))),
+        cost = 36111, methodCostDetails(SHeader.minerPkMethod, 10), 1782))),
       existingPropTest("minerPk", { (x: Header) => x.minerPk }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeGroupElement("0361299207fa392231e23666f6945ae3e867b978e021d8d702872bde454e9abe9c")),
-        cost = 36111, methodCostDetails(SHeader.powOnetimePkMethod, 10), 1802))),
+        cost = 36111, methodCostDetails(SHeader.powOnetimePkMethod, 10), 1782))),
       existingPropTest("powOnetimePk", { (x: Header) => x.powOnetimePk }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("7f4f09012a807f01")),
-        cost = 36176, methodCostDetails(SHeader.powNonceMethod, 10), 1786))),
+        cost = 36176, methodCostDetails(SHeader.powNonceMethod, 10), 1766))),
       existingPropTest("powNonce", { (x: Header) => x.powNonce }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         CBigInt(new BigInteger("-e24990c47e15ed4d0178c44f1790cc72155d516c43c3e8684e75db3800a288", 16))),
-        cost = 36220, methodCostDetails(SHeader.powDistanceMethod, 10), 1785))),
+        cost = 36220, methodCostDetails(SHeader.powDistanceMethod, 10), 1765))),
       existingPropTest("powDistance", { (x: Header) => x.powDistance }))
 
     verifyCases(
       Seq((h1, Expected(Success(
         Helpers.decodeBytes("7f0180")),
-        cost = 36100, methodCostDetails(SHeader.votesMethod, 10), 1786))),
+        cost = 36100, methodCostDetails(SHeader.votesMethod, 10), 1766))),
       existingPropTest("votes", { (x: Header) => x.votes }))
   }
 
@@ -4884,7 +4884,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = TracedCost(testTraceBase)
     verifyCases(
       Seq(
-        (ctx, Expected(Success(dataBox), cost = 37087, costDetails, 1789)),
+        (ctx, Expected(Success(dataBox), cost = 37087, costDetails, 1769)),
         (ctx.copy(_dataInputs = Coll()), Expected(new ArrayIndexOutOfBoundsException("0")))
       ),
       existingFeature({ (x: Context) => x.dataInputs(0) },
@@ -4909,7 +4909,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       Seq(
         (ctx, Expected(Success(
           Helpers.decodeBytes("7da4b55971f19a78d007638464580f91a020ab468c0dbe608deb1f619e245bc3")),
-          cost = 37193, idCostDetails, 1792))
+          cost = 37193, idCostDetails, 1772))
       ),
       existingFeature({ (x: Context) => x.dataInputs(0).id },
         "{ (x: Context) => x.dataInputs(0).id }",
@@ -4970,7 +4970,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
     )
     verifyCases(
-      Seq(ctx -> Expected(Success(ctx.HEIGHT), cost = 35885, heightCostDetails, 1786)),
+      Seq(ctx -> Expected(Success(ctx.HEIGHT), cost = 35885, heightCostDetails, 1766)),
       existingFeature(
         { (x: Context) => x.HEIGHT },
         "{ (x: Context) => x.HEIGHT }",
@@ -4991,7 +4991,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         FixedCostItem(ValUse),
         FixedCostItem(ExtractAmount)))
     verifyCases(
-      Seq((ctx, Expected(Success(Coll[Long](80946L)), cost = 39152, inputsCostDetails1, 1790))),
+      Seq((ctx, Expected(Success(Coll[Long](80946L)), cost = 39152, inputsCostDetails1, 1770))),
       existingFeature(
         { (x: Context) => x.INPUTS.map { (b: Box) => b.value } },
         "{ (x: Context) => x.INPUTS.map { (b: Box) => b.value } }",
@@ -5020,7 +5020,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         FixedCostItem(ValUse),
         FixedCostItem(Tuple)))
     verifyCases(
-      Seq((ctx, Expected(Success(Coll((80946L, 80946L))), cost = 39959, inputsCostDetails2, 1794))),
+      Seq((ctx, Expected(Success(Coll((80946L, 80946L))), cost = 39959, inputsCostDetails2, 1774))),
       existingFeature(
         { (x: Context) => x.INPUTS.map { (b: Box) => (b.value, b.value) } },
         """{ (x: Context) =>
@@ -5086,9 +5086,9 @@ class SigmaDslSpecification extends SigmaDslTesting
         (ctx, Expected(
           Success(-1), cost = 36318,
           expectedDetails = CostDetails.ZeroCost,
-          newCost = 1786,
+          newCost = 1766,
           newVersionedResults = {
-            val res = (ExpectedResult(Success(0), Some(1786)) -> Some(selfCostDetails))
+            val res = (ExpectedResult(Success(0), Some(1766)) -> Some(selfCostDetails))
             Seq(0, 1, 2).map(version => version -> res)
           }))
       ),
@@ -5118,7 +5118,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     }
 
     verifyCases(
-      Seq(ctx -> Expected(Success(ctx.LastBlockUtxoRootHash), cost = 35990, methodCostDetails(SContext.lastBlockUtxoRootHashMethod, 15), 1786)),
+      Seq(ctx -> Expected(Success(ctx.LastBlockUtxoRootHash), cost = 35990, methodCostDetails(SContext.lastBlockUtxoRootHashMethod, 15), 1766)),
       existingPropTest("LastBlockUtxoRootHash", { (x: Context) => x.LastBlockUtxoRootHash }),
       preGeneratedSamples = Some(samples))
 
@@ -5131,7 +5131,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
     )
     verifyCases(
-      Seq(ctx -> Expected(Success(ctx.LastBlockUtxoRootHash.isUpdateAllowed), cost = 36288, isUpdateAllowedCostDetails, 1787)),
+      Seq(ctx -> Expected(Success(ctx.LastBlockUtxoRootHash.isUpdateAllowed), cost = 36288, isUpdateAllowedCostDetails, 1767)),
       existingFeature(
         { (x: Context) => x.LastBlockUtxoRootHash.isUpdateAllowed },
         "{ (x: Context) => x.LastBlockUtxoRootHash.isUpdateAllowed }",
@@ -5152,7 +5152,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       preGeneratedSamples = Some(samples))
 
     verifyCases(
-      Seq(ctx -> Expected(Success(ctx.minerPubKey), cost = 36047, methodCostDetails(SContext.minerPubKeyMethod, 20), 1787)),
+      Seq(ctx -> Expected(Success(ctx.minerPubKey), cost = 36047, methodCostDetails(SContext.minerPubKeyMethod, 20), 1767)),
       existingPropTest("minerPubKey", { (x: Context) => x.minerPubKey }),
       preGeneratedSamples = Some(samples))
 
@@ -5192,7 +5192,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         FixedCostItem(GetVar),
         FixedCostItem(OptionGet)))
     verifyCases(
-      Seq((ctx, Expected(Success(true), cost = 36750, getVarCostDetails, 1785))),
+      Seq((ctx, Expected(Success(true), cost = 36750, getVarCostDetails, 1765))),
       existingFeature((x: Context) => x.getVar[Boolean](11).get,
       "{ (x: Context) => getVar[Boolean](11).get }",
         FuncValue(Vector((1, SContext)), OptionGet(GetVar(11.toByte, SOption(SBoolean))))),
@@ -5226,7 +5226,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        ctx -> Expected(Success(-135729055492651903L), 38399, registerIsDefinedCostDetails, 1799)
+        ctx -> Expected(Success(-135729055492651903L), 38399, registerIsDefinedCostDetails, 1779)
       ),
       existingFeature(
       { (x: Context) =>
@@ -5286,9 +5286,9 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       Seq(
-        ctx -> Expected(Failure(expectedError), 0, CostDetails.ZeroCost, 1813,
+        ctx -> Expected(Failure(expectedError), 0, CostDetails.ZeroCost, 1793,
           newVersionedResults = {
-            Seq.tabulate(3)(v => v -> (ExpectedResult(Success(true), Some(1813)) -> None))
+            Seq.tabulate(3)(v => v -> (ExpectedResult(Success(true), Some(1793)) -> None))
           }
         )
       ),
@@ -5454,12 +5454,12 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       Seq(
-        ctx -> Expected(Success(5008366408131208436L), 40406, registerTagCostDetails1, 1811),
+        ctx -> Expected(Success(5008366408131208436L), 40406, registerTagCostDetails1, 1791),
         ctxWithRegsInOutput(ctx, Map(
           ErgoBox.R5 -> LongConstant(0L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(10L), 40396, registerTagCostDetails2, 1810),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(10L), 40396, registerTagCostDetails2, 1790),
         ctxWithRegsInOutput(ctx, Map(
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 40396, registerTagCostDetails3, 1797)
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 40396, registerTagCostDetails3, 1777)
       ),
       existingFeature(
       { (x: Context) =>
@@ -5662,22 +5662,22 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq(
         // case 1L
-        ctx -> Expected(Success(5008366408131289382L), 41016, tagRegisterCostDetails1, 1814),
+        ctx -> Expected(Success(5008366408131289382L), 41016, tagRegisterCostDetails1, 1794),
         // case 0L
         ctxWithRegsInOutput(ctx, Map(
           ErgoBox.R5 -> LongConstant(0L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(80956L), 41006, tagRegisterCostDetails2, 1813),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(80956L), 41006, tagRegisterCostDetails2, 1793),
 
         // case returning 0L
         ctxWithRegsInOutput(ctx, Map(
           ErgoBox.R5 -> LongConstant(2L),
           // note R4 is required to avoid
           // "RuntimeException: Set of non-mandatory indexes is not densely packed"
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41006, tagRegisterCostDetails3, 1804),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41006, tagRegisterCostDetails3, 1784),
 
         // case returning -1L
         ctxWithRegsInOutput(ctx, Map(
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41006, tagRegisterCostDetails4, 1797)
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41006, tagRegisterCostDetails4, 1777)
       ),
       existingFeature(
       { (x: Context) =>
@@ -5895,15 +5895,15 @@ class SigmaDslSpecification extends SigmaDslTesting
       Seq(
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(1L),
-          ErgoBox.R4 -> LongConstant(10))) -> Expected(Success(10L), 41084, tagRegisterCostDetails1, 1812),
+          ErgoBox.R4 -> LongConstant(10))) -> Expected(Success(10L), 41084, tagRegisterCostDetails1, 1792),
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(0L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(10L), 41084, tagRegisterCostDetails2, 1811),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(10L), 41084, tagRegisterCostDetails2, 1791),
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(2L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41084, tagRegisterCostDetails3, 1806),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41084, tagRegisterCostDetails3, 1786),
         ctxWithRegsInDataInput(ctx, Map(
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41084, tagRegisterCostDetails4, 1799)
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41084, tagRegisterCostDetails4, 1779)
       ),
       existingFeature(
       { (x: Context) =>
@@ -6128,15 +6128,15 @@ class SigmaDslSpecification extends SigmaDslTesting
       Seq(
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(1L),
-          ErgoBox.R4 -> LongConstant(10))) -> Expected(Success(80956L), 41694, costDetails1, 1816),
+          ErgoBox.R4 -> LongConstant(10))) -> Expected(Success(80956L), 41694, costDetails1, 1796),
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(0L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(80956L), 41694, costDetails2, 1814),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(80956L), 41694, costDetails2, 1794),
         ctxWithRegsInDataInput(ctx, Map(
           ErgoBox.R5 -> LongConstant(2L),
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41694, costDetails3, 1806),
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(0L), 41694, costDetails3, 1786),
         ctxWithRegsInDataInput(ctx, Map(
-          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41694, costDetails4, 1799)
+          ErgoBox.R4 -> ShortConstant(10))) -> Expected(Success(-1L), 41694, costDetails4, 1779)
       ),
       existingFeature(
       { (x: Context) =>
@@ -6240,8 +6240,8 @@ class SigmaDslSpecification extends SigmaDslTesting
           value = Success(v),
           cost = c,
           expectedDetails = CostDetails.ZeroCost,
-          newCost = 1786,
-          newVersionedResults = Seq(0, 1, 2).map(i => i -> (ExpectedResult(Success(newV), Some(1786)) -> Some(cd)))
+          newCost = 1766,
+          newVersionedResults = Seq(0, 1, 2).map(i => i -> (ExpectedResult(Success(newV), Some(1766)) -> Some(cd)))
         )
         Seq(
           (Coll[Boolean](), successNew(false, 37061, newV = false, costDetails(0))),
@@ -6276,8 +6276,8 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = TracedCost(traceBase :+ FixedCostItem(LogicalNot))
     verifyCases(
       Seq(
-        (true, Expected(Success(false), 35864, costDetails, 1785)),
-        (false, Expected(Success(true), 35864, costDetails, 1785))),
+        (true, Expected(Success(false), 35864, costDetails, 1765)),
+        (false, Expected(Success(true), 35864, costDetails, 1765))),
       existingFeature((x: Boolean) => !x,
         "{ (x: Boolean) => !x }",
         FuncValue(Vector((1, SBoolean)), LogicalNot(ValUse(1, SBoolean)))))
@@ -6287,7 +6287,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = TracedCost(traceBase :+ FixedCostItem(Negation))
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1766)
         Seq(
           (Byte.MinValue, success(Byte.MinValue)), // !!!
           ((Byte.MinValue + 1).toByte, success(Byte.MaxValue)),
@@ -6306,7 +6306,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1766)
         Seq(
           (Short.MinValue, success(Short.MinValue)), // special case!
           ((Short.MinValue + 1).toShort, success(Short.MaxValue)),
@@ -6324,7 +6324,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1766)
         Seq(
           (Int.MinValue, success(Int.MinValue)),  // special case!
           (Int.MinValue + 1, success(Int.MaxValue)),
@@ -6341,7 +6341,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1786)
+        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1766)
         Seq(
           (Long.MinValue, success(Long.MinValue)),   // special case!
           (Long.MinValue + 1, success(Long.MaxValue)),
@@ -6358,7 +6358,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1787)
+        def success[T](v: T) = Expected(Success(v), 36136, costDetails, 1767)
         Seq(
           (CBigInt(new BigInteger("-1655a05845a6ad363ac88ea21e88b97e436a1f02c548537e12e2d9667bf0680", 16)), success(CBigInt(new BigInteger("1655a05845a6ad363ac88ea21e88b97e436a1f02c548537e12e2d9667bf0680", 16)))),
           (CBigInt(new BigInteger("-1b24ba8badba8abf347cce054d9b9f14f229321507245b8", 16)), success(CBigInt(new BigInteger("1b24ba8badba8abf347cce054d9b9f14f229321507245b8", 16)))),
@@ -6396,7 +6396,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35981, costDetails, 1802)
+        def success[T](v: T) = Expected(Success(v), 35981, costDetails, 1782)
         Seq(
           (-1, success(Helpers.decodeGroupElement("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
           (1, success(Helpers.decodeGroupElement("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))))
@@ -6415,7 +6415,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35981, costDetails, 1802)
+        def success[T](v: T) = Expected(Success(v), 35981, costDetails, 1782)
         Seq(
           (-1, success(Helpers.decodeGroupElement("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))),
           (1, success(Helpers.decodeGroupElement("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"))))
@@ -6441,7 +6441,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
       verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 41237, expCostDetails, 1892)
+        def success[T](v: T) = Expected(Success(v), 41237, expCostDetails, 1872)
         Seq(
           (CBigInt(new BigInteger("-e5c1a54694c85d644fa30a6fc5f3aa209ed304d57f72683a0ebf21038b6a9d", 16)), success(Helpers.decodeGroupElement("023395bcba3d7cf21d73c50f8af79d09a8c404c15ce9d04f067d672823bae91a54"))),
           (CBigInt(new BigInteger("-bc2d08f935259e0eebf272c66c6e1dbd484c6706390215", 16)), success(Helpers.decodeGroupElement("02ddcf4c48105faf3c16f7399b5dbedd82ab0bb50ae292d8f88f49a3f86e78974e"))),
@@ -6486,7 +6486,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       )
       verifyCases(
       {
-        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 36903, cd, 1789)
+        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 36903, cd, 1769)
         Seq(
           ((Helpers.decodeBytes(""), Helpers.decodeBytes("")), success(Helpers.decodeBytes(""), costDetails(0))),
           ((Helpers.decodeBytes("01"), Helpers.decodeBytes("01")), success(Helpers.decodeBytes("00"), costDetails(1))),
@@ -6496,9 +6496,9 @@ class SigmaDslSpecification extends SigmaDslTesting
             Expected(Failure(new ArrayIndexOutOfBoundsException("1")),
               cost = 0,
               expectedDetails = CostDetails.ZeroCost,
-              newCost = 1789,
+              newCost = 1769,
               newVersionedResults =  {
-                val res = (ExpectedResult(Success(Helpers.decodeBytes("00")), Some(1789)), Some(costDetails(1)))
+                val res = (ExpectedResult(Success(Helpers.decodeBytes("00")), Some(1769)), Some(costDetails(1)))
                 Seq(0, 1, 2).map(version => version -> res)
               }
             )),
@@ -6690,9 +6690,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, c: Int, costDetails: CostDetails, newCost: Int) = Expected(Success(v), c, costDetails, newCost)
         Seq(
-          (Coll[Box](), success(Coll[Box](), 37297, costDetails, 1787)),
-          (Coll[Box](b1), success(Coll[Box](), 37397, costDetails2, 1792)),
-          (Coll[Box](b1, b2), success(Coll[Box](b2), 37537, costDetails3, 1796))
+          (Coll[Box](), success(Coll[Box](), 37297, costDetails, 1767)),
+          (Coll[Box](b1), success(Coll[Box](), 37397, costDetails2, 1772)),
+          (Coll[Box](b1, b2), success(Coll[Box](b2), 37537, costDetails3, 1776))
         )
       },
       existingFeature({ (x: Coll[Box]) => x.filter({ (b: Box) => b.value > 1 }) },
@@ -6745,13 +6745,13 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       {
         Seq(
-          (Coll[Box](), Expected(Success(Coll[Byte]()), 38126, costDetails1, 1793)),
+          (Coll[Box](), Expected(Success(Coll[Byte]()), 38126, costDetails1, 1773)),
           (Coll[Box](b1), Expected(Success(Helpers.decodeBytes(
             "0008ce02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e4190257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd5"
-          )), 38206, costDetails2, 1811)),
+          )), 38206, costDetails2, 1791)),
           (Coll[Box](b1, b2), Expected(Success(Helpers.decodeBytes(
             "0008ce02c1a9311ecf1e76c787ba4b1c0e10157b4f6d1e4db3ef0d84f411c99f2d4d2c5b027d1bd9a437e73726ceddecc162e5c85f79aee4798505bc826b8ad1813148e4190257cff6d06fe15d1004596eeb97a7f67755188501e36adc49bd807fe65e9d8281033c6021cff6ba5fdfc4f1742486030d2ebbffd9c9c09e488792f3102b2dcdabd500d197830201010096850200"
-          )), 38286, costDetails3, 1815))
+          )), 38286, costDetails3, 1795))
         )
       },
       existingFeature({ (x: Coll[Box]) => x.flatMap({ (b: Box) => b.propositionBytes }) },
@@ -6786,9 +6786,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, c: Int, cd: CostDetails, nc: Int) = Expected(Success(v), c, cd, nc)
         Seq(
-          (Coll[Box](), success(Coll[(Box, Box)](), 37399, costDetails(0), 1786)),
-          (Coll[Box](b1), success(Coll[(Box, Box)]((b1, b1)), 37559, costDetails(1), 1788)),
-          (Coll[Box](b1, b2), success(Coll[(Box, Box)]((b1, b1), (b2, b2)), 37719, costDetails(2), 1790))
+          (Coll[Box](), success(Coll[(Box, Box)](), 37399, costDetails(0), 1766)),
+          (Coll[Box](b1), success(Coll[(Box, Box)]((b1, b1)), 37559, costDetails(1), 1768)),
+          (Coll[Box](b1, b2), success(Coll[(Box, Box)]((b1, b1), (b2, b2)), 37719, costDetails(2), 1770))
         )
       },
       existingFeature({ (x: Coll[Box]) => x.zip(x) },
@@ -6814,7 +6814,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = TracedCost(traceBase :+ FixedCostItem(SizeOf))
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35954, costDetails, 1785)
+        def success[T](v: T) = Expected(Success(v), 35954, costDetails, 1765)
         Seq(
           (Coll[Box](), success(0)),
           (Coll[Box](b1), success(1)),
@@ -6839,7 +6839,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       {
-        def success[T](v: T, i: Int) = Expected(Success(v), 36036, costDetails(i), 1788)
+        def success[T](v: T, i: Int) = Expected(Success(v), 36036, costDetails(i), 1768)
         Seq(
           (Coll[Box](), success(Coll[Int](), 0)),
           (Coll[Box](b1), success(Coll[Int](0), 1)),
@@ -6898,9 +6898,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
         {
           Seq(
-            (Coll[Box](), Expected(Success(true), 37909, costDetails1, 1784)),
-            (Coll[Box](b1), Expected(Success(false), 37969, costDetails2, 1789)),
-            (Coll[Box](b1, b2), Expected(Success(false), 38029, costDetails3, 1789))
+            (Coll[Box](), Expected(Success(true), 37909, costDetails1, 1764)),
+            (Coll[Box](b1), Expected(Success(false), 37969, costDetails2, 1769)),
+            (Coll[Box](b1, b2), Expected(Success(false), 38029, costDetails3, 1769))
           )
         },
         existingFeature({ (x: Coll[Box]) => x.forall({ (b: Box) => b.value > 1 }) },
@@ -6968,9 +6968,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
         {
           Seq(
-            (Coll[Box](), Expected(Success(false), 38455, costDetails1, 1784)),
-            (Coll[Box](b1), Expected(Success(false), 38515, costDetails2, 1789)),
-            (Coll[Box](b1, b2), Expected(Success(true), 38575, costDetails3, 1793))
+            (Coll[Box](), Expected(Success(false), 38455, costDetails1, 1764)),
+            (Coll[Box](b1), Expected(Success(false), 38515, costDetails2, 1769)),
+            (Coll[Box](b1, b2), Expected(Success(true), 38575, costDetails3, 1773))
           )
         },
         existingFeature({ (x: Coll[Box]) => x.exists({ (b: Box) => b.value > 1 }) },
@@ -7055,11 +7055,11 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
         {
           Seq(
-            (Coll[BigInt](), Expected(Success(false), 38955, costDetails1, 1784)),
-            (Coll[BigInt](BigIntZero), Expected(Success(false), 39045, costDetails2, 1789)),
-            (Coll[BigInt](BigIntOne), Expected(Success(true), 39045, costDetails3, 1792)),
-            (Coll[BigInt](BigIntZero, BigIntOne), Expected(Success(true), 39135, costDetails4, 1797)),
-            (Coll[BigInt](BigIntZero, BigInt10), Expected(Success(false), 39135, costDetails4, 1797))
+            (Coll[BigInt](), Expected(Success(false), 38955, costDetails1, 1764)),
+            (Coll[BigInt](BigIntZero), Expected(Success(false), 39045, costDetails2, 1769)),
+            (Coll[BigInt](BigIntOne), Expected(Success(true), 39045, costDetails3, 1772)),
+            (Coll[BigInt](BigIntZero, BigIntOne), Expected(Success(true), 39135, costDetails4, 1777)),
+            (Coll[BigInt](BigIntZero, BigInt10), Expected(Success(false), 39135, costDetails4, 1777))
           )
         },
         existingFeature(
@@ -7158,11 +7158,11 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
         {
           Seq(
-            (Coll[BigInt](), Expected(Success(true), 38412, costDetails1, 1784)),
-            (Coll[BigInt](BigIntMinusOne), Expected(Success(false), 38502, costDetails2, 1789)),
-            (Coll[BigInt](BigIntOne), Expected(Success(true), 38502, costDetails3, 1792)),
-            (Coll[BigInt](BigIntZero, BigIntOne), Expected(Success(true), 38592, costDetails4, 1799)),
-            (Coll[BigInt](BigIntZero, BigInt11), Expected(Success(false), 38592, costDetails4, 1799))
+            (Coll[BigInt](), Expected(Success(true), 38412, costDetails1, 1764)),
+            (Coll[BigInt](BigIntMinusOne), Expected(Success(false), 38502, costDetails2, 1769)),
+            (Coll[BigInt](BigIntOne), Expected(Success(true), 38502, costDetails3, 1772)),
+            (Coll[BigInt](BigIntZero, BigIntOne), Expected(Success(true), 38592, costDetails4, 1779)),
+            (Coll[BigInt](BigIntZero, BigInt11), Expected(Success(false), 38592, costDetails4, 1779))
           )
         },
         existingFeature(
@@ -7282,9 +7282,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, c: Int, cd: CostDetails, newCost: Int) = Expected(Success(v), c, cd, newCost)
         Seq(
-           Coll[GroupElement]() -> Expected(Success(Coll[Byte]()), 40133, CostDetails.ZeroCost, 1794,
+           Coll[GroupElement]() -> Expected(Success(Coll[Byte]()), 40133, CostDetails.ZeroCost, 1774,
              newVersionedResults = {
-               val res = ExpectedResult(Success(Coll[Byte]()), Some(1793))
+               val res = ExpectedResult(Success(Coll[Byte]()), Some(1773))
                Seq.tabulate(3)(v =>
                  v -> (res -> Some(costDetails0))
                )
@@ -7294,14 +7294,14 @@ class SigmaDslSpecification extends SigmaDslTesting
             Helpers.decodeGroupElement("0390e9daa9916f30d0bc61a8e381c6005edfb7938aee5bb4fc9e8a759c7748ffaa")) ->
               success(Helpers.decodeBytes(
                 "02d65904820f8330218cf7318b3810d0c9ab9df86f1ee6100882683f23c0aee5870390e9daa9916f30d0bc61a8e381c6005edfb7938aee5bb4fc9e8a759c7748ffaa"
-              ), 40213, costDetails2, 1854),
+              ), 40213, costDetails2, 1834),
           Coll[GroupElement](
             Helpers.decodeGroupElement("02d65904820f8330218cf7318b3810d0c9ab9df86f1ee6100882683f23c0aee587"),
             Helpers.decodeGroupElement("0390e9daa9916f30d0bc61a8e381c6005edfb7938aee5bb4fc9e8a759c7748ffaa"),
             Helpers.decodeGroupElement("03bd839b969b02d218fd1192f2c80cbda9c6ce9c7ddb765f31b748f4666203df85")) ->
               success(Helpers.decodeBytes(
                 "02d65904820f8330218cf7318b3810d0c9ab9df86f1ee6100882683f23c0aee5870390e9daa9916f30d0bc61a8e381c6005edfb7938aee5bb4fc9e8a759c7748ffaa03bd839b969b02d218fd1192f2c80cbda9c6ce9c7ddb765f31b748f4666203df85"
-              ), 40253, costDetails3, 1884)
+              ), 40253, costDetails3, 1864)
         )
       },
       existingFeature(
@@ -7429,7 +7429,7 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     verifyCases(
       {
-        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 37514, cd, 1796)
+        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 37514, cd, 1776)
         Seq(
           ((Coll[Int](), (0, 0)), success(Coll[Int](), costDetails(0))),
           ((Coll[Int](1), (0, 0)), success(Coll[Int](1, 1), costDetails(2))),
@@ -7518,7 +7518,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       // (coll, (index, elem))
       {
-        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 37180, cd, 1794)
+        def success[T](v: T, cd: CostDetails) = Expected(Success(v), 37180, cd, 1774)
         Seq(
           ((Coll[Int](), (0, 0)), Expected(new IndexOutOfBoundsException("0"))),
           ((Coll[Int](1), (0, 0)), success(Coll[Int](0), costDetails(1))),
@@ -7595,7 +7595,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       // (coll, (indexes, values))
       {
-        def success[T](v: T, i: Int) = Expected(Success(v), 37817, costDetails(i), 1794)
+        def success[T](v: T, i: Int) = Expected(Success(v), 37817, costDetails(i), 1774)
         Seq(
           ((Coll[Int](), (Coll(0), Coll(0))), Expected(new IndexOutOfBoundsException("0"))),
           ((Coll[Int](), (Coll(0, 1), Coll(0, 0))), Expected(new IndexOutOfBoundsException("0"))),
@@ -7772,15 +7772,15 @@ class SigmaDslSpecification extends SigmaDslTesting
         // (coll, initState)
         {
           Seq(
-            ((Coll[Byte](),  0), Expected(Success(0), 41266, costDetails1, 1787)),
-            ((Coll[Byte](),  Int.MaxValue), Expected(Success(Int.MaxValue), 41266, costDetails1, 1787)),
-            ((Coll[Byte](1),  Int.MaxValue - 1), Expected(Success(Int.MaxValue), 41396, costDetails2, 1793)),
+            ((Coll[Byte](),  0), Expected(Success(0), 41266, costDetails1, 1767)),
+            ((Coll[Byte](),  Int.MaxValue), Expected(Success(Int.MaxValue), 41266, costDetails1, 1767)),
+            ((Coll[Byte](1),  Int.MaxValue - 1), Expected(Success(Int.MaxValue), 41396, costDetails2, 1773)),
             ((Coll[Byte](1),  Int.MaxValue), Expected(new ArithmeticException("integer overflow"))),
-            ((Coll[Byte](-1),  Int.MinValue + 1), Expected(Success(Int.MinValue), 41396, costDetails2, 1793)),
+            ((Coll[Byte](-1),  Int.MinValue + 1), Expected(Success(Int.MinValue), 41396, costDetails2, 1773)),
             ((Coll[Byte](-1),  Int.MinValue), Expected(new ArithmeticException("integer overflow"))),
-            ((Coll[Byte](1, 2), 0), Expected(Success(3), 41526, costDetails3, 1799)),
-            ((Coll[Byte](1, -1), 0), Expected(Success(0), 41526, costDetails3, 1799)),
-            ((Coll[Byte](1, -1, 1), 0), Expected(Success(1), 41656, costDetails4, 1805))
+            ((Coll[Byte](1, 2), 0), Expected(Success(3), 41526, costDetails3, 1779)),
+            ((Coll[Byte](1, -1), 0), Expected(Success(0), 41526, costDetails3, 1779)),
+            ((Coll[Byte](1, -1, 1), 0), Expected(Success(1), 41656, costDetails4, 1785))
           )
         },
         existingFeature(
@@ -8014,15 +8014,15 @@ class SigmaDslSpecification extends SigmaDslTesting
         // (coll, initState)
         {
           Seq(
-            ((Coll[Byte](),  0), Expected(Success(0), 42037, costDetails1, 1787)),
-            ((Coll[Byte](),  Int.MaxValue), Expected(Success(Int.MaxValue), 42037, costDetails1, 1787)),
-            ((Coll[Byte](1),  Int.MaxValue - 1), Expected(Success(Int.MaxValue), 42197, costDetails2, 1799)),
+            ((Coll[Byte](),  0), Expected(Success(0), 42037, costDetails1, 1767)),
+            ((Coll[Byte](),  Int.MaxValue), Expected(Success(Int.MaxValue), 42037, costDetails1, 1767)),
+            ((Coll[Byte](1),  Int.MaxValue - 1), Expected(Success(Int.MaxValue), 42197, costDetails2, 1779)),
             ((Coll[Byte](1),  Int.MaxValue), Expected(new ArithmeticException("integer overflow"))),
-            ((Coll[Byte](-1),  Int.MinValue + 1), Expected(Success(Int.MinValue + 1), 42197, costDetails3, 1797)),
-            ((Coll[Byte](-1),  Int.MinValue), Expected(Success(Int.MinValue), 42197, costDetails3, 1797)),
-            ((Coll[Byte](1, 2), 0), Expected(Success(3), 42357, costDetails4, 1811)),
-            ((Coll[Byte](1, -1), 0), Expected(Success(1), 42357, costDetails5, 1809)),
-            ((Coll[Byte](1, -1, 1), 0), Expected(Success(2), 42517, costDetails6, 1821))
+            ((Coll[Byte](-1),  Int.MinValue + 1), Expected(Success(Int.MinValue + 1), 42197, costDetails3, 1777)),
+            ((Coll[Byte](-1),  Int.MinValue), Expected(Success(Int.MinValue), 42197, costDetails3, 1777)),
+            ((Coll[Byte](1, 2), 0), Expected(Success(3), 42357, costDetails4, 1791)),
+            ((Coll[Byte](1, -1), 0), Expected(Success(1), 42357, costDetails5, 1789)),
+            ((Coll[Byte](1, -1, 1), 0), Expected(Success(2), 42517, costDetails6, 1801))
           )
         },
         existingFeature(
@@ -8099,11 +8099,11 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       // (coll, (elem: Byte, from: Int))
       {
-        def success0[T](v: T) = Expected(Success(v), 37649, costDetails(0), 1793)
-        def success1[T](v: T) = Expected(Success(v), 37649, costDetails(1), 1793)
-        def success2[T](v: T) = Expected(Success(v), 37649, costDetails(2), 1794)
-        def success3[T](v: T) = Expected(Success(v), 37649, costDetails(3), 1795)
-        def success12[T](v: T) = Expected(Success(v), 37649, costDetails(12), 1802)
+        def success0[T](v: T) = Expected(Success(v), 37649, costDetails(0), 1773)
+        def success1[T](v: T) = Expected(Success(v), 37649, costDetails(1), 1773)
+        def success2[T](v: T) = Expected(Success(v), 37649, costDetails(2), 1774)
+        def success3[T](v: T) = Expected(Success(v), 37649, costDetails(3), 1775)
+        def success12[T](v: T) = Expected(Success(v), 37649, costDetails(12), 1782)
         Seq(
           ((Coll[Byte](),  (0.toByte, 0)), success0(-1)),
           ((Coll[Byte](),  (0.toByte, -1)), success0(-1)),
@@ -8165,7 +8165,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 36410, costDetails, 1789)
+        def success[T](v: T) = Expected(Success(v), 36410, costDetails, 1769)
         Seq(
           ((Coll[Int](), 0), Expected(new ArrayIndexOutOfBoundsException("0"))),
           ((Coll[Int](), -1), Expected(new ArrayIndexOutOfBoundsException("-1"))),
@@ -8218,7 +8218,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
       // (coll, (index, default))
       {
-        def success[T](v: T) = Expected(Success(v), 37020, costDetails, 1793)
+        def success[T](v: T) = Expected(Success(v), 37020, costDetails, 1773)
         Seq(
           ((Coll[Int](), (0, default)), success(default)),
           ((Coll[Int](), (-1, default)), success(default)),
@@ -8350,7 +8350,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     )
     verifyCases(
       {
-        def success[T](v: T) = Expected(Success(v), 35905, costDetails, 1783)
+        def success[T](v: T) = Expected(Success(v), 35905, costDetails, 1763)
         Seq(
           ((0, 0), success(2)),
           ((1, 2), success(2))
@@ -8365,7 +8365,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val samples = genSamples[(Int, Int)](DefaultMinSuccessful)
     val costDetails = TracedCost(traceBase :+ FixedCostItem(SelectField))
     verifyCases(
-      Seq(((1, 2), Expected(Success(1), cost = 36013, costDetails, 1784))),
+      Seq(((1, 2), Expected(Success(1), cost = 36013, costDetails, 1764))),
       existingFeature((x: (Int, Int)) => x._1,
         "{ (x: (Int, Int)) => x(0) }",
         FuncValue(
@@ -8374,7 +8374,7 @@ class SigmaDslSpecification extends SigmaDslTesting
         )),
       preGeneratedSamples = Some(samples))
     verifyCases(
-      Seq(((1, 2), Expected(Success(2), cost = 36013, costDetails, 1784))),
+      Seq(((1, 2), Expected(Success(2), cost = 36013, costDetails, 1764))),
       existingFeature((x: (Int, Int)) => x._2,
         "{ (x: (Int, Int)) => x(1) }",
         FuncValue(
@@ -8407,9 +8407,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, c: Int) = Expected(Success(v), c)
         Seq(
-          (Coll[Int](), Expected(Success(Coll[Int]()), 38886, costDetails(0), 1788)),
-          (Coll[Int](1), Expected(Success(Coll[Int](2)), 38936, costDetails(1), 1791)),
-          (Coll[Int](1, 2), Expected(Success(Coll[Int](2, 3)), 38986, costDetails(2), 1794)),
+          (Coll[Int](), Expected(Success(Coll[Int]()), 38886, costDetails(0), 1768)),
+          (Coll[Int](1), Expected(Success(Coll[Int](2)), 38936, costDetails(1), 1771)),
+          (Coll[Int](1, 2), Expected(Success(Coll[Int](2, 3)), 38986, costDetails(2), 1774)),
           (Coll[Int](1, 2, Int.MaxValue), Expected(new ArithmeticException("integer overflow")))
         )
       },
@@ -8486,10 +8486,10 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         def success[T](v: T, c: Int) = Expected(Success(v), c)
         Seq(
-          (Coll[Int](), Expected(Success(Coll[Int]()), 39571, costDetails1, 1788)),
-          (Coll[Int](1), Expected(Success(Coll[Int](2)), 39671, costDetails2, 1795)),
-          (Coll[Int](-1), Expected(Success(Coll[Int](1)), 39671, costDetails3, 1795)),
-          (Coll[Int](1, -2), Expected(Success(Coll[Int](2, 2)), 39771, costDetails4, 1802)),
+          (Coll[Int](), Expected(Success(Coll[Int]()), 39571, costDetails1, 1768)),
+          (Coll[Int](1), Expected(Success(Coll[Int](2)), 39671, costDetails2, 1775)),
+          (Coll[Int](-1), Expected(Success(Coll[Int](1)), 39671, costDetails3, 1775)),
+          (Coll[Int](1, -2), Expected(Success(Coll[Int](2, 2)), 39771, costDetails4, 1782)),
           (Coll[Int](1, 2, Int.MaxValue), Expected(new ArithmeticException("integer overflow"))),
           (Coll[Int](1, 2, Int.MinValue), Expected(new ArithmeticException("integer overflow")))
         )
@@ -8538,11 +8538,11 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
     {
       Seq(
-        (Coll[Int](), Expected(Success(Coll[Int]()), 37223, costDetails(0), 1788)),
-        (Coll[Int](1), Expected(Success(Coll[Int](1)), 37273, costDetails(1), 1791)),
-        (Coll[Int](1, 2), Expected(Success(Coll[Int](1, 2)), 37323, costDetails(2), 1795)),
-        (Coll[Int](1, 2, -1), Expected(Success(Coll[Int](1, 2)), 37373, costDetails(3), 1798)),
-        (Coll[Int](1, -1, 2, -2), Expected(Success(Coll[Int](1, 2)), 37423, costDetails(4), 1802))
+        (Coll[Int](), Expected(Success(Coll[Int]()), 37223, costDetails(0), 1768)),
+        (Coll[Int](1), Expected(Success(Coll[Int](1)), 37273, costDetails(1), 1771)),
+        (Coll[Int](1, 2), Expected(Success(Coll[Int](1, 2)), 37323, costDetails(2), 1775)),
+        (Coll[Int](1, 2, -1), Expected(Success(Coll[Int](1, 2)), 37373, costDetails(3), 1778)),
+        (Coll[Int](1, -1, 2, -2), Expected(Success(Coll[Int](1, 2)), 37423, costDetails(4), 1782))
       )
     },
     existingFeature((x: Coll[Int]) => x.filter({ (v: Int) => o.gt(v, 0) }),
@@ -8614,12 +8614,12 @@ class SigmaDslSpecification extends SigmaDslTesting
     {
       def success[T](v: T, c: Int) = Expected(Success(v), c)
       Seq(
-        (Coll[Int](), Expected(Success(Coll[Int]()), 37797, costDetails(0), 1788)),
-        (Coll[Int](1), Expected(Success(Coll[Int](1)), 37887, costDetails(1), 1795)),
-        (Coll[Int](10), Expected(Success(Coll[Int]()), 37887, costDetails(1), 1795)),
-        (Coll[Int](1, 2), Expected(Success(Coll[Int](1, 2)), 37977, costDetails(2), 1803)),
-        (Coll[Int](1, 2, 0), Expected(Success(Coll[Int](1, 2)), 38067, costDetails3, 1808)),
-        (Coll[Int](1, -1, 2, -2, 11), Expected(Success(Coll[Int](1, 2)), 38247, costDetails5, 1820))
+        (Coll[Int](), Expected(Success(Coll[Int]()), 37797, costDetails(0), 1768)),
+        (Coll[Int](1), Expected(Success(Coll[Int](1)), 37887, costDetails(1), 1775)),
+        (Coll[Int](10), Expected(Success(Coll[Int]()), 37887, costDetails(1), 1775)),
+        (Coll[Int](1, 2), Expected(Success(Coll[Int](1, 2)), 37977, costDetails(2), 1783)),
+        (Coll[Int](1, 2, 0), Expected(Success(Coll[Int](1, 2)), 38067, costDetails3, 1788)),
+        (Coll[Int](1, -1, 2, -2, 11), Expected(Success(Coll[Int](1, 2)), 38247, costDetails5, 1800))
       )
     },
     existingFeature((x: Coll[Int]) => x.filter({ (v: Int) => if (o.gt(v, 0)) v < 10 else false }),
@@ -8662,7 +8662,7 @@ class SigmaDslSpecification extends SigmaDslTesting
       verifyCases(
       {
         val cost = 36964
-        val newCost = 1792
+        val newCost = 1772
         Seq(
           // (coll, (from, until))
           ((Coll[Int](), (-1, 0)), Expected(Success(Coll[Int]()), cost, costDetails(1), newCost)),
@@ -8727,7 +8727,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     if (lowerMethodCallsInTests) {
       verifyCases(
       {
-        def success[T](v: T, size: Int) = Expected(Success(v), 37765, costDetails(size), 1790)
+        def success[T](v: T, size: Int) = Expected(Success(v), 37765, costDetails(size), 1770)
         val arr1 = Gen.listOfN(100, arbitrary[Int]).map(_.toArray).sample.get
         val arr2 = Gen.listOfN(200, arbitrary[Int]).map(_.toArray).sample.get
         Seq(
@@ -8738,7 +8738,7 @@ class SigmaDslSpecification extends SigmaDslTesting
           (Coll[Int](1), Coll[Int](2, 3)) -> success(Coll[Int](1, 2, 3), 3),
           (Coll[Int](1, 2), Coll[Int](3)) -> success(Coll[Int](1, 2, 3), 3),
           (Coll[Int](1, 2), Coll[Int](3, 4)) -> success(Coll[Int](1, 2, 3, 4), 4),
-          (Coll[Int](arr1:_*), Coll[Int](arr2:_*)) -> Expected(Success(Coll[Int](arr1 ++ arr2:_*)), 37785, costDetails(300), 1791)
+          (Coll[Int](arr1:_*), Coll[Int](arr2:_*)) -> Expected(Success(Coll[Int](arr1 ++ arr2:_*)), 37785, costDetails(300), 1771)
         )
       },
       existingFeature(
@@ -8819,32 +8819,32 @@ class SigmaDslSpecification extends SigmaDslTesting
     verifyCases(
       Seq(
         (None -> Expected(new NoSuchElementException("None.get"))),
-        (Some(10L) -> Expected(Success(10L), 36046, costDetails1, 1785))),
+        (Some(10L) -> Expected(Success(10L), 36046, costDetails1, 1765))),
       existingFeature({ (x: Option[Long]) => x.get },
         "{ (x: Option[Long]) => x.get }",
         FuncValue(Vector((1, SOption(SLong))), OptionGet(ValUse(1, SOption(SLong))))))
 
     verifyCases(
       Seq(
-        (None -> Expected(Success(false), 36151, costDetails2, 1784)),
-        (Some(10L) -> Expected(Success(true), 36151, costDetails2, 1784))),
+        (None -> Expected(Success(false), 36151, costDetails2, 1764)),
+        (Some(10L) -> Expected(Success(true), 36151, costDetails2, 1764))),
       existingFeature({ (x: Option[Long]) => x.isDefined },
         "{ (x: Option[Long]) => x.isDefined }",
         FuncValue(Vector((1, SOption(SLong))), OptionIsDefined(ValUse(1, SOption(SLong))))))
 
     verifyCases(
       Seq(
-        (None -> Expected(Success(1L), 36367, costDetails3, 1786)),
-        (Some(10L) -> Expected(Success(10L), 36367, costDetails3, 1786))),
+        (None -> Expected(Success(1L), 36367, costDetails3, 1766)),
+        (Some(10L) -> Expected(Success(10L), 36367, costDetails3, 1766))),
       existingFeature({ (x: Option[Long]) => x.getOrElse(1L) },
         "{ (x: Option[Long]) => x.getOrElse(1L) }",
         FuncValue(Vector((1, SOption(SLong))), OptionGetOrElse(ValUse(1, SOption(SLong)), LongConstant(1L)))))
 
     verifyCases(
       Seq(
-        (None -> Expected(Success(None), 38239, costDetails4, 1786)),
-        (Some(10L) -> Expected(Success(None), 38239, costDetails5, 1788)),
-        (Some(1L) -> Expected(Success(Some(1L)), 38239, costDetails5, 1789))),
+        (None -> Expected(Success(None), 38239, costDetails4, 1766)),
+        (Some(10L) -> Expected(Success(None), 38239, costDetails5, 1768)),
+        (Some(1L) -> Expected(Success(Some(1L)), 38239, costDetails5, 1769))),
       existingFeature({ (x: Option[Long]) => x.filter({ (v: Long) => v == 1} ) },
         "{ (x: Option[Long]) => x.filter({ (v: Long) => v == 1 }) }",
         FuncValue(
@@ -8860,8 +8860,8 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactNumeric.LongIsExactNumeric
     verifyCases(
       Seq(
-        (None -> Expected(Success(None), 38575, costDetails6, 1786)),
-        (Some(10L) -> Expected(Success(Some(11L)), 38575, costDetails7, 1790)),
+        (None -> Expected(Success(None), 38575, costDetails6, 1766)),
+        (Some(10L) -> Expected(Success(Some(11L)), 38575, costDetails7, 1770)),
         (Some(Long.MaxValue) -> Expected(new ArithmeticException("long overflow")))),
       existingFeature({ (x: Option[Long]) => x.map( (v: Long) => n.plus(v, 1) ) },
         "{ (x: Option[Long]) => x.map({ (v: Long) => v + 1 }) }",
@@ -8923,10 +8923,10 @@ class SigmaDslSpecification extends SigmaDslTesting
     val o = ExactOrdering.LongIsExactOrdering
     verifyCases(
       Seq(
-        (None -> Expected(Success(None), 38736, costDetails1, 1786)),
-        (Some(0L) -> Expected(Success(None), 38736, costDetails2, 1791)),
-        (Some(10L) -> Expected(Success(Some(10L)), 38736, costDetails3, 1794)),
-        (Some(11L) -> Expected(Success(None), 38736, costDetails3, 1794))),
+        (None -> Expected(Success(None), 38736, costDetails1, 1766)),
+        (Some(0L) -> Expected(Success(None), 38736, costDetails2, 1771)),
+        (Some(10L) -> Expected(Success(Some(10L)), 38736, costDetails3, 1774)),
+        (Some(11L) -> Expected(Success(None), 38736, costDetails3, 1774))),
       existingFeature(
         { (x: Option[Long]) => x.filter({ (v: Long) => if (o.gt(v, 0L)) v <= 10 else false } ) },
         "{ (x: Option[Long]) => x.filter({ (v: Long) => if (v > 0) v <= 10 else false }) }",
@@ -8987,10 +8987,10 @@ class SigmaDslSpecification extends SigmaDslTesting
     val n = ExactNumeric.LongIsExactNumeric
     verifyCases(
       Seq(
-        (None -> Expected(Success(None), 39077, costDetails4, 1786)),
-        (Some(0L) -> Expected(Success(Some(0L)), 39077, costDetails5, 1792)),
-        (Some(10L) -> Expected(Success(Some(10L)), 39077, costDetails5, 1792)),
-        (Some(-1L) -> Expected(Success(Some(-2L)), 39077, costDetails6, 1794)),
+        (None -> Expected(Success(None), 39077, costDetails4, 1766)),
+        (Some(0L) -> Expected(Success(Some(0L)), 39077, costDetails5, 1772)),
+        (Some(10L) -> Expected(Success(Some(10L)), 39077, costDetails5, 1772)),
+        (Some(-1L) -> Expected(Success(Some(-2L)), 39077, costDetails6, 1774)),
         (Some(Long.MinValue) -> Expected(new ArithmeticException("long overflow")))),
       existingFeature(
         { (x: Option[Long]) => x.map( (v: Long) => if (o.lt(v, 0)) n.minus(v, 1) else v ) },
@@ -9060,14 +9060,14 @@ class SigmaDslSpecification extends SigmaDslTesting
             value = Failure(new NoSuchElementException("None.get")),
             cost = 0,
             expectedDetails = CostDetails.ZeroCost,
-            newCost = 1786,
-            newVersionedResults = Seq.tabulate(3)(v => v -> (ExpectedResult(Success(5L), Some(1786)) -> Some(costDetails1)))
+            newCost = 1766,
+            newVersionedResults = Seq.tabulate(3)(v => v -> (ExpectedResult(Success(5L), Some(1766)) -> Some(costDetails1)))
           )),
         (Some(0L) -> Expected(
           Success(1L),
           cost = 39012,
           expectedDetails = costDetails2,
-          expectedNewCost = 1794)),
+          expectedNewCost = 1774)),
         (Some(Long.MaxValue) -> Expected(new ArithmeticException("long overflow")))
       ),
       changedFeature(
@@ -9134,19 +9134,19 @@ class SigmaDslSpecification extends SigmaDslTesting
           Success(Helpers.decodeBytes("0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8")),
           36269,
           costDetailsBlake(0),
-          1788
+          1768
         ),
         Helpers.decodeBytes("e0ff0105ffffac31010017ff33") -> Expected(
           Success(Helpers.decodeBytes("33707eed9aab64874ff2daa6d6a378f61e7da36398fb36c194c7562c9ff846b5")),
           36269,
           costDetailsBlake(13),
-          1788
+          1768
         ),
         Colls.replicate(1024, 1.toByte) -> Expected(
           Success(Helpers.decodeBytes("45d8456fc5d41d1ec1124cb92e41192c1c3ec88f0bf7ae2dc6e9cf75bec22045")),
           36369,
           costDetailsBlake(1024),
-          1793
+          1773
         )
       ),
       existingFeature((x: Coll[Byte]) => SigmaDsl.blake2b256(x),
@@ -9159,19 +9159,19 @@ class SigmaDslSpecification extends SigmaDslTesting
           Success(Helpers.decodeBytes("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")),
           36393,
           costDetailsSha(0),
-          1794
+          1774
         ),
         Helpers.decodeBytes("e0ff0105ffffac31010017ff33") -> Expected(
           Success(Helpers.decodeBytes("367d0ec2cdc14aac29d5beb60c2bfc86d5a44a246308659af61c1b85fa2ca2cc")),
           36393,
           costDetailsSha(13),
-          1794
+          1774
         ),
         Colls.replicate(1024, 1.toByte) -> Expected(
           Success(Helpers.decodeBytes("5a648d8015900d89664e00e125df179636301a2d8fa191c1aa2bd9358ea53a69")),
           36493,
           costDetailsSha(1024),
-          1806
+          1786
         )
       ),
       existingFeature((x: Coll[Byte]) => SigmaDsl.sha256(x),
@@ -9183,8 +9183,8 @@ class SigmaDslSpecification extends SigmaDslTesting
     val costDetails = TracedCost(traceBase :+ FixedCostItem(BoolToSigmaProp))
     verifyCases(
       Seq(
-        (false, Expected(Success(CSigmaProp(TrivialProp.FalseProp)), 35892, costDetails, 1785)),
-        (true, Expected(Success(CSigmaProp(TrivialProp.TrueProp)), 35892, costDetails, 1785))),
+        (false, Expected(Success(CSigmaProp(TrivialProp.FalseProp)), 35892, costDetails, 1765)),
+        (true, Expected(Success(CSigmaProp(TrivialProp.TrueProp)), 35892, costDetails, 1765))),
       existingFeature((x: Boolean) => sigmaProp(x),
        "{ (x: Boolean) => sigmaProp(x) }",
         FuncValue(Vector((1, SBoolean)), BoolToSigmaProp(ValUse(1, SBoolean)))))
@@ -9211,7 +9211,7 @@ class SigmaDslSpecification extends SigmaDslTesting
               Helpers.decodeECPoint("02614b14a8c6c6b4b7ce017d72fbca7f9218b72c16bdd88f170ffb300b106b9014"),
               Helpers.decodeECPoint("034cc5572276adfa3e283a3f1b0f0028afaadeaa362618c5ec43262d8cefe7f004")
             )
-          )) -> Expected(Success(CSigmaProp(TrivialProp.TrueProp)), 36462, costDetails(1), 1790),
+          )) -> Expected(Success(CSigmaProp(TrivialProp.TrueProp)), 36462, costDetails(1), 1770),
         Coll[SigmaProp](
           CSigmaProp(
             ProveDHTuple(
@@ -9239,7 +9239,7 @@ class SigmaDslSpecification extends SigmaDslTesting
               )
             )
           )
-        ), 36462, costDetails(3), 1893),
+        ), 36462, costDetails(3), 1873),
         Colls.replicate[SigmaProp](AtLeast.MaxChildrenCount + 1, CSigmaProp(TrivialProp.TrueProp)) ->
           Expected(new IllegalArgumentException("Expected input elements count should not exceed 255, actual: 256"))
       ),
@@ -9283,19 +9283,19 @@ class SigmaDslSpecification extends SigmaDslTesting
                       ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))
                     )
                   )
-                ), 1822),
+                ), 1802),
           (CSigmaProp(TrivialProp.TrueProp),
               CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))) ->
-              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1804),
+              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1784),
           (CSigmaProp(TrivialProp.FalseProp),
               CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))) ->
-              success(CSigmaProp(TrivialProp.FalseProp), 1787),
+              success(CSigmaProp(TrivialProp.FalseProp), 1767),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))),
               CSigmaProp(TrivialProp.TrueProp)) ->
-              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1804),
+              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1784),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))),
               CSigmaProp(TrivialProp.FalseProp)) ->
-              success(CSigmaProp(TrivialProp.FalseProp), 1787)
+              success(CSigmaProp(TrivialProp.FalseProp), 1767)
         )
       },
       existingFeature(
@@ -9315,9 +9315,9 @@ class SigmaDslSpecification extends SigmaDslTesting
       {
         Seq(
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), true) ->
-              Expected(Success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))), 36522, costDetails2, 1806),
+              Expected(Success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))), 36522, costDetails2, 1786),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), false) ->
-              Expected(Success(CSigmaProp(TrivialProp.FalseProp)), 36522, costDetails2, 1789)
+              Expected(Success(CSigmaProp(TrivialProp.FalseProp)), 36522, costDetails2, 1769)
         )
       },
       existingFeature(
@@ -9359,19 +9359,19 @@ class SigmaDslSpecification extends SigmaDslTesting
                     )
                   )
                 ),
-                1822),
+                1802),
           (CSigmaProp(TrivialProp.FalseProp),
               CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))) ->
-              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1804),
+              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1784),
           (CSigmaProp(TrivialProp.TrueProp),
               CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606")))) ->
-              success(CSigmaProp(TrivialProp.TrueProp), 1787),
+              success(CSigmaProp(TrivialProp.TrueProp), 1767),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))),
               CSigmaProp(TrivialProp.FalseProp)) ->
-              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1804),
+              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1784),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))),
               CSigmaProp(TrivialProp.TrueProp)) ->
-              success(CSigmaProp(TrivialProp.TrueProp), 1787)
+              success(CSigmaProp(TrivialProp.TrueProp), 1767)
         )
       },
       existingFeature(
@@ -9398,9 +9398,9 @@ class SigmaDslSpecification extends SigmaDslTesting
         def success[T](v: T, newCost: Int) = Expected(Success(v), 36588, costDetails2, newCost)
         Seq(
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), false) ->
-              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1806),
+              success(CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), 1786),
           (CSigmaProp(ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))), true) ->
-              success(CSigmaProp(TrivialProp.TrueProp), 1789)
+              success(CSigmaProp(TrivialProp.TrueProp), 1769)
         )
       },
       existingFeature(
@@ -9438,25 +9438,25 @@ class SigmaDslSpecification extends SigmaDslTesting
             Helpers.decodeBytes(
               "0008ce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441"
             )
-          ), cost = 35902, newDetails(4), expectedNewCost = 1791),
+          ), cost = 35902, newDetails(4), expectedNewCost = 1771),
           CSigmaProp(pk) -> Expected(Success(
             Helpers.decodeBytes("0008cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6f")),
-            cost = 35902, newDetails(1), expectedNewCost = 1789),
+            cost = 35902, newDetails(1), expectedNewCost = 1769),
           CSigmaProp(and) -> Expected(Success(
             Helpers.decodeBytes(
               "00089602cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441"
             )
-          ), cost = 35902, newDetails(6), expectedNewCost = 1792),
+          ), cost = 35902, newDetails(6), expectedNewCost = 1772),
           CSigmaProp(threshold) -> Expected(Success(
             Helpers.decodeBytes(
               "0008980204cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419702cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419602cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441"
             )
-          ), cost = 35902, newDetails(18), expectedNewCost = 1800),
+          ), cost = 35902, newDetails(18), expectedNewCost = 1780),
           CSigmaProp(COR(Array(pk, dht, and, or, threshold))) -> Expected(Success(
             Helpers.decodeBytes(
               "00089705cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419602cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419702cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441980204cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419702cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b04419602cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441"
             )
-          ), cost = 35902, newDetails(36), expectedNewCost = 1811)
+          ), cost = 35902, newDetails(36), expectedNewCost = 1791)
         )
       },
       existingFeature((x: SigmaProp) => x.propBytes,
@@ -9487,17 +9487,17 @@ class SigmaDslSpecification extends SigmaDslTesting
     def costDetails(i: Int) = TracedCost(traceBase :+ SeqCostItem(CompanionDesc(AND), PerItemCost(JitCost(10), JitCost(5), 32), i))
     verifyCases(
       Seq(
-        (Coll[Boolean]()                   -> Expected(Success(true), 36018, costDetails(0), 1785)),
-        (Coll[Boolean](true)               -> Expected(Success(true), 36028, costDetails(1), 1785)),
-        (Coll[Boolean](false)              -> Expected(Success(false), 36028, costDetails(1), 1785)),
-        (Coll[Boolean](false, false)       -> Expected(Success(false), 36038, costDetails(1), 1785)),
-        (Coll[Boolean](false, true)        -> Expected(Success(false), 36038, costDetails(1), 1785)),
-        (Coll[Boolean](true, false)        -> Expected(Success(false), 36038, costDetails(2), 1785)),
-        (Coll[Boolean](true, true)         -> Expected(Success(true), 36038, costDetails(2), 1785)),
-        (Coll[Boolean](true, false, false) -> Expected(Success(false), 36048, costDetails(2), 1785)),
-        (Coll[Boolean](true, false, true)  -> Expected(Success(false), 36048, costDetails(2), 1785)),
-        (Coll[Boolean](true, true, false)  -> Expected(Success(false), 36048, costDetails(3), 1785)),
-        (Coll[Boolean](true, true, true)   -> Expected(Success(true), 36048, costDetails(3), 1785))
+        (Coll[Boolean]()                   -> Expected(Success(true), 36018, costDetails(0), 1765)),
+        (Coll[Boolean](true)               -> Expected(Success(true), 36028, costDetails(1), 1765)),
+        (Coll[Boolean](false)              -> Expected(Success(false), 36028, costDetails(1), 1765)),
+        (Coll[Boolean](false, false)       -> Expected(Success(false), 36038, costDetails(1), 1765)),
+        (Coll[Boolean](false, true)        -> Expected(Success(false), 36038, costDetails(1), 1765)),
+        (Coll[Boolean](true, false)        -> Expected(Success(false), 36038, costDetails(2), 1765)),
+        (Coll[Boolean](true, true)         -> Expected(Success(true), 36038, costDetails(2), 1765)),
+        (Coll[Boolean](true, false, false) -> Expected(Success(false), 36048, costDetails(2), 1765)),
+        (Coll[Boolean](true, false, true)  -> Expected(Success(false), 36048, costDetails(2), 1765)),
+        (Coll[Boolean](true, true, false)  -> Expected(Success(false), 36048, costDetails(3), 1765)),
+        (Coll[Boolean](true, true, true)   -> Expected(Success(true), 36048, costDetails(3), 1765))
       ),
       existingFeature((x: Coll[Boolean]) => SigmaDsl.allOf(x),
         "{ (x: Coll[Boolean]) => allOf(x) }",
@@ -9508,17 +9508,17 @@ class SigmaDslSpecification extends SigmaDslTesting
     def costDetails(i: Int) = TracedCost(traceBase :+ SeqCostItem(CompanionDesc(OR), PerItemCost(JitCost(5), JitCost(5), 64), i))
     verifyCases(
       Seq(
-        (Coll[Boolean]()                   -> Expected(Success(false), 36062, costDetails(0), 1784)),
-        (Coll[Boolean](true)               -> Expected(Success(true), 36072, costDetails(1), 1784)),
-        (Coll[Boolean](false)              -> Expected(Success(false), 36072, costDetails(1), 1784)),
-        (Coll[Boolean](false, false)       -> Expected(Success(false), 36082, costDetails(2), 1784)),
-        (Coll[Boolean](false, true)        -> Expected(Success(true), 36082, costDetails(2), 1784)),
-        (Coll[Boolean](true, false)        -> Expected(Success(true), 36082, costDetails(1), 1784)),
-        (Coll[Boolean](true, true)         -> Expected(Success(true), 36082, costDetails(1), 1784)),
-        (Coll[Boolean](true, false, false) -> Expected(Success(true), 36092, costDetails(1), 1784)),
-        (Coll[Boolean](true, false, true)  -> Expected(Success(true), 36092, costDetails(1), 1784)),
-        (Coll[Boolean](true, true, false)  -> Expected(Success(true), 36092, costDetails(1), 1784)),
-        (Coll[Boolean](true, true, true)   -> Expected(Success(true), 36092, costDetails(1), 1784))
+        (Coll[Boolean]()                   -> Expected(Success(false), 36062, costDetails(0), 1764)),
+        (Coll[Boolean](true)               -> Expected(Success(true), 36072, costDetails(1), 1764)),
+        (Coll[Boolean](false)              -> Expected(Success(false), 36072, costDetails(1), 1764)),
+        (Coll[Boolean](false, false)       -> Expected(Success(false), 36082, costDetails(2), 1764)),
+        (Coll[Boolean](false, true)        -> Expected(Success(true), 36082, costDetails(2), 1764)),
+        (Coll[Boolean](true, false)        -> Expected(Success(true), 36082, costDetails(1), 1764)),
+        (Coll[Boolean](true, true)         -> Expected(Success(true), 36082, costDetails(1), 1764)),
+        (Coll[Boolean](true, false, false) -> Expected(Success(true), 36092, costDetails(1), 1764)),
+        (Coll[Boolean](true, false, true)  -> Expected(Success(true), 36092, costDetails(1), 1764)),
+        (Coll[Boolean](true, true, false)  -> Expected(Success(true), 36092, costDetails(1), 1764)),
+        (Coll[Boolean](true, true, true)   -> Expected(Success(true), 36092, costDetails(1), 1764))
       ),
       existingFeature((x: Coll[Boolean]) => SigmaDsl.anyOf(x),
         "{ (x: Coll[Boolean]) => anyOf(x) }",
@@ -9534,7 +9534,7 @@ class SigmaDslSpecification extends SigmaDslTesting
                CSigmaProp(ProveDlog(Helpers.decodeECPoint("02288f0e55610c3355c89ed6c5de43cf20da145b8c54f03a29f481e540d94e9a69")))),
                cost = 45935,
                costDetails,
-               1802))
+               1782))
       ),
       existingFeature({ (x: GroupElement) => SigmaDsl.proveDlog(x) },
         "{ (x: GroupElement) => proveDlog(x) }",
@@ -9564,7 +9564,7 @@ class SigmaDslSpecification extends SigmaDslTesting
             )),
             cost = 76215,
             costDetails,
-            1856
+            1836
           ))
       ),
       existingFeature({ (x: GroupElement) => SigmaDsl.proveDHTuple(x, x, x, x) },
@@ -9616,9 +9616,9 @@ class SigmaDslSpecification extends SigmaDslTesting
             Success(Helpers.decodeBytes("000008d3")),
             cost = 37694,
             expectedDetails = CostDetails.ZeroCost,
-            newCost = 1803,
+            newCost = 1783,
             newVersionedResults = {
-              val res = (ExpectedResult(Success(Helpers.decodeBytes("0008d3")), Some(1803)) -> Some(costDetails(0)))
+              val res = (ExpectedResult(Success(Helpers.decodeBytes("0008d3")), Some(1783)) -> Some(costDetails(0)))
               Seq(0, 1, 2).map(version => version -> res)
             }),
 
@@ -9626,19 +9626,19 @@ class SigmaDslSpecification extends SigmaDslTesting
             Success(Helpers.decodeBytes("00000008d3")),
             cost = 37694,
             expectedDetails = CostDetails.ZeroCost,
-            newCost = 1803,
+            newCost = 1783,
             newVersionedResults = {
               // since the tree without constant segregation, substitution has no effect
-              val res = (ExpectedResult(Success(Helpers.decodeBytes("000008d3")), Some(1803)) -> Some(costDetails(0)))
+              val res = (ExpectedResult(Success(Helpers.decodeBytes("000008d3")), Some(1783)) -> Some(costDetails(0)))
               Seq(0, 1, 2).map(version => version -> res)
             }),
           // tree with segregation flag, empty constants array
-          (Coll(t2.bytes:_*), 0) -> success(Helpers.decodeBytes("100008d3"), costDetails(0), 1803),
-          (Helpers.decodeBytes("100008d3"), 0) -> success(Helpers.decodeBytes("100008d3"), costDetails(0), 1803),
+          (Coll(t2.bytes:_*), 0) -> success(Helpers.decodeBytes("100008d3"), costDetails(0), 1783),
+          (Helpers.decodeBytes("100008d3"), 0) -> success(Helpers.decodeBytes("100008d3"), costDetails(0), 1783),
           // tree with one segregated constant
-          (Coll(t3.bytes:_*), 0) -> success(Helpers.decodeBytes("100108d27300"), costDetails(1), 1813),
-          (Helpers.decodeBytes("100108d37300"), 0) -> success(Helpers.decodeBytes("100108d27300"), costDetails(1), 1813),
-          (Coll(t3.bytes:_*), 1) -> success(Helpers.decodeBytes("100108d37300"), costDetails(1), 1813),
+          (Coll(t3.bytes:_*), 0) -> success(Helpers.decodeBytes("100108d27300"), costDetails(1), 1793),
+          (Helpers.decodeBytes("100108d37300"), 0) -> success(Helpers.decodeBytes("100108d27300"), costDetails(1), 1793),
+          (Coll(t3.bytes:_*), 1) -> success(Helpers.decodeBytes("100108d37300"), costDetails(1), 1793),
           (Coll(t4.bytes:_*), 0) -> Expected(new IllegalArgumentException("requirement failed: expected new constant to have the same SInt$ tpe, got SSigmaProp"))
         )
       },
@@ -9701,8 +9701,8 @@ class SigmaDslSpecification extends SigmaDslTesting
             Failure(error),
             cost = 37694,
             expectedDetails = CostDetails.ZeroCost,
-            newCost = 1796,
-            newVersionedResults = (0 to 2).map(i => i -> (ExpectedResult(Success(true), Some(1796)) -> Some(costDetails)))
+            newCost = 1776,
+            newVersionedResults = (0 to 2).map(i => i -> (ExpectedResult(Success(true), Some(1776)) -> Some(costDetails)))
           )
         ),
         changedFeature(
@@ -9814,7 +9814,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     val keys = Colls.fromArray(Array(Coll[Byte](1, 2, 3, 4, 5)))
     val initial = Coll[Byte](0, 0, 0, 0, 0)
     val cases =  Seq(
-      (keys, initial) -> Expected(Success(Coll[Byte](1, 2, 3, 4, 5)), cost = 46522, expectedDetails = CostDetails.ZeroCost, 1821)
+      (keys, initial) -> Expected(Success(Coll[Byte](1, 2, 3, 4, 5)), cost = 46522, expectedDetails = CostDetails.ZeroCost, 1801)
     )
     val scalaFunc = { (x: (Coll[Coll[Byte]], Coll[Byte])) =>
       x._1.foldLeft(x._2, { (a: (Coll[Byte], Coll[Byte])) =>


### PR DESCRIPTION
  The cost of `Value[T]` deserialization is O(n), where n is the length of its bytes array. To evaluate `DeserializeContext` and `DeserializeRegister` we add the following cost of deserialization for each byte.
```
  val CostPerByteDeserialized = 2
```

The cost of substituting `DeserializeContext` and `DeserializeRegister nodes with the deserialized expression is also O(n), where n is the number of nodes in ErgoTree. The following is the cost added for each tree node.
```
  val CostPerTreeNode = 2
```
