### PR TITLE
Towards sigma-data module

### DIFF
--- a/interpreter/js/src/main/scala/sigma/interpreter/js/ErgoTree.scala
+++ b/interpreter/js/src/main/scala/sigma/interpreter/js/ErgoTree.scala
@@ -1,7 +1,6 @@
-package org.ergoplatform.sdk.js
+package sigma.interpreter.js
 
 import sigma.js.Value
-import sigmastate.Values
 
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.JSRichIterableOnce
@@ -36,7 +35,7 @@ class ErgoTree(tree: sigmastate.ErgoTree) extends js.Object {
   /** Returns segregated constants of this tree as [[js.Array]]. */
   def constants(): js.Array[Value] = {
     val constants = tree.constants
-    val values = constants.map(Isos.isoValueToConstant.from)
+    val values = constants.map(isoValueToConstant.from)
     values.toJSArray
   }
 }

--- a/interpreter/js/src/main/scala/sigma/interpreter/js/package.scala
+++ b/interpreter/js/src/main/scala/sigma/interpreter/js/package.scala
@@ -1,0 +1,21 @@
+package sigma.interpreter
+
+import sigma.Evaluation
+import sigma.ast.SType
+import sigma.data.Iso
+import sigma.js.{Type, Value}
+import sigmastate.Values.Constant
+
+package object js {
+  /** Conversion between `Value` and `Constant[SType]`. */
+  implicit val isoValueToConstant: Iso[Value, Constant[SType]] = new Iso[Value, Constant[SType]] {
+    override def to(x: Value): Constant[SType] =
+      Constant(x.runtimeData.asInstanceOf[SType#WrappedType], Evaluation.rtypeToSType(x.tpe.rtype))
+
+    override def from(x: Constant[SType]): Value = {
+      val rtype   = Evaluation.stypeToRType(x.tpe)
+      val jsvalue = Value.fromRuntimeData(x.value, rtype)
+      new Value(jsvalue, new Type(rtype))
+    }
+  }
+}

--- a/sc/js/src/main/scala/sigmastate/lang/js/SigmaCompiler.scala
+++ b/sc/js/src/main/scala/sigmastate/lang/js/SigmaCompiler.scala
@@ -1,15 +1,13 @@
 package sigmastate.lang.js
 
 import org.ergoplatform.ErgoAddressEncoder
-import org.ergoplatform.sdk.js.Isos.isoValueToConstant
 import org.scalablytyped.runtime.StringDictionary
+import sigma.interpreter.js.{ErgoTree, isoValueToConstant}
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExportTopLevel
-import org.ergoplatform.sdk.js.ErgoTree
 import sigma.js.Value
 import sigmastate.ErgoTree.HeaderType
-import sigmastate.Values
 import sigmastate.eval.CompiletimeIRContext
 import sigmastate.lang.Terms.ValueOps
 

--- a/sdk/js/src/main/scala/org/ergoplatform/sdk/js/Isos.scala
+++ b/sdk/js/src/main/scala/org/ergoplatform/sdk/js/Isos.scala
@@ -32,18 +32,6 @@ import scala.scalajs.js.Object
 
 /** Definitions of isomorphisms. */
 object Isos {
-  /** Conversion between `Value` and `Constant[SType]`. */
-  implicit val isoValueToConstant: Iso[Value, Constant[SType]] = new Iso[Value, Constant[SType]] {
-    override def to(x: Value): Constant[SType] =
-      Constant(x.runtimeData.asInstanceOf[SType#WrappedType], Evaluation.rtypeToSType(x.tpe.rtype))
-
-    override def from(x: Constant[SType]): Value = {
-      val rtype = Evaluation.stypeToRType(x.tpe)
-      val jsvalue = Value.fromRuntimeData(x.value, rtype)
-      new Value(jsvalue, new Type(rtype))
-    }
-  }
-
   val isoStringToGroupElement: Iso[String, sigma.GroupElement] = new Iso[String, sigma.GroupElement] {
     override def to(x: String): sigma.GroupElement = {
       val bytes = Base16.decode(x).get

--- a/sdk/js/src/test/scala/org/ergoplatform/sdk/js/ValueSpec.scala
+++ b/sdk/js/src/test/scala/org/ergoplatform/sdk/js/ValueSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scorex.util.encode.Base16
 import sigma.ast.SType
-import sigmastate.Values.{AvlTreeConstant, BigIntConstant, BooleanConstant, BoxConstant, ByteConstant, Constant, GroupElementConstant, IntConstant, LongConstant, ShortConstant, SigmaPropConstant, UnitConstant}
+import sigmastate.Values._
 import sigmastate.crypto.CryptoConstants.dlogGroup
 import sigma.crypto.CryptoFacade
 import sigmastate.lang.DeserializationSigmaBuilder
@@ -13,6 +13,7 @@ import sigmastate.serialization.ConstantSerializer
 import sigmastate.utils.Helpers
 import sigma.SigmaTestingData
 import sigma.data.{CSigmaProp, ProveDlog}
+import sigma.interpreter.js.isoValueToConstant
 import sigma.js.Value
 
 import java.math.BigInteger
@@ -20,11 +21,11 @@ import java.math.BigInteger
 class ValueSpec extends AnyPropSpec with Matchers with SigmaTestingData with ScalaCheckPropertyChecks {
 
   def test[T <: SType](c: Constant[T], expectedHex: String) = {
-    val v = Isos.isoValueToConstant.from(c)
+    val v = isoValueToConstant.from(c)
     val S = ConstantSerializer(DeserializationSigmaBuilder)
     Base16.encode(S.toBytes(c)) shouldBe expectedHex
     v.toHex() shouldBe expectedHex
-    Isos.isoValueToConstant.to(Value.fromHex(expectedHex)) shouldBe c
+    isoValueToConstant.to(Value.fromHex(expectedHex)) shouldBe c
   }
 
   property("Boolean toHex()/fromHex()") {


### PR DESCRIPTION
In this PR:
- [x] [js.ErgoTree moved to interpreter module](https://github.com/ScorexFoundation/sigmastate-interpreter/commit/26345ad0a158f97724d8f73e7bf41635ab2248ba)