### PR TITLE
Move DataJsonEncoder and JsonCodecs to the sdk module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ lazy val sc = (project in file("sc"))
 
 lazy val sdk = crossProject(JVMPlatform, JSPlatform)
     .in(file("sdk"))
-    .dependsOn(corelib % allConfigDependency, interpreter % allConfigDependency)
+    .dependsOn(corelib % allConfigDependency, interpreter % allConfigDependency, parsers % allConfigDependency)
     .settings(commonSettings ++ testSettings2,
       commonDependenies2,
       testingDependencies2,

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/DataJsonEncoder.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/DataJsonEncoder.scala
@@ -1,4 +1,4 @@
-package sigmastate.serialization
+package org.ergoplatform.sdk
 
 import java.math.BigInteger
 import io.circe._
@@ -10,14 +10,18 @@ import scalan.RType
 import scorex.util._
 import sigmastate.Values.{Constant, EvaluatedValue}
 import sigmastate._
-import sigmastate.eval._
 import sigmastate.lang.SigmaParser
+import sigmastate.eval._
 import special.collection.Coll
 import special.sigma._
 import debox.cfor
 import sigmastate.exceptions.SerializerException
 import scala.collection.compat.immutable.ArraySeq
 import scala.collection.mutable
+import fastparse.{Parsed, parse}
+import sigmastate.serialization.SigmaSerializer
+import sigmastate.serialization.DataSerializer
+import sigmastate.serialization.ErgoTreeSerializer
 
 object DataJsonEncoder {
   def encode[T <: SType](v: T#WrappedType, tpe: T): Json = {

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/JsonCodecs.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/JsonCodecs.scala
@@ -1,4 +1,4 @@
-package org.ergoplatform
+package org.ergoplatform.sdk
 
 import java.math.BigInteger
 
@@ -16,12 +16,22 @@ import sigmastate.eval.Extensions._
 import sigmastate.eval.{CPreHeader, WrapperOf, _}
 import sigmastate.exceptions.SigmaException
 import sigmastate.interpreter.{ContextExtension, ProverResult}
-import sigmastate.serialization.{DataJsonEncoder, ErgoTreeSerializer, ValueSerializer}
 import sigmastate.{AvlTreeData, AvlTreeFlags, SType}
 import special.collection.Coll
 import special.sigma.{AnyValue, Header, PreHeader}
 import scala.util.Try
 import sigmastate.utils.Helpers._  // required for Scala 2.11
+import org.ergoplatform.ErgoBox
+import sigmastate.serialization.ValueSerializer
+import org.ergoplatform.DataInput
+import org.ergoplatform.Input
+import org.ergoplatform.UnsignedInput
+import sigmastate.serialization.ErgoTreeSerializer
+import org.ergoplatform.ErgoLikeTransaction
+import org.ergoplatform.UnsignedErgoLikeTransaction
+import org.ergoplatform.ErgoLikeTransactionTemplate
+import org.ergoplatform.ErgoBoxCandidate
+import org.ergoplatform.ErgoLikeContext
 
 trait JsonCodecs {
 

--- a/sdk/shared/src/test/scala/org/ergoplatform/sdk/DataJsonEncoderSpecification.scala
+++ b/sdk/shared/src/test/scala/org/ergoplatform/sdk/DataJsonEncoderSpecification.scala
@@ -1,9 +1,8 @@
-package sigmastate.serialization
+package org.ergoplatform.sdk
 
 
 import java.math.BigInteger
 
-import org.ergoplatform.JsonCodecs
 import org.scalacheck.Arbitrary._
 import scalan.RType
 import sigmastate.SCollection.SByteArray
@@ -15,6 +14,7 @@ import sigmastate.eval.{Evaluation, _}
 import sigmastate.basics.CryptoConstants.EcPointType
 import sigmastate.exceptions.SerializerException
 import special.sigma.{Box, AvlTree}
+import sigmastate.serialization.SerializationSpecification
 
 class DataJsonEncoderSpecification extends SerializationSpecification {
   object JsonCodecs extends JsonCodecs

--- a/sdk/shared/src/test/scala/org/ergoplatform/sdk/JsonSerializationSpec.scala
+++ b/sdk/shared/src/test/scala/org/ergoplatform/sdk/JsonSerializationSpec.scala
@@ -1,4 +1,5 @@
-package org.ergoplatform
+package org.ergoplatform.sdk
+
 
 import io.circe._
 import io.circe.syntax._
@@ -13,14 +14,21 @@ import sigmastate.Values.{ByteArrayConstant, ByteConstant, ErgoTree, EvaluatedVa
 import sigmastate.basics.CryptoConstants
 import sigmastate.basics.DLogProtocol.ProveDlog
 import sigmastate.eval.Digest32Coll
-import sigmastate.helpers.CompilerTestingCommons
 import sigmastate.interpreter.{ContextExtension, ProverResult}
 import sigmastate.serialization.SerializationSpecification
 import sigmastate.utils.Helpers._
 import special.collection.Coll
 import special.sigma.{Header, PreHeader}
+import org.ergoplatform.ErgoLikeContext
+import org.ergoplatform.DataInput
+import org.ergoplatform.Input
+import org.ergoplatform.UnsignedInput
+import org.ergoplatform.ErgoBox
+import org.ergoplatform.ErgoLikeTransaction
+import org.ergoplatform.UnsignedErgoLikeTransaction
+import org.ergoplatform.ErgoLikeTransactionTemplate
 
-class JsonSerializationSpec extends CompilerTestingCommons with SerializationSpecification with JsonCodecs {
+class JsonSerializationSpec extends SerializationSpecification with JsonCodecs {
 
   def jsonRoundTrip[T](v: T)(implicit encoder: Encoder[T], decoder: Decoder[T]): Unit = {
     val json = v.asJson


### PR DESCRIPTION
Ground work part 2 for #851 

Moved `DataJsonEncoder` and `JsonCodecs` to the `sdk` module. This is done because we need these to be available from the `sdk` module for EIP-5 implementation and we don't want the `sdk` module to depend on the `sc` module.