### PR TITLE
Correct environment for Template Compiler

### DIFF
--- a/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
+++ b/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
@@ -105,7 +105,7 @@ object ContractDoc {
  * @param tpe          The type of the parameter.
  * @param defaultValue The default value assigned to the parameter, if it exists.
  */
-case class ContractParam(name: String, tpe: SType, defaultValue: Option[Constant[SType]])
+case class ContractParam(name: String, tpe: SType, defaultValue: Option[SType#WrappedType])
 
 /**
  * Represents the signature of a contract.
@@ -189,7 +189,7 @@ object ContractParser {
 
     def paramDefault[_: P] = P(WL.? ~ `=` ~ WL.? ~ ExprLiteral)
 
-    def param[_: P] = P(WL.? ~ Id.! ~ ":" ~ Type ~ paramDefault.?).map(s => ContractParam(s._1, s._2, s._3))
+    def param[_: P] = P(WL.? ~ Id.! ~ ":" ~ Type ~ paramDefault.?).map(s => ContractParam(s._1, s._2, s._3.map(_.value)))
 
     def params[_: P] = P("(" ~ param.rep(1, ",").? ~ ")")
   }

--- a/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
+++ b/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
@@ -3,7 +3,7 @@ package sigmastate.lang
 import fastparse._
 import fastparse.NoWhitespace._
 import SigmaParser._
-import sigma.ast.SType
+import sigma.ast.{Constant, SType}
 import sigma.ast.syntax.SValue
 import sigmastate.lang.parsers.Basic
 
@@ -105,7 +105,7 @@ object ContractDoc {
  * @param tpe          The type of the parameter.
  * @param defaultValue The default value assigned to the parameter, if it exists.
  */
-case class ContractParam(name: String, tpe: SType, defaultValue: Option[SType#WrappedType])
+case class ContractParam(name: String, tpe: SType, defaultValue: Option[Constant[SType]])
 
 /**
  * Represents the signature of a contract.
@@ -187,7 +187,7 @@ object ContractParser {
 
     def annotation[_: P] = P("@contract")
 
-    def paramDefault[_: P] = P(WL.? ~ `=` ~ WL.? ~ ExprLiteral).map(s => s.asWrappedType)
+    def paramDefault[_: P] = P(WL.? ~ `=` ~ WL.? ~ ExprLiteral)
 
     def param[_: P] = P(WL.? ~ Id.! ~ ":" ~ Type ~ paramDefault.?).map(s => ContractParam(s._1, s._2, s._3))
 

--- a/parsers/shared/src/test/scala/sigmastate/lang/ContractParserSpec.scala
+++ b/parsers/shared/src/test/scala/sigmastate/lang/ContractParserSpec.scala
@@ -34,8 +34,8 @@ class ContractParserSpec extends AnyPropSpec with ScalaCheckPropertyChecks with 
 
     parsed.name shouldBe "contractName"
     parsed.params should contain theSameElementsInOrderAs Seq(
-      ContractParam("p1", SInt, Some(IntConstant(5).asWrappedType)),
-      ContractParam("p2", SString, Some(StringConstant("default string").asWrappedType)),
+      ContractParam("p1", SInt, Some(IntConstant(5))),
+      ContractParam("p2", SString, Some(StringConstant("default string"))),
       ContractParam("param3", SLong, None)
     )
   }

--- a/parsers/shared/src/test/scala/sigmastate/lang/ContractParserSpec.scala
+++ b/parsers/shared/src/test/scala/sigmastate/lang/ContractParserSpec.scala
@@ -3,6 +3,7 @@ package sigmastate.lang
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import sigma.ast.SType.AnyOps
 import sigma.ast._
 
 class ContractParserSpec extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
@@ -34,8 +35,8 @@ class ContractParserSpec extends AnyPropSpec with ScalaCheckPropertyChecks with 
 
     parsed.name shouldBe "contractName"
     parsed.params should contain theSameElementsInOrderAs Seq(
-      ContractParam("p1", SInt, Some(IntConstant(5))),
-      ContractParam("p2", SString, Some(StringConstant("default string"))),
+      ContractParam("p1", SInt, Some(5.asWrappedType)),
+      ContractParam("p2", SString, Some("default string".asWrappedType)),
       ContractParam("param3", SLong, None)
     )
   }

--- a/sc/shared/src/main/scala/sigmastate/lang/SigmaTemplateCompiler.scala
+++ b/sc/shared/src/main/scala/sigmastate/lang/SigmaTemplateCompiler.scala
@@ -50,7 +50,7 @@ class SigmaTemplateCompiler(networkPrefix: Byte) {
       name = parsed.signature.name,
       description = parsed.docs.description,
       constTypes = constTypes.toIndexedSeq,
-      constValues = constValues.map(_.map(_.map(_.value))),
+      constValues = constValues,
       parameters = contractParams.toIndexedSeq,
       expressionTree = expr.toSigmaProp
     )

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaTemplateCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaTemplateCompilerTest.scala
@@ -2,13 +2,14 @@ package sigmastate.lang
 
 import org.ergoplatform.ErgoAddressEncoder
 import org.ergoplatform.sdk.Parameter
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import sigma.ast.{IntConstant, SInt, SLong, SString, StringConstant}
+import sigma.ast.{SBoolean, SInt, SLong, SString}
+import sigma.exceptions.TyperException
 import sigmastate.eval.CompiletimeIRContext
+import sigmastate.interpreter.Interpreter.ScriptEnv
 
-class SigmaTemplateCompilerTest extends AnyPropSpec with ScalaCheckPropertyChecks with Matchers {
+class SigmaTemplateCompilerTest extends AnyPropSpec with ScalaCheckPropertyChecks with LangTests {
   property("compiles full contract template") {
     val source =
       """/** This is my contracts description.
@@ -36,8 +37,8 @@ class SigmaTemplateCompilerTest extends AnyPropSpec with ScalaCheckPropertyCheck
     )
     template.constTypes should contain theSameElementsInOrderAs Seq(SInt, SString, SLong)
     template.constValues.get should contain theSameElementsInOrderAs IndexedSeq(
-      Some(IntConstant(5).asWrappedType),
-      Some(StringConstant("default string").asWrappedType),
+      Some(5),
+      Some("default string"),
       None
     )
 
@@ -73,8 +74,8 @@ class SigmaTemplateCompilerTest extends AnyPropSpec with ScalaCheckPropertyCheck
     )
     template.constTypes should contain theSameElementsInOrderAs Seq(SInt, SString)
     template.constValues.get should contain theSameElementsInOrderAs IndexedSeq(
-      Some(IntConstant(5).asWrappedType),
-      Some(StringConstant("default string").asWrappedType)
+      Some(5),
+      Some("default string")
     )
 
     val sigmaCompiler = new SigmaCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
@@ -83,6 +84,74 @@ class SigmaTemplateCompilerTest extends AnyPropSpec with ScalaCheckPropertyCheck
 
     template.expressionTree shouldBe result.buildTree
   }
+
+  property("uses default value from parameter definition") {
+    val source =
+      """/**/
+        |@contract def contractName(p: Boolean = true) = sigmaProp(p)
+        |""".stripMargin
+    val compiler = SigmaTemplateCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
+    val template = compiler.compile(Map.empty, source)
+
+    template.parameters should contain theSameElementsInOrderAs IndexedSeq(
+      Parameter("p", "", 0),
+    )
+    template.constTypes should contain theSameElementsInOrderAs Seq(SBoolean)
+    template.constValues.get should contain theSameElementsInOrderAs IndexedSeq(
+      Some(true),
+    )
+
+    val sigmaCompiler = new SigmaCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
+    implicit val ir = new CompiletimeIRContext
+    val result = sigmaCompiler.compile(Map("p" -> true), "sigmaProp(p)")
+
+    template.expressionTree shouldBe result.buildTree
+  }
+
+  property("uses given environment when provided (overriding default value)") {
+    val explicitEnv = Map("low" -> 10, "high" -> 100)
+    val source =
+      """/**/
+        |@contract def contractName(low: Int = 0, high: Int) = sigmaProp(low < HEIGHT && HEIGHT < high)
+        |""".stripMargin
+    val compiler = SigmaTemplateCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
+    val template = compiler.compile(explicitEnv, source)
+
+    template.parameters should contain theSameElementsInOrderAs IndexedSeq(
+      Parameter("low", "", 0),
+      Parameter("high", "", 1),
+    )
+    template.constTypes should contain theSameElementsInOrderAs Seq(SInt, SInt)
+    // check parsed default values
+    template.constValues.get should contain theSameElementsInOrderAs IndexedSeq(
+      Some(0),
+      None,
+    )
+
+    val sigmaCompiler = new SigmaCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
+    implicit val ir = new CompiletimeIRContext
+    val result = sigmaCompiler.compile(
+      env = explicitEnv,
+      code = "sigmaProp(low < HEIGHT && HEIGHT < high)"
+    )
+
+    template.expressionTree shouldBe result.buildTree
+  }
+
+  property("fails when constant value in not provided") {
+    // NOTE: parameter `high` without default value */
+    val source      =
+      """/**/
+       |@contract def contractName(low: Int = 0, high: Int) = sigmaProp(low < HEIGHT && HEIGHT < high)
+       |""".stripMargin
+    val compiler    = SigmaTemplateCompiler(ErgoAddressEncoder.MainnetNetworkPrefix)
+    val env: ScriptEnv = Map.empty // no value for "high"
+    assertExceptionThrown(
+      compiler.compile(env, source),
+      exceptionLike[TyperException]("Cannot assign type for variable 'high' because it is not found in env")
+    )
+  }
+
 }
 
 


### PR DESCRIPTION
Closes #966 
In this PR:
- fixed parsing of ContractParam
- default parameter values used to create environment for Compiler
- default env is merged with explicitly provided
- more tests for SigmaTemplateCompiler