### PR TITLE
Removing unused code #3

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/CostItem.scala
+++ b/data/shared/src/main/scala/sigma/ast/CostItem.scala
@@ -1,8 +1,5 @@
 package sigma.ast
 
-import sigma.ast
-import sigma.eval.CostDetails
-
 /** An item in the cost accumulation trace of a [[sigma.ast.ErgoTree]] evaluation. */
 abstract class CostItem {
   def opName: String

--- a/sc/shared/src/main/scala/scalan/primitives/Functions.scala
+++ b/sc/shared/src/main/scala/scalan/primitives/Functions.scala
@@ -332,7 +332,7 @@ trait Functions extends Base with ProgramGraphs { self: Scalan =>
     val m = new java.util.HashMap[Sym, Sym](100)
     m.put(lam.x, s)
     val subst = new MapTransformer(m)
-    val t = DefaultMirror.mirrorSymbols(subst, NoRewriting, lam, body)
+    val t = DefaultMirror.mirrorSymbols(subst, NoRewriting, body)
     t(lam.y)
   }
 

--- a/sc/shared/src/main/scala/scalan/primitives/Thunks.scala
+++ b/sc/shared/src/main/scala/scalan/primitives/Thunks.scala
@@ -323,7 +323,7 @@ trait Thunks extends Functions { self: Scalan =>
     */
   def forceThunkDefByMirror[A](th: ThunkDef[A], subst: MapTransformer = MapTransformer.empty()): Ref[A] = {
     val body = th.scheduleIds
-    val t = DefaultMirror.mirrorSymbols(subst, NoRewriting, th, body)
+    val t = DefaultMirror.mirrorSymbols(subst, NoRewriting, body)
     t(th.root)
   }
 

--- a/sc/shared/src/main/scala/scalan/staged/Transforming.scala
+++ b/sc/shared/src/main/scala/scalan/staged/Transforming.scala
@@ -65,10 +65,6 @@ trait Transforming { self: Scalan =>
   def beginPass(pass: Pass): Unit = {
     _currentPass = pass
   }
-  /** Called to let this IR context to finalized the given pass. */
-  def endPass(pass: Pass): Unit = {
-    _currentPass = Pass.defaultPass
-  }
 
   /** Concrete and default implementation of Transformer using underlying HashMap.
     * HOTSPOT:  don't beatify the code */
@@ -152,7 +148,7 @@ trait Transforming { self: Scalan =>
     protected def mirrorElem(node: Sym): Elem[_] = node.elem
 
     // every mirrorXXX method should return a pair (t + (v -> v1), v1)
-    protected def mirrorVar[A](t: Transformer, rewriter: Rewriter, v: Ref[A]): Transformer = {
+    protected def mirrorVar[A](t: Transformer, v: Ref[A]): Transformer = {
       val newVar = variable(Lazy(mirrorElem(v)))
       t + (v, newVar)
     }
@@ -173,7 +169,7 @@ trait Transforming { self: Scalan =>
 
     protected def mirrorLambda[A, B](t: Transformer, rewriter: Rewriter, node: Ref[A => B], lam: Lambda[A, B]): Transformer = {
       var tRes: Transformer = t
-      val t1 = mirrorNode(t, rewriter, lam, lam.x)
+      val t1 = mirrorNode(t, rewriter, lam.x)
 
       // original root
       val originalRoot = lam.y
@@ -190,7 +186,7 @@ trait Transforming { self: Scalan =>
 //        lambdaStack = newLambdaCandidate :: lambdaStack
         val newRoot = { // reifyEffects block
           val schedule = lam.scheduleIds
-          val t2 = mirrorSymbols(t1, rewriter, lam, schedule)
+          val t2 = mirrorSymbols(t1, rewriter, schedule)
           tRes = t2
           tRes(originalRoot) // this will be a new root
         }
@@ -214,7 +210,7 @@ trait Transforming { self: Scalan =>
 
       val newScope = thunkStack.beginScope(newThunkSym)
       val schedule = thunk.scheduleIds
-      val t1 = mirrorSymbols(t, rewriter, thunk, schedule)
+      val t1 = mirrorSymbols(t, rewriter, schedule)
       thunkStack.endScope()
 
       val newRoot = t1(thunk.root)
@@ -230,12 +226,12 @@ trait Transforming { self: Scalan =>
 
     protected def isMirrored(t: Transformer, node: Sym): Boolean = t.isDefinedAt(node)
 
-    def mirrorNode(t: Transformer, rewriter: Rewriter, g: AstGraph, node: Sym): Transformer = {
+    def mirrorNode(t: Transformer, rewriter: Rewriter, node: Sym): Transformer = {
       if (isMirrored(t, node)) t
       else {
         node.node match {
-          case v: Variable[_] =>
-            mirrorVar(t, rewriter, node)
+          case _: Variable[_] =>
+            mirrorVar(t, node)
           case lam: Lambda[a, b] =>
             mirrorLambda(t, rewriter, node.asInstanceOf[Ref[a => b]], lam)
           case th: ThunkDef[a] =>
@@ -247,12 +243,12 @@ trait Transforming { self: Scalan =>
     }
 
     /** HOTSPOT: */
-    def mirrorSymbols(t0: Transformer, rewriter: Rewriter, g: AstGraph, nodes: DBuffer[Int]) = {
+    def mirrorSymbols(t0: Transformer, rewriter: Rewriter, nodes: DBuffer[Int]): Transformer = {
       var t: Transformer = t0
       cfor(0)(_ < nodes.length, _ + 1) { i =>
         val n = nodes(i)
         val s = getSym(n)
-        t = mirrorNode(t, rewriter, g, s)
+        t = mirrorNode(t, rewriter, s)
       }
       t
     }

--- a/sc/shared/src/main/scala/special/collection/CollsUnit.scala
+++ b/sc/shared/src/main/scala/special/collection/CollsUnit.scala
@@ -9,9 +9,6 @@ package sigma {
     * for details.
     */
   trait Colls extends Base { self: Library =>
-    import Coll._;
-    import CollBuilder._;
-    import WOption._;
     trait Coll[A] extends Def[Coll[A]] {
       implicit def eA: Elem[A];
       def length: Ref[Int];

--- a/sc/shared/src/main/scala/special/sigma/impl/SigmaDslImpl.scala
+++ b/sc/shared/src/main/scala/special/sigma/impl/SigmaDslImpl.scala
@@ -22,19 +22,16 @@ import BigInt._
 import Box._
 import Coll._
 import CollBuilder._
-import Context._
 import GroupElement._
 import Header._
 import PreHeader._
-import SigmaDslBuilder._
 import SigmaProp._
 import WOption._
-import WRType._
+
 
 object BigInt extends EntityObject("BigInt") {
   // entityConst: single const for each entity
   import Liftables._
-  import scala.reflect.{ClassTag, classTag}
   type SBigInt = sigma.BigInt
   case class BigIntConst(
         constValue: SBigInt

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/Extensions.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/Extensions.scala
@@ -13,29 +13,6 @@ import scala.reflect.ClassTag
 
 object Extensions {
 
-  implicit class GenIterableOps[A, Source[X] <: GenIterable[X]](val xs: Source[A]) extends AnyVal {
-
-    /** Apply m for each element of this collection, group by key and reduce each group
-      * using r.
-      * Note, the ordering of the resulting keys is deterministic and the keys appear in
-      * the order they first produced by `map`.
-      *
-      * @returns one item for each group in a new collection of (K,V) pairs. */
-    def mapReduce[K, V](map: A => (K, V))(reduce: (V, V) => V)
-        (implicit cbf: BuildFrom[Source[A], (K, V), Source[(K, V)]]): Source[(K, V)] = {
-      val result = scala.collection.mutable.LinkedHashMap.empty[K, V]
-      xs.foreach { x =>
-        val (key, value) = map(x)
-        val reduced = if (result.contains(key)) reduce(result(key), value) else value
-        result.update(key, reduced)
-      }
-
-      val b = cbf.newBuilder(xs)
-      for ( kv <- result ) b += kv
-      b.result()
-    }
-  }
-
   implicit class CollOps[A](val coll: Coll[A]) extends AnyVal {
 
     /** Partitions this $coll in two $colls according to a predicate.

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/Extensions.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/Extensions.scala
@@ -182,7 +182,4 @@ object Extensions {
     }
   }
 
-  implicit class DoubleOps(val i: Double) extends AnyVal {
-    def erg: Long = (i * 1000000000L).toLong
-  }
 }

--- a/sdk/shared/src/test/scala/org/ergoplatform/sdk/ExtensionsSpec.scala
+++ b/sdk/shared/src/test/scala/org/ergoplatform/sdk/ExtensionsSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import sigma.{Coll, CollGens}
-import org.ergoplatform.sdk.Extensions.{CollBuilderOps, CollOps, GenIterableOps, PairCollOps}
+import org.ergoplatform.sdk.Extensions.{CollBuilderOps, CollOps, PairCollOps}
 import sigma.data.{CSigmaDslBuilder, RType}
 
 class ExtensionsSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with CollGens {
@@ -13,10 +13,6 @@ class ExtensionsSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matc
 
   val items: Iterable[(Int, String)] = Array((1, "a"), (2, "b"), (1, "c"))
 
-  property("Traversable.mapReduce") {
-    val res = items.mapReduce(p => (p._1, p._2))((v1, v2) => v1 + v2)
-    assertResult(List((1, "ac"), (2, "b")))(res)
-  }
 
   property("Coll.partition") {
     forAll(collGen) { col: Coll[Int] =>

--- a/sdk/shared/src/test/scala/org/ergoplatform/sdk/ExtensionsSpec.scala
+++ b/sdk/shared/src/test/scala/org/ergoplatform/sdk/ExtensionsSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import sigma.{Coll, CollGens}
 import org.ergoplatform.sdk.Extensions.{CollBuilderOps, CollOps, PairCollOps}
+import sigma.Extensions.ArrayOps
 import sigma.data.{CSigmaDslBuilder, RType}
 
 class ExtensionsSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers with CollGens {
@@ -24,14 +25,14 @@ class ExtensionsSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matc
   }
 
   property("Coll.mapReduce") {
-    def m(x: Int) = (math.abs(x) % 10, x)
+    def m(x: Int): (Int, Int) = (math.abs(x) % 10, x)
 
     forAll(collGen) { col =>
       val res = col.mapReduce(m, plusF)
       val (ks, vs) = builder.unzip(res)
       vs.toArray.sum shouldBe col.toArray.sum
       ks.length <= 10 shouldBe true
-      res.toArray shouldBe col.toArray.toIterable.mapReduce(m)(plus).toArray
+      res.toArray shouldBe col.toArray.toColl.mapReduce[Int, Int](m, plusF).toArray
     }
   }
 


### PR DESCRIPTION
In this PR:

* unused arguments in `mirrorNode` / `mirrorVar` / `mirrorSymbols` removed 
* unused `GenIterableOps` removed
* unused `class DoubleOps`
* `Coll.mapReduce` test fixed (it actually tested `GenIterableOps.mapReduce`)