### PR TITLE
[sigma-js] Add missing reflection metadata

### DIFF
--- a/core/jvm/src/main/scala/sigma/reflection/Platform.scala
+++ b/core/jvm/src/main/scala/sigma/reflection/Platform.scala
@@ -28,7 +28,7 @@ object Platform {
     // Should be used only for debugging and never in production.
 //    /** Check class registration. Should be used only for debugging. */
 //    def checkRegisteredClass[T](clazz: Class[T]): Unit = {
-//      CommonReflection.classes.get(clazz) match {
+//      ReflectionData.classes.get(clazz) match {
 //        case Some(c) =>
 //          assert(c.clazz == clazz)
 //        case _ =>

--- a/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
+++ b/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
@@ -33,7 +33,7 @@ object ReflectionData {
     */
   def registerClassEntry[T](clazz: Class[T],
                             constructors: Seq[SRConstructor[_]] = ArraySeq.empty,
-                            fields: Map[String, SRField] = Map.empty,
+                            fields: Map[String, RField] = Map.empty,
                             methods: Map[(String, Seq[Class[_]]), RMethod] = Map.empty): Unit = classes.synchronized {
     classes.put(clazz, new SRClass(clazz, constructors, fields, methods))
   }

--- a/core/shared/src/main/scala/sigma/reflection/StaticImpl.scala
+++ b/core/shared/src/main/scala/sigma/reflection/StaticImpl.scala
@@ -5,17 +5,18 @@ package sigma.reflection
   * Extends [[RField]] by providing a concrete implementation without relying on Java reflection.
   * The instances of this class are used as parameters of `registerClassEntry` method.
   *
+  * @param declaringClass the class that declares the field
   * @param name the name of the field
   * @param tpe the type of the field as runtime [[java.lang.Class]]
   */
-class SRField(val name: String, tpe: Class[_]) extends RField {
+class SRField(val declaringClass: Class[_], val name: String, tpe: Class[_]) extends RField {
   override def getType: Class[_] = tpe
 
   override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
-    case that: SRField => name == that.name
+    case that: SRField => declaringClass == that.declaringClass && name == that.name
     case _ => false
   })
-  override def hashCode(): Int = name.hashCode()
+  override def hashCode(): Int = 31 * name.hashCode() + declaringClass.hashCode()
 }
 
 /** Represents a constructor in an Sigma Reflection metadata.
@@ -60,7 +61,7 @@ abstract class SRMethod(declaringClass: Class[_], name: String, parameterTypes: 
   */
 class SRClass[T](val clazz: Class[T],
                  constructors: Seq[SRConstructor[_]],
-                 fields: Map[String, SRField],
+                 fields: Map[String, RField],
                  methods: Map[(String, Seq[Class[_]]), RMethod]) extends RClass[T] {
 
   override def getField(fieldName: String): RField = fields.get(fieldName) match {

--- a/core/shared/src/main/scala/sigma/reflection/package.scala
+++ b/core/shared/src/main/scala/sigma/reflection/package.scala
@@ -32,6 +32,20 @@ package object reflection {
     }
   }
 
+  /** Creates a new SRField instance with the given parameters and handler function.
+    * This is analogous to the Java Reflection API's [[java.lang.reflect.Field]] class.
+    *
+    * @param clazz      the [[java.lang.Class]] that declares the field
+    * @param name       the name of the field
+    * @param fieldType  the type of the field value
+    * @return a tuple containing the field's name  as its first element,
+    *         and an SRField instance as its second element
+    * @see [[SRField]]
+    */
+  def mkField(clazz: Class[_], name: String, fieldType: Class[_]): (String, RField) = {
+    name -> new SRField(clazz, name, fieldType)
+  }
+
   /** Creates a new SRMethod instance with the given parameters and handler function.
     * This is analogous to the Java Reflection API's [[java.lang.reflect.Method]] class.
     *

--- a/core/shared/src/main/scala/sigma/reflection/package.scala
+++ b/core/shared/src/main/scala/sigma/reflection/package.scala
@@ -32,7 +32,7 @@ package object reflection {
     }
   }
 
-  /** Creates a new SRField instance with the given parameters and handler function.
+  /** Creates a new SRField instance with the given parameters.
     * This is analogous to the Java Reflection API's [[java.lang.reflect.Field]] class.
     *
     * @param clazz      the [[java.lang.Class]] that declares the field

--- a/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
+++ b/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
@@ -701,49 +701,49 @@ object SigmaDataReflection {
     )
   )
 
-  { val clazz = classOf[sigma.ast.Global.type]
+  { val clazz = sigma.ast.Global.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[sigma.ast.GroupGenerator.type]
+  { val clazz = sigma.ast.GroupGenerator.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[Height.type]
+  { val clazz = Height.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[sigma.ast.Inputs.type]
+  { val clazz = sigma.ast.Inputs.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[sigma.ast.LastBlockUtxoRootHash.type]
+  { val clazz = sigma.ast.LastBlockUtxoRootHash.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[MinerPubkey.type]
+  { val clazz = MinerPubkey.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[sigma.ast.Outputs.type]
+  { val clazz = sigma.ast.Outputs.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )
   }
 
-  { val clazz = classOf[sigma.ast.Self.type]
+  { val clazz = sigma.ast.Self.getClass
     registerClassEntry(clazz,
       fields = Map( mkField(clazz, "MODULE$", clazz) )
     )

--- a/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
+++ b/data/shared/src/main/scala/sigma/SigmaDataReflection.scala
@@ -7,7 +7,7 @@ import sigma.ast.syntax._
 import sigma.data.KeyValueColl
 import sigma.eval.ErgoTreeEvaluator
 import sigma.reflection.ReflectionData.registerClassEntry
-import sigma.reflection.{ReflectionData, mkConstructor, mkMethod}
+import sigma.reflection.{ReflectionData, mkConstructor, mkField, mkMethod}
 import sigma.serialization.ValueCodes.OpCode
 
 /** Reflection metadata for `interpreter` module.
@@ -633,6 +633,134 @@ object SigmaDataReflection {
       mkConstructor(Array(classOf[Value[_]], classOf[Value[_]], classOf[Value[_]])) { args =>
         new Slice(args(0).asInstanceOf[CollectionValue[SType]],
           args(1).asInstanceOf[IntValue], args(2).asInstanceOf[IntValue])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[GetVar[_]],
+    constructors = Array(
+      mkConstructor(Array(classOf[Byte], classOf[SOption[_]])) { args =>
+        new GetVar[SType](args(0).asInstanceOf[Byte], args(1).asInstanceOf[SOption[SType]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[LongToByteArray],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new LongToByteArray(args(0).asInstanceOf[Value[SLong.type]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[ValUse[_]],
+    constructors = Array(
+      mkConstructor(Array(classOf[Int], classOf[SType])) { args =>
+        new ValUse(args(0).asInstanceOf[Int], args(1).asInstanceOf[SType])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[ByteArrayToLong],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new ByteArrayToLong(args(0).asInstanceOf[Value[SByteArray]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[ConstantNode[_]],
+    constructors = Array(
+      mkConstructor(Array(classOf[java.lang.Object], classOf[SType])) { args =>
+        ConstantNode(args(0).asInstanceOf[SType#WrappedType], args(1).asInstanceOf[SType])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[CreateProveDlog],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new CreateProveDlog(args(0).asInstanceOf[Value[SGroupElement.type]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[DecodePoint],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new DecodePoint(args(0).asInstanceOf[Value[SByteArray]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[ExtractBytes],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new ExtractBytes(args(0).asInstanceOf[Value[SBox.type]])
+      }
+    )
+  )
+
+  { val clazz = classOf[sigma.ast.Global.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[sigma.ast.GroupGenerator.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[Height.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[sigma.ast.Inputs.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[sigma.ast.LastBlockUtxoRootHash.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[MinerPubkey.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[sigma.ast.Outputs.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  { val clazz = classOf[sigma.ast.Self.type]
+    registerClassEntry(clazz,
+      fields = Map( mkField(clazz, "MODULE$", clazz) )
+    )
+  }
+
+  registerClassEntry(classOf[Xor],
+    constructors = Array(
+      mkConstructor(Array(classOf[ast.Value[_]], classOf[ast.Value[_]])) { args =>
+        new Xor(args(0).asInstanceOf[Value[SByteArray]], args(1).asInstanceOf[Value[SByteArray]])
+      }
+    )
+  )
+
+  registerClassEntry(classOf[XorOf],
+    constructors = Array(
+      mkConstructor(Array(classOf[Value[_]])) { args =>
+        new XorOf(args(0).asInstanceOf[Value[SCollection[SBoolean.type]]])
       }
     )
   )

--- a/sc/shared/src/test/scala/sigma/SigmaDslSpecification.scala
+++ b/sc/shared/src/test/scala/sigma/SigmaDslSpecification.scala
@@ -93,7 +93,11 @@ class SigmaDslSpecification extends SigmaDslTesting
 
     profilerOpt = Some(CErgoTreeEvaluator.DefaultProfiler),
     isTestRun = true
+    // isDebug = true  uncomment to enable debug mode
   )
+
+  /** Set this to true to enable debug console output in tests */
+  override val printDebugInfo: Boolean = false
 
   def warmupSettings(p: Profiler) = evalSettingsInTests.copy(
     isLogEnabled = false,
@@ -10015,9 +10019,18 @@ class SigmaDslSpecification extends SigmaDslTesting
   }
 
   override protected def afterAll(): Unit = {
-    printDebug(CErgoTreeEvaluator.DefaultProfiler.generateReport)
+    printDebug(CErgoTreeEvaluator.DefaultProfiler.generateReport())
     printDebug("==========================================================")
-    printDebug(Interpreter.verifySignatureProfiler.generateReport)
+    printDebug(Interpreter.verifySignatureProfiler.generateReport())
     printDebug("==========================================================")
+
+// Uncomment to print reflection metadata for missing classes and methods.
+// Make sure also:
+// - this.printDebugInfo is set to true
+// - Debug code in Platform.resolveClass is also uncommented
+// Note, ReflectionGenerator is only available on JVM, so the line below should be
+// commented back to run tests on JS.
+//    printDebug(ReflectionGenerator.generateReport())
+//    printDebug("==========================================================")
   }
 }

--- a/sc/shared/src/test/scala/sigmastate/helpers/CompilerTestingCommons.scala
+++ b/sc/shared/src/test/scala/sigmastate/helpers/CompilerTestingCommons.scala
@@ -17,6 +17,8 @@ import sigma.compiler.ir.IRContext
 import sigma.eval.{CostDetails, EvalSettings, Extensions, GivenCost, TracedCost}
 import sigmastate.helpers.TestingHelpers._
 import sigma.interpreter.ContextExtension.VarBinding
+import sigma.kiama.rewriting.Rewriter
+import sigma.kiama.rewriting.Rewriter.{everywherebu, strategy}
 import sigmastate.interpreter.CErgoTreeEvaluator.DefaultProfiler
 import sigmastate.interpreter.Interpreter.ScriptEnv
 import sigmastate.interpreter._
@@ -160,6 +162,11 @@ trait CompilerTestingCommons extends TestingCommons
         printCostDetails(funcScript, costDetails)
       }
       (res.value, costDetails)
+    }
+    if (evalSettings.isDebug) {
+      // Deep clone expr using kiama. This is to make sure JS reflection works correctly.
+      val copyRule = strategy[Any] { case x: SValue => Some(Rewriter.copy(x)) }
+      val Some(copy) = everywherebu(copyRule)(expr)
     }
     val sigma.ast.Apply(funcVal, _) = expr.asInstanceOf[SValue]
     CompiledFunc(funcScript, bindings, funcVal, expr, f)


### PR DESCRIPTION
In this PR:
- missing classes registered 
- Scala objects that are used reflectively (in Kiama rewriting) declared with MODULE$ field
- additional sanity check added in isDebug mode in SigmaDslSpecification