### PR TITLE
Add new publish approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ flamegraphs/
 node_modules/
 package-lock.json
 .npmrc
+sigma-js/dist/
 
 # sbt specific
 .cache

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sigmastate-js",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Sigma.js library",
   "main": "dist/interpreter.js",
   "files": [

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -31,8 +31,8 @@
     "prepublishOnly": "npm run clean && npm run copy-output"
   },
   "dependencies": {
-    "bouncycastle-js": "0.1.8",
-    "sigmajs-crypto-facade": "0.0.3"
+    "sigmajs-crypto-facade": "0.0.3",
+    "bouncycastle-js": "0.1.8"
   },
   "devDependencies": {
     "jest": "^29.0.3",

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -2,14 +2,14 @@
   "name": "sigmastate-js",
   "version": "0.0.7",
   "description": "Sigma.js library",
-  "main": "interpreter/js/target/scala-2.13/interpreter-fastopt/interpreter.js",
+  "main": "dist/interpreter.js",
   "files": [
-    "interpreter/js/target/scala-2.13/interpreter-fastopt/",
-    "sigma-js/README.md"
+    "dist/",
+    "README.md"
   ],
   "exports": {
     "./internal-*": null,
-    "./*": "./interpreter/js/target/scala-2.13/interpreter-fastopt/*.js"
+    "./*": "./dist/*.js"
   },
   "license": "MIT",
   "publishConfig": {
@@ -25,13 +25,17 @@
   },
   "homepage": "https://github.com/ScorexFoundation/sigmastate-interpreter/blob/v5.x-scala-js/sigma-js/README.md",
   "scripts": {
-    "test": "node_modules/.bin/jest"
+    "test": "node_modules/.bin/jest",
+    "clean": "shx rm -rf ./dist/*",
+    "copy-output": "shx cp -r ../interpreter/js/target/scala-2.13/interpreter-fastopt/* ./dist/",
+    "prepublishOnly": "npm run clean && npm run copy-output"
   },
   "dependencies": {
-    "sigmajs-crypto-facade": "0.0.3",
-    "bouncycastle-js": "0.1.8"
+    "bouncycastle-js": "0.1.8",
+    "sigmajs-crypto-facade": "0.0.3"
   },
   "devDependencies": {
-    "jest": "^29.0.3"
+    "jest": "^29.0.3",
+    "shx": "^0.3.4"
   }
 }


### PR DESCRIPTION
This PR moves `package.json` file to `sigma-js/` dir and makes use of `prepublishOnly` hook script (which will be automatically called on `npm publish`) to copy output files from `interpreter/js/target/scala-2.13/interpreter-fastopt/` to `sigma-js/dist/`. 

This also allows publishing npm package from inside the `sigma-js/` dir and having the corresponding `README.md` file in the published package.