### PR TITLE
bigInt predefined function

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -12,6 +12,8 @@ import sigma.exceptions.InvalidArguments
 import sigma.serialization.CoreByteWriter.ArgInfo
 import sigma.serialization.ValueSerializer
 
+import java.math.BigInteger
+
 object SigmaPredef {
 
   type IrBuilderFunc = PartialFunction[(SValue, Seq[SValue]), SValue]
@@ -177,6 +179,17 @@ object SigmaPredef {
       }),
       OperationInfo(Constant, "Deserializes values from Base58 encoded binary data at compile time into a value of type T.",
           Seq(ArgInfo("", "")))
+    )
+
+    val BigIntFromStringFunc = PredefinedFunc("bigInt",
+      Lambda(Array("input" -> SString), SBigInt, None),
+      PredefFuncInfo(
+        { case (_, Seq(arg: EvaluatedValue[SString.type]@unchecked)) =>
+          BigIntConstant(new BigInteger(arg.value))
+        }),
+      OperationInfo(Constant,
+        """Parsing string argument as a 256-bit signed big integer.""".stripMargin,
+        Seq(ArgInfo("", "")))
     )
 
     val FromBase16Func = PredefinedFunc("fromBase16",
@@ -402,6 +415,7 @@ object SigmaPredef {
       SigmaPropFunc,
       GetVarFunc,
       DeserializeFunc,
+      BigIntFromStringFunc,
       FromBase16Func,
       FromBase64Func,
       FromBase58Func,

--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -188,7 +188,7 @@ object SigmaPredef {
           BigIntConstant(new BigInteger(arg.value))
         }),
       OperationInfo(Constant,
-        """Parsing string argument as a 256-bit signed big integer.""".stripMargin,
+        """Parsing string literal argument as a 256-bit signed big integer.""".stripMargin,
         Seq(ArgInfo("", "")))
     )
 

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -989,6 +989,12 @@ def proveDlog(value: GroupElement): SigmaProp
   * It is a compile-time operation and only string literal (constant) can be its
   * argument.
   */
+def bigInt(input: String): BigInt
+
+/** Transforms Base16 encoded string literal into constant of type Coll[Byte].
+  * It is a compile-time operation and only string literal (constant) can be its
+  * argument.
+  */
 def fromBase16(input: String): Coll[Byte]
 
 /** Transforms Base58 encoded string literal into constant of type Coll[Byte].

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -985,7 +985,7 @@ def proveDHTuple(g: GroupElement, h: GroupElement,
   */
 def proveDlog(value: GroupElement): SigmaProp
 
-/** Transforms Base16 encoded string literal into constant of type Coll[Byte].
+/** Transforms Base16 encoded string literal into constant of type BigInt.
   * It is a compile-time operation and only string literal (constant) can be its
   * argument.
   */

--- a/parsers/shared/src/test/scala/sigmastate/lang/SigmaParserTest.scala
+++ b/parsers/shared/src/test/scala/sigmastate/lang/SigmaParserTest.scala
@@ -615,6 +615,11 @@ class SigmaParserTest extends AnyPropSpec with ScalaCheckPropertyChecks with Mat
       MethodCallLike(StringConstant("hello"), "+", IndexedSeq(StringConstant("hello")))
   }
 
+  property("bigInt string decoding") {
+    parse("""bigInt("32667486267383620946248345338628674027033885928301927616853987602485119134400")""") shouldBe
+      Apply(BigIntFromStringFunc.symNoType, IndexedSeq(StringConstant("32667486267383620946248345338628674027033885928301927616853987602485119134400")))
+  }
+
   property("fromBaseX string decoding") {
     parse("""fromBase16("1111")""") shouldBe Apply(FromBase16Func.symNoType, IndexedSeq(StringConstant("1111")))
     parse("""fromBase58("111")""") shouldBe Apply(FromBase58Func.symNoType, IndexedSeq(StringConstant("111")))

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -12,6 +12,8 @@ import sigma.ast.{Apply, MethodCall, ZKProofBlock}
 import sigma.exceptions.{GraphBuildingException, InvalidArguments, TyperException}
 import sigma.serialization.ValueSerializer
 import sigma.serialization.generators.ObjectGenerators
+
+import java.math.BigInteger
 import scala.annotation.unused
 
 class SigmaCompilerTest extends CompilerTestingCommons with LangTests with ObjectGenerators {
@@ -125,6 +127,13 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     val code = s"""PK("$encodedP2PK")"""
     val res = comp(code)
     res shouldEqual SigmaPropConstant(dk1)
+  }
+
+  property("bigInt") {
+    comp(""" bigInt("326674862673836209462483453386286740270338859283019276168539876024851191344") """) shouldBe
+      BigIntConstant(new BigInteger("326674862673836209462483453386286740270338859283019276168539876024851191344"))
+    comp(""" bigInt("-10") """) shouldBe
+      BigIntConstant(-10L)
   }
 
   property("fromBaseX") {

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -113,6 +113,7 @@ class SigmaTyperTest extends AnyPropSpec
     typecheck(env, "min(HEIGHT, INPUTS.size)") shouldBe SInt
     typecheck(env, "max(1, 2)") shouldBe SInt
     typecheck(env, "max(1L, 2)") shouldBe SLong
+    typecheck(env, """bigInt("1111")""") shouldBe SBigInt
     typecheck(env, """fromBase16("1111")""") shouldBe SByteArray
     typecheck(env, """fromBase58("111")""") shouldBe SByteArray
     typecheck(env, """fromBase64("111")""") shouldBe SByteArray


### PR DESCRIPTION
This PR contains new ErgoScript predefined function to construct big integer from string.

```
/** Transforms Base16 encoded string literal into constant of type Coll[Byte].
  * It is a compile-time operation and only string literal (constant) can be its
  * argument.
  */
def bigInt(input: String): BigInt
```

example: ` bigInt("326674862673836209462483453386286740270338859283019276168539876024851191344")`