### PR TITLE
[6.0]  Common SMethod and MethodCallSerializer new features

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SMethod.scala
+++ b/data/shared/src/main/scala/sigma/ast/SMethod.scala
@@ -63,6 +63,7 @@ case class MethodIRInfo(
   * @param docInfo         optional human readable method description data
   * @param costFunc        optional specification of how the cost should be computed for the
   *                        given method call (See ErgoTreeEvaluator.calcCost method).
+  * @param userDefinedInvoke optional custom method evaluation function
   */
 case class SMethod(
     objType: MethodsContainer,

--- a/data/shared/src/main/scala/sigma/ast/SMethod.scala
+++ b/data/shared/src/main/scala/sigma/ast/SMethod.scala
@@ -50,17 +50,19 @@ case class MethodIRInfo(
 
 /** Represents method descriptor.
   *
-  * @param objType type or type constructor descriptor
-  * @param name    method name
-  * @param stype   method signature type,
-  *                where `stype.tDom`` - argument type and
-  *                `stype.tRange` - method result type.
-  * @param methodId method code, it should be unique among methods of the same objType.
-  * @param costKind cost descriptor for this method
-  * @param irInfo  meta information connecting SMethod with ErgoTree (see [[MethodIRInfo]])
-  * @param docInfo optional human readable method description data
-  * @param costFunc optional specification of how the cost should be computed for the
-  *                 given method call (See ErgoTreeEvaluator.calcCost method).
+  * @param objType         type or type constructor descriptor
+  * @param name            method name
+  * @param stype           method signature type,
+  *                        where `stype.tDom`` - argument type and
+  *                        `stype.tRange` - method result type.
+  * @param methodId        method code, it should be unique among methods of the same objType.
+  * @param costKind        cost descriptor for this method
+  * @param explicitTypeArgs list of type parameters which require explicit
+  *                        serialization in [[MethodCall]]s (i.e for deserialize[T], getVar[T], getReg[T])
+  * @param irInfo          meta information connecting SMethod with ErgoTree (see [[MethodIRInfo]])
+  * @param docInfo         optional human readable method description data
+  * @param costFunc        optional specification of how the cost should be computed for the
+  *                        given method call (See ErgoTreeEvaluator.calcCost method).
   */
 case class SMethod(
     objType: MethodsContainer,
@@ -68,12 +70,18 @@ case class SMethod(
     stype: SFunc,
     methodId: Byte,
     costKind: CostKind,
+    explicitTypeArgs: Seq[STypeVar],
     irInfo: MethodIRInfo,
     docInfo: Option[OperationInfo],
-    costFunc: Option[MethodCostFunc]) {
+    costFunc: Option[MethodCostFunc],
+    userDefinedInvoke: Option[SMethod.InvokeHandler]
+) {
 
   /** Operation descriptor of this method. */
   lazy val opDesc = MethodDesc(this)
+
+  /** Return true if this method has runtime type parameters */
+  def hasExplicitTypeArgs: Boolean = explicitTypeArgs.nonEmpty
 
   /** Finds and keeps the [[RMethod]] instance which corresponds to this method descriptor.
     * The lazy value is forced only if irInfo.javaMethod == None
@@ -106,7 +114,12 @@ case class SMethod(
   /** Invoke this method on the given object with the arguments.
     * This is used for methods with FixedCost costKind. */
   def invokeFixed(obj: Any, args: Array[Any]): Any = {
-    javaMethod.invoke(obj, args.asInstanceOf[Array[AnyRef]]:_*)
+    userDefinedInvoke match {
+      case Some(h) =>
+        h(this, obj, args)
+      case None =>
+        javaMethod.invoke(obj, args.asInstanceOf[Array[AnyRef]]:_*)
+    }
   }
 
   // TODO optimize: avoid lookup when this SMethod is created via `specializeFor`
@@ -144,6 +157,11 @@ case class SMethod(
       throw new RuntimeException(s"Cannot find eval method def $methodName(${Seq(paramTypes:_*)})", e)
     }
     m
+  }
+
+  /** Create a new instance with the given user-defined invoke handler. */
+  def withUserDefinedInvoke(handler: SMethod.InvokeHandler): SMethod = {
+    copy(userDefinedInvoke = Some(handler))
   }
 
   /** Create a new instance with the given stype. */
@@ -255,6 +273,12 @@ object SMethod {
     */
   type InvokeDescBuilder = SFunc => Seq[SType]
 
+  /** Type of user-defined function which is called to handle method invocation.
+    * Instances of this type can be attached to [[SMethod]] instances.
+    * @see SNumericTypeMethods.ToBytesMethod
+    */
+  type InvokeHandler = (SMethod, Any, Array[Any]) => Any
+
   /** Return [[Method]] descriptor for the given `methodName` on the given `cT` type.
     * @param methodName the name of the method to lookup
     * @param cT the class where to search the methodName
@@ -284,10 +308,12 @@ object SMethod {
   /** Convenience factory method. */
   def apply(objType: MethodsContainer, name: String, stype: SFunc,
       methodId: Byte,
-      costKind: CostKind): SMethod = {
+      costKind: CostKind,
+      explicitTypeArgs: Seq[STypeVar] = Nil
+  ): SMethod = {
     SMethod(
-      objType, name, stype, methodId, costKind,
-      MethodIRInfo(None, None, None), None, None)
+      objType, name, stype, methodId, costKind, explicitTypeArgs,
+      MethodIRInfo(None, None, None), None, None, None)
   }
 
 

--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
@@ -139,7 +139,8 @@ class SigmaTyper(val builder: SigmaBuilder,
       obj.tpe match {
         case p: SProduct =>
           MethodsContainer.getMethod(p, n) match {
-            case Some(method @ SMethod(_, _, genFunTpe @ SFunc(_, _, _), _, _, _, _, _)) =>
+            case Some(method: SMethod) =>
+              val genFunTpe = method.stype
               val subst = Map(genFunTpe.tpeParams.head.ident -> rangeTpe)
               val concrFunTpe = applySubst(genFunTpe, subst)
               val expectedArgs = concrFunTpe.asFunc.tDom.tail
@@ -511,6 +512,7 @@ class SigmaTyper(val builder: SigmaBuilder,
     case v: SigmaBoolean => v
     case v: Upcast[_, _] => v
     case v @ Select(_, _, Some(_)) => v
+    case v @ MethodCall(_, _, _, _) => v
     case v =>
       error(s"Don't know how to assignType($v)", v.sourceContext)
   }).ensuring(v => v.tpe != NoType,


### PR DESCRIPTION
This PR contains new features in SMethod and MethodCallSerialize, extracted from #979, #984, #989

* SMethod - new arguments, `explicitTypeArgs` and `userDefinedInvoke`
* MethodCallSerializer - support for polymorphic calls serialization
