### PR TITLE
More tests related to ErgoTree versioning

### DIFF
--- a/core/shared/src/main/scala/sigma/VersionContext.scala
+++ b/core/shared/src/main/scala/sigma/VersionContext.scala
@@ -39,8 +39,8 @@ object VersionContext {
   val JitActivationVersion: Byte = 2
 
   private val _defaultContext = VersionContext(
-    activatedVersion = 2/* v5.x */,
-    ergoTreeVersion = 2
+    activatedVersion = 1 /* v4.x */,
+    ergoTreeVersion  = 1
   )
 
   /** Universally accessible version context which is used to version the code

--- a/data/shared/src/main/scala/org/ergoplatform/ErgoAddress.scala
+++ b/data/shared/src/main/scala/org/ergoplatform/ErgoAddress.scala
@@ -165,11 +165,7 @@ class Pay2SHAddress(val scriptHash: Array[Byte])(implicit val encoder: ErgoAddre
       ByteArrayConstant(scriptHash)
     )
     val scriptIsCorrect = DeserializeContext(scriptId, SSigmaProp)
-    // Get script version either from the default context or from a context provided by an application
-    // This is never part of the consensus and can be controlled by applications
-    val treeVersion = VersionContext.current.ergoTreeVersion
-    val header = setVersionBits(ZeroHeader, treeVersion)
-    ErgoTree.withoutSegregation(header, SigmaAnd(hashEquals.toSigmaProp, scriptIsCorrect))
+    ErgoTree.withoutSegregation(ZeroHeader, SigmaAnd(hashEquals.toSigmaProp, scriptIsCorrect))
   }
 
   override def equals(obj: Any): Boolean = obj match {

--- a/sc/shared/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
+++ b/sc/shared/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
@@ -1,6 +1,7 @@
 package org.ergoplatform
 
 import org.ergoplatform.ErgoAddressEncoder.{MainnetNetworkPrefix, TestnetNetworkPrefix, hash256}
+import org.scalatest.propspec.AnyPropSpecLike
 import org.scalatest.{Assertion, TryValues}
 import scorex.crypto.hash.Blake2b256
 import scorex.util.encode.Base58
@@ -29,7 +30,7 @@ import sigma.validation.ValidationRules.CheckTypeCode
 import java.math.BigInteger
 
 class ErgoAddressSpecification extends SigmaDslTesting
-  with TryValues with CompilerCrossVersionProps {
+  with TryValues with CompilerCrossVersionProps with AnyPropSpecLike {
 
   private implicit val ergoAddressEncoder: ErgoAddressEncoder =
     new ErgoAddressEncoder(TestnetNetworkPrefix)
@@ -275,6 +276,16 @@ class ErgoAddressSpecification extends SigmaDslTesting
       Pay2SHAddress(prop)
     }
     address.script.version shouldBe ergoTreeVersionInTests
+  }
+
+  // create non-versioned property which is executed under default version context
+  // see VersionContext._defaultContext
+  // When default version will be upgraded (as part of protocol upgrade) then this test will fail
+  // and will have to be explicitly fixed.
+  super[AnyPropSpecLike].property("using default VersionContext") {
+    val (prop, _) = createPropAndScriptBytes()
+    val address = Pay2SHAddress(prop)
+    address.script.version shouldBe VersionContext.JitActivationVersion
   }
 
   property("negative cases: deserialized script + costing exceptions") {

--- a/sc/shared/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
+++ b/sc/shared/src/test/scala/org/ergoplatform/ErgoAddressSpecification.scala
@@ -269,23 +269,21 @@ class ErgoAddressSpecification extends SigmaDslTesting
     testPay2SHAddress(Pay2SHAddress(tree), scriptBytes) // NOTE: same scriptBytes regardless of ErgoTree version
   }
 
-  property("Pay2SHAddress.script should use VersionContext.current.ergoTreeVersion") {
+  property("Pay2SHAddress.script should create ErgoTree v0") {
     val (prop, _) = createPropAndScriptBytes()
 
     val address = VersionContext.withVersions(activatedVersionInTests, ergoTreeVersionInTests) {
       Pay2SHAddress(prop)
     }
-    address.script.version shouldBe ergoTreeVersionInTests
+    address.script.version shouldBe 0
   }
 
   // create non-versioned property which is executed under default version context
   // see VersionContext._defaultContext
-  // When default version will be upgraded (as part of protocol upgrade) then this test will fail
-  // and will have to be explicitly fixed.
-  super[AnyPropSpecLike].property("using default VersionContext") {
+  super[AnyPropSpecLike].property("using default VersionContext still creates ErgoTree v0") {
     val (prop, _) = createPropAndScriptBytes()
     val address = Pay2SHAddress(prop)
-    address.script.version shouldBe VersionContext.JitActivationVersion
+    address.script.version shouldBe 0
   }
 
   property("negative cases: deserialized script + costing exceptions") {
@@ -309,7 +307,7 @@ class ErgoAddressSpecification extends SigmaDslTesting
     // when everything is ok
     testPay2SHAddress(addr, script = scriptVarId -> ByteArrayConstant(scriptBytes))
 
-    val expectedCost = if (ergoTreeVersionInTests == 0) 88 else 90 // account for size serialized for version > 0
+    val expectedCost = 88
 
     // when limit is low
     {


### PR DESCRIPTION
In this PR:
- added property("Pay2SHAddress.script should create ErgoTree v0")
- added property("using default VersionContext still creates ErgoTree v0")
- Rollback changes in Pay2SHAddress behaviour introduced in v5.0.14-RC
