### PR TITLE
remove incorrect comment regarding max tokens limit in tx serialization;

### DIFF
--- a/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
+++ b/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala
@@ -121,9 +121,6 @@ object ErgoLikeTransactionSerializer extends SigmaSerializer[ErgoLikeTransaction
       w.putBytes(input.boxId)
     }
     // Serialize distinct ids of tokens in transaction outputs.
-    // This optimization is crucial to allow up to MaxTokens (== 255) in a box.
-    // Without it total size of all token ids 255 * 32 = 8160,
-    // way beyond MaxBoxSize (== 4K)
     val tokenIds = tx.outputCandidates.toColl
       .flatMap(box => box.additionalTokens.map(t => t._1))
 


### PR DESCRIPTION
Since it contradicts the check for max box size in tx verification on the node - https://github.com/ergoplatform/ergo/blob/a4d1e62fb8f888a33db3fc5881c2090ec3dd0ebb/src/main/scala/org/ergoplatform/modifiers/mempool/ErgoTransaction.scala#L168
