### PR TITLE
Export modules individually

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "files": [
     "interpreter/js/target/scala-2.13/interpreter-fastopt/"
   ],
+  "exports": {
+    "./internal-*": null,
+    "./*": "./interpreter/js/target/scala-2.13/interpreter-fastopt/*.js"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR modifies package.json in order to allow individual modules exporting while ignores all `internal-*` files.

Modules can be imported as follows:

```js
import { Value, Values } from "sigmastate-js/core";
import { ErgoTrees } from "sigmastate-js/ergotree";
```

This is good because allows bundlers like webpack to "[tree-shake](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking)" the code, when possible, and extract only what's needed for production.

