### PR TITLE
replacing-arrays-hash-code

### DIFF
--- a/common/shared/src/main/scala/scalan/util/CollectionUtil.scala
+++ b/common/shared/src/main/scala/scalan/util/CollectionUtil.scala
@@ -6,6 +6,7 @@ import scala.collection.{Seq, mutable, GenIterable}
 import scala.collection.mutable.{HashMap, ArrayBuffer}
 import scala.reflect.ClassTag
 import scala.collection.compat._
+import scorex.utils.Ints
 
 object CollectionUtil {
 
@@ -53,14 +54,14 @@ object CollectionUtil {
     */
   def deepHashCode[T](arr: Array[T]): Int = arr match {
     case arr: Array[AnyRef] => util.Arrays.deepHashCode(arr)
-    case arr: Array[Byte] => util.Arrays.hashCode(arr)
-    case arr: Array[Short] => util.Arrays.hashCode(arr)
-    case arr: Array[Int] => util.Arrays.hashCode(arr)
-    case arr: Array[Long] => util.Arrays.hashCode(arr)
-    case arr: Array[Char] => util.Arrays.hashCode(arr)
-    case arr: Array[Float] => util.Arrays.hashCode(arr)
-    case arr: Array[Double] => util.Arrays.hashCode(arr)
-    case arr: Array[Boolean] => util.Arrays.hashCode(arr)
+    case arr: Array[Byte] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Short] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Int] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Long] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Char] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Float] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Double] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Boolean] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
   }
 
   /** Group the given sequence of pairs by first values as keys.

--- a/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
+++ b/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
@@ -1,11 +1,10 @@
-package org.ergoplatform.validation
-
 import java.util
+import scorex.utils.Ints
 
-/** Base trait for rule status information. */
 sealed trait RuleStatus {
   def statusCode: Byte
 }
+
 object RuleStatus {
   val EnabledRuleCode: Byte = 1.toByte
   val DisabledRuleCode: Byte = 2.toByte
@@ -13,39 +12,22 @@ object RuleStatus {
   val ChangedRuleCode: Byte = 4.toByte
 }
 
-/** This is a default status of a rule which is registered in the table
-  * and not yet altered by soft-forks.
-  */
 case object EnabledRule extends RuleStatus {
   val statusCode: Byte = RuleStatus.EnabledRuleCode
 }
 
-/** This is a status of a rule which is disabled in current version
-  * and not yet altered by soft-forks.
-  * The rule can be disabled via block extensions and voting process.
-  */
 case object DisabledRule extends RuleStatus {
   val statusCode: Byte = RuleStatus.DisabledRuleCode
 }
 
-/** The status of the rule which is replaced by a new rule via soft-fork extensions.
-  * This is similar to DisabledRule, but in addition require the new rule to be enabled
-  * at the same time (i.e. atomically)
-  * @see `ValidationSettings.isSoftFork`
-  * @param newRuleId  id of a new rule which replaces the rule marked with this status
-  */
-case class  ReplacedRule(newRuleId: Short) extends RuleStatus {
+case class ReplacedRule(newRuleId: Short) extends RuleStatus {
   val statusCode: Byte = RuleStatus.ReplacedRuleCode
 }
 
-/** The status of the rule whose parameters are changed via soft-fork extensions.
-  * The same rule can be changed many times via voting.
-  * @param newValue  new value of block extension value with key == rule.id
-  */
 case class ChangedRule(newValue: Array[Byte]) extends RuleStatus {
   val statusCode: Byte = RuleStatus.ChangedRuleCode
 
-  override def hashCode(): Int = util.Arrays.hashCode(newValue)
+  override def hashCode(): Int = Ints.fromByteArray(newValue)
 
   override def canEqual(that: Any): Boolean = that.isInstanceOf[ChangedRule]
 

--- a/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
+++ b/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
@@ -1,4 +1,5 @@
 package org.ergoplatform.validation
+import scorex.utils.Ints
 
 import java.util
 

--- a/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
+++ b/interpreter/shared/src/main/scala/org/ergoplatform/validation/RuleStatus.scala
@@ -1,10 +1,11 @@
-import java.util
-import scorex.utils.Ints
+package org.ergoplatform.validation
 
+import java.util
+
+/** Base trait for rule status information. */
 sealed trait RuleStatus {
   def statusCode: Byte
 }
-
 object RuleStatus {
   val EnabledRuleCode: Byte = 1.toByte
   val DisabledRuleCode: Byte = 2.toByte
@@ -12,18 +13,35 @@ object RuleStatus {
   val ChangedRuleCode: Byte = 4.toByte
 }
 
+/** This is a default status of a rule which is registered in the table
+  * and not yet altered by soft-forks.
+  */
 case object EnabledRule extends RuleStatus {
   val statusCode: Byte = RuleStatus.EnabledRuleCode
 }
 
+/** This is a status of a rule which is disabled in current version
+  * and not yet altered by soft-forks.
+  * The rule can be disabled via block extensions and voting process.
+  */
 case object DisabledRule extends RuleStatus {
   val statusCode: Byte = RuleStatus.DisabledRuleCode
 }
 
-case class ReplacedRule(newRuleId: Short) extends RuleStatus {
+/** The status of the rule which is replaced by a new rule via soft-fork extensions.
+  * This is similar to DisabledRule, but in addition require the new rule to be enabled
+  * at the same time (i.e. atomically)
+  * @see `ValidationSettings.isSoftFork`
+  * @param newRuleId  id of a new rule which replaces the rule marked with this status
+  */
+case class  ReplacedRule(newRuleId: Short) extends RuleStatus {
   val statusCode: Byte = RuleStatus.ReplacedRuleCode
 }
 
+/** The status of the rule whose parameters are changed via soft-fork extensions.
+  * The same rule can be changed many times via voting.
+  * @param newValue  new value of block extension value with key == rule.id
+  */
 case class ChangedRule(newValue: Array[Byte]) extends RuleStatus {
   val statusCode: Byte = RuleStatus.ChangedRuleCode
 

--- a/interpreter/shared/src/main/scala/sigmastate/crypto/GF2_192.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/crypto/GF2_192.scala
@@ -29,6 +29,7 @@
 package sigmastate.crypto
 
 import debox.cfor
+import scorex.utils.Ints
 
 import java.util
 
@@ -113,7 +114,7 @@ class GF2_192 extends AnyRef {
     }
   }
 
-  override def hashCode = util.Arrays.hashCode(word)
+  override def hashCode = Ints.fromByteArray(word)
 
   /**
     *

--- a/interpreter/shared/src/main/scala/sigmastate/interpreter/ProverResult.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/interpreter/ProverResult.scala
@@ -5,6 +5,7 @@ import java.util
 import scorex.util.encode.Base16
 import sigmastate.serialization.SigmaSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
+import scorex.utils.Ints
 
 /**
   * Proof of correctness of tx spending
@@ -13,7 +14,7 @@ import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
   * @param extension - user-defined variables to be put into context
   */
 class ProverResult(val proof: Array[Byte], val extension: ContextExtension) {
-  override def hashCode(): Int = util.Arrays.hashCode(proof) * 31 + extension.hashCode()
+  override def hashCode(): Int = Ints.fromByteArray(proof) * 31 + extension.hashCode()
 
   override def equals(obj: scala.Any): Boolean =
   (this eq obj.asInstanceOf[AnyRef]) || (obj match {

--- a/interpreter/shared/src/main/scala/sigmastate/utils/Helpers.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/utils/Helpers.scala
@@ -79,16 +79,16 @@ object Helpers {
     result
   }
 
-  def deepHashCode[T](arr: Array[T]): Int = arr match {
+    def deepHashCode[T](arr: Array[T]): Int = arr match {
     case arr: Array[AnyRef] => util.Arrays.deepHashCode(arr)
-    case arr: Array[Byte] => util.Arrays.hashCode(arr)
-    case arr: Array[Short] => util.Arrays.hashCode(arr)
-    case arr: Array[Int] => util.Arrays.hashCode(arr)
-    case arr: Array[Long] => util.Arrays.hashCode(arr)
-    case arr: Array[Char] => util.Arrays.hashCode(arr)
-    case arr: Array[Float] => util.Arrays.hashCode(arr)
-    case arr: Array[Double] => util.Arrays.hashCode(arr)
-    case arr: Array[Boolean] => util.Arrays.hashCode(arr)
+    case arr: Array[Byte] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Short] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Int] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Long] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Char] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Float] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Double] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
+    case arr: Array[Boolean] => Ints.fromByteArray(arr) // Replace with Ints.fromByteArray
   }
 
   /** Optimized hashCode for array of bytes when it represents some hash thus it have
@@ -97,7 +97,7 @@ object Helpers {
     */
   @inline final def safeIdHashCode(id: Array[Byte]): Int =
     if (id != null && id.length >= 4) Ints.fromBytes(id(0), id(1), id(2), id(3))
-    else util.Arrays.hashCode(id)
+    else Ints.fromByteArray(id)
 
   implicit class TryOps[+A](val source: Try[A]) extends AnyVal {
     def fold[B](onError: Throwable => B, onSuccess: A => B) = source match {

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/ErgoId.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/ErgoId.scala
@@ -19,7 +19,7 @@ class ErgoId(val _idBytes: Array[Byte]) {
 
   override def hashCode =
     if (_idBytes != null && _idBytes.length >= 4) Ints.fromByteArray(_idBytes)
-    else util.Arrays.hashCode(_idBytes)
+    else Ints.fromByteArray(_idBytes)
 
   override def equals(obj: Any): Boolean = {
     if (obj == null) return false

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/SecretString.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/SecretString.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform.sdk
 
 import debox.cfor
+import scorex.utils.Ints
 
 import java.util
 
@@ -73,7 +74,7 @@ final class SecretString private[sdk](val _data: Array[Char]) {
 
   override def hashCode(): Int = {
     checkErased()
-    util.Arrays.hashCode(_data)
+    Ints.fromByteArray(_data)
   }
 
   /** this is adapted version of java.lang.String */

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/wallet/secrets/ExtendedPublicKey.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/wallet/secrets/ExtendedPublicKey.scala
@@ -7,6 +7,7 @@ import sigmastate.crypto.CryptoFacade
 import sigmastate.crypto.BigIntegers
 import sigmastate.serialization.SigmaSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
+import scorex.utils.Ints
 
 import scala.annotation.tailrec
 
@@ -36,8 +37,8 @@ final class ExtendedPublicKey(/*private[secrets] */val keyBytes: Array[Byte],
   })
 
   override def hashCode(): Int = {
-    var h = util.Arrays.hashCode(keyBytes)
-    h = 31 * h + util.Arrays.hashCode(chainCode)
+    var h = Ints.fromByteArray(keyBytes)
+    h = 31 * h + Ints.fromByteArray(chainCode)
     h = 31 * h + path.hashCode()
     h
   }

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/wallet/secrets/ExtendedSecretKey.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/wallet/secrets/ExtendedSecretKey.scala
@@ -10,6 +10,7 @@ import sigmastate.basics.CryptoConstants
 import sigmastate.crypto.CryptoFacade
 import sigmastate.serialization.SigmaSerializer
 import sigmastate.utils.{SigmaByteReader, SigmaByteWriter}
+import scorex.utils.Ints
 
 /**
   * Secret, its chain code and path in key tree.
@@ -45,8 +46,8 @@ final class ExtendedSecretKey(/*private[secrets]*/ val keyBytes: Array[Byte],
   })
 
   override def hashCode(): Int = {
-    var h = util.Arrays.hashCode(keyBytes)
-    h = 31 * h + util.Arrays.hashCode(chainCode)
+    var h = Ints.fromByteArray(keyBytes)
+    h = 31 * h + Ints.fromByteArray(chainCode)
     h = 31 * h + path.hashCode()
     h
   }


### PR DESCRIPTION
closes #197

searched for all the places where array.hashcode was being used 
replaced it with Ints.fromByteArray 
