### PR TITLE
Tree template types

### DIFF
--- a/sigma-js/README.md
+++ b/sigma-js/README.md
@@ -15,26 +15,22 @@ The modules published here can be used directly from JavaScript.
 
 # Getting Started
 
-Add the following dependency to your `package.json`:
+Run following command to add Sigma.JS as a project dependency:
 
-```json
-{
-  "dependencies": {
-    "sigmastate-js": "0.1.1"
-  }
-}
+```bash
+npm install sigmastate-js
 ```
-Then run `npm install`.
 
 # Examples
 
 ### How to create Sigma type descriptors
 
 Import `TypeObj` module, then use:
+
 - fields to create simple types (e.g. `TypeObj.Int`)
 - method `TypeObj.pairType` (e.g. `TypeObj.pairType(TypeObj.Int, TypeObj.Long)`)
 - method `TypeObj.collType` (e.g. `TypeObj.collType(TypeObj.Int)`)
- 
+
 See examples in tests [Type.spec.js](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/933acd7a3753725c8b41994c2126a20279b6809b/sigma-js/tests/js/Type.spec.js)
 
 ### How to create Sigma values
@@ -51,4 +47,3 @@ See examples in tests [ErgoTree.spec.js](https://github.com/ScorexFoundation/sig
 
 Import `SigmaCompilerObj` module and `SigmaCompiler` class, then use its methods.
 See compiler tests in [SigmaCompiler.spec.js](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/933acd7a3753725c8b41994c2126a20279b6809b/sigma-js/tests/js/SigmaCompiler.spec.js)
-

--- a/sigma-js/package.json
+++ b/sigma-js/package.json
@@ -2,16 +2,17 @@
   "name": "sigmastate-js",
   "version": "0.2.1",
   "description": "Sigma.js library",
-  "main": "dist/main.js",
   "files": [
     "dist/",
     "sigmastate-js.d.ts",
     "README.md"
   ],
-  "types": "./sigmastate-js.d.ts",
   "exports": {
     "./internal-*": null,
-    "./*": "./dist/*.js"
+    "./main": {
+      "types": "./sigmastate-js.d.ts",
+      "default": "./dist/main.js"
+    }
   },
   "license": "MIT",
   "publishConfig": {

--- a/sigma-js/sigmastate-js.d.ts
+++ b/sigma-js/sigmastate-js.d.ts
@@ -1,28 +1,31 @@
 declare module "sigmastate-js/main" {
   type SigmaCompilerNamedConstantsMap = { [key: string]: Value };
   type HexString = string;
+  type ByteArray = { u: Int8Array };
 
-  class ErgoTree {
+  export declare class ErgoTree {
     toHex(): HexString;
-    bytes(): { u: Uint8Array };
+    bytes(): ByteArray;
     header(): number;
     version(): number;
     isConstantSegregation(): boolean;
     hasSize(): boolean;
     constants(): Value[];
+    template(): ByteArray;
+    templateHex(): HexString;
     toString(): string;
   }
 
-  class ErgoTreeObj {
+  export declare class ErgoTreeObj {
     static fromHex(value: HexString): ErgoTree;
   }
 
-  class Type {
+  export declare class Type {
     name: string;
     toString(): string;
   }
 
-  class TypeObj {
+  export declare class TypeObj {
     static Byte: Type;
     static Short: Type;
     static Int: Type;
@@ -40,13 +43,13 @@ declare module "sigmastate-js/main" {
     static collType(elemType: Type): Type;
   }
 
-  class Value<T = unknown> {
+  export declare class Value<T = unknown> {
     data: T;
     tpe: Type;
     toHex(): HexString;
   }
 
-  class ValueObj {
+  export declare class ValueObj {
     static ofByte(value: number): Value<number>;
     static ofShort(value: number): Value<number>;
     static ofInt(value: number): Value<number>;
@@ -57,7 +60,7 @@ declare module "sigmastate-js/main" {
     static fromHex<T>(hex: HexString): Value<T>;
   }
 
-  class SigmaCompiler {
+  export declare class SigmaCompiler {
     compile(
       namedConstants: SigmaCompilerNamedConstantsMap,
       segregateConstants: boolean,
@@ -66,7 +69,7 @@ declare module "sigmastate-js/main" {
     ): ErgoTree;
   }
 
-  class SigmaCompilerObj {
+  export declare class SigmaCompilerObj {
     static forMainnet(): SigmaCompiler;
     static forTestnet(): SigmaCompiler;
   }


### PR DESCRIPTION
### In this PR
 * Fix types exporting by tweaking `package.json` and adding export declarations in `d.ts` file.
 * Add `ErgoTree.template()` and `ErgoTree.templateHex()` methods.
 * Simplify NPM package installation instructions.