### PR TITLE
Fix JS tests and publish script

### DIFF
--- a/sigma-js/jest.config.js
+++ b/sigma-js/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import("jest").Config} */
+const config = {
+  moduleDirectories: ["<rootDir>/node_modules"],
+  moduleNameMapper: {
+    "sigmastate-js": "<rootDir>/../sdk/js/target/scala-2.13/sdk-fastopt/main.js",
+  },
+};
+
+module.exports = config;

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "node_modules/.bin/jest",
     "clean": "shx rm -rf ./dist/*",
-    "copy-output": "shx mkdir -p ./dist/ && cp -r ../sdk/js/target/scala-2.12/sdk-fastopt/* ./dist/",
+    "copy-output": "shx mkdir -p ./dist/ && cp -r ../sdk/js/target/scala-2.13/sdk-fastopt/* ./dist/",
     "prepublishOnly": "npm run clean && npm run copy-output"
   },
   "dependencies": {

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/ScorexFoundation/sigmastate-interpreter/blob/master/sigma-js/README.md",
   "scripts": {
-    "test": "node_modules/.bin/jest",
+    "test": "jest",
     "clean": "shx rm -rf ./dist/*",
     "copy-output": "shx mkdir -p ./dist/ && cp -r ../sdk/js/target/scala-2.13/sdk-fastopt/* ./dist/",
     "prepublishOnly": "npm run clean && npm run copy-output"

--- a/sigma-js/tests/js/bindings.spec.js
+++ b/sigma-js/tests/js/bindings.spec.js
@@ -1,6 +1,4 @@
-const {
-  Types, Values, ErgoTree, ErgoTrees
-} = require("../../../sdk/js/target/scala-2.13/sdk-fastopt/main.js");
+const { Types, Values, ErgoTree, ErgoTrees } = require("sigmastate-js");
 
 describe("Smoke tests for API exporting", () => {
   it("Should export ErgoTree object", () => {


### PR DESCRIPTION
In this PR:
  * Fix pre-publish hook by updating relative path of `copy-output` script;
  * Fix JS tests by restricting jest to only look at `sigma-js/node_modules` for module resolution; and
  * Add `sigmastate-js` module mapper for JS output file.