### PR TITLE
Revise all error messages adopting usability pattern 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,9 @@ lazy val commonSettings = Seq(
         Seq("-Ywarn-unused:_,imports", "-Ywarn-unused:imports", "-release", "8")
       case Some((2, 11)) =>
         Seq()
-      case _ => sys.error("Unsupported scala version")
+      case _ => sys.error("The Scala version you are using is not supported. " +
+        "Please use one of the supported versions: Scala 2.11, 2.12, or 2.13. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
   },
   javacOptions ++= javacReleaseOption,

--- a/core/js/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/js/src/main/scala/sigma/crypto/Platform.scala
@@ -246,7 +246,9 @@ object Platform {
     case c: Coll[_] => tpe match {
       case STuple(items) => c.tItem == sigma.AnyType && c.length == items.length
       case tpeColl: SCollection[_] => true
-      case _ => sys.error(s"Collection value $c has unexpected type $tpe")
+      case _ => sys.error(s"The value in the collection $c is not the correct type: $tpe. " +
+        "Please make sure the value is of the correct type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
     case _: Option[_] => tpe.isOption
     case _: Tuple2[_, _] => tpe.isTuple && tpe.asTuple.items.length == 2

--- a/core/js/src/main/scala/sigma/reflection/Platform.scala
+++ b/core/js/src/main/scala/sigma/reflection/Platform.scala
@@ -19,7 +19,9 @@ object Platform {
         assert(c.clazz == clazz)
         c
       case _ =>
-        sys.error(s"Cannot find RClass data for $clazz")
+        sys.error(s"We couldn't find the data for class $clazz. " +
+          "Please check that the class name is correct and try again. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       // Uncomment the following line to collect missing reflection data and generate Scala code for it
       //        memoize(classes)(clazz, new JRClass[T](clazz))
     }

--- a/core/jvm/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/Platform.scala
@@ -175,7 +175,9 @@ object Platform {
     case c: Coll[_] => tpe match {
       case STuple(items) => c.tItem == sigma.AnyType && c.length == items.length
       case _: SCollection[_] => true
-      case _ => sys.error(s"Collection value $c has unexpected type $tpe")
+      case _ => sys.error(s"The value in the collection $c is not the correct type: $tpe. " +
+        "Please make sure the value is of the correct type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
     case _: Option[_] => tpe.isOption
     case _: Tuple2[_, _] => tpe.isTuple && tpe.asTuple.items.length == 2

--- a/core/shared/src/main/scala/sigma/Evaluation.scala
+++ b/core/shared/src/main/scala/sigma/Evaluation.scala
@@ -51,7 +51,9 @@ object Evaluation {
       val tpeArg = args(0)
       funcRType(stypeToRType(tpeArg), stypeToRType(tpeRange))
     case _ =>
-      sys.error(s"Don't know how to convert SType $t to RType")
+      sys.error(s"We couldn't process the type $t. " +
+        "Please ensure that $t is compatible with the expected type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }).asInstanceOf[RType[T#WrappedType]]
 
   /** Transforms RType descriptor of SigmaDsl, which is used during evaluation,
@@ -82,7 +84,9 @@ object Evaluation {
     case ct: CollType[_] => SCollection(rtypeToSType(ct.tItem))
     case ft: FuncType[_,_] => SFunc(rtypeToSType(ft.tDom), rtypeToSType(ft.tRange))
     case pt: PairType[_,_] => STuple(rtypeToSType(pt.tFst), rtypeToSType(pt.tSnd))
-    case _ => sys.error(s"Don't know how to convert RType $t to SType")
+    case _ => sys.error(s"We couldn't process the type $t. " +
+      "Please ensure that $t is compatible with the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
   /** Convert SigmaDsl representation of tuple to ErgoTree serializable representation. */
@@ -90,7 +94,9 @@ object Evaluation {
     case t: Tuple2[_,_] => TupleColl(t._1, t._2)
     case a: Coll[Any]@unchecked if a.tItem == sigma.AnyType => a
     case _ =>
-      sys.error(s"Cannot execute fromDslTuple($value, $tupleTpe)")
+      sys.error(s"Failed to process the value $value with type $tupleTpe. " +
+        "Please make sure the value is the correct type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
   /** Convert ErgoTree serializable representation of tuple to SigmaDsl representation. */

--- a/core/shared/src/main/scala/sigma/ast/SType.scala
+++ b/core/shared/src/main/scala/sigma/ast/SType.scala
@@ -163,17 +163,23 @@ object SType {
     case _: SOption[_] => x.isInstanceOf[Option[_]]
     case t: STuple =>
       if (t.items.length == 2) x.isInstanceOf[Tuple2[_,_]]
-      else sys.error(s"Unsupported tuple type $t")
+      else sys.error(s"The type $t is not supported. " +
+        "Please make sure you are using a valid type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     case tF: SFunc =>
       if (tF.tDom.length == 1) x.isInstanceOf[Function1[_,_]]
-      else sys.error(s"Unsupported function type $tF")
+      else sys.error(s"The type $tF is not supported. " +
+        "Please make sure you are using a valid type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     case SContext => x.isInstanceOf[Context]
     case SAvlTree => x.isInstanceOf[AvlTree]
     case SGlobal => x.isInstanceOf[SigmaDslBuilder]
     case SHeader => x.isInstanceOf[Header]
     case SPreHeader => x.isInstanceOf[PreHeader]
     case SUnit => x.isInstanceOf[Unit]
-    case _ => sys.error(s"Unknown type $tpe")
+    case _ => sys.error(s"We don't recognize the type $tpe. " +
+      "Please check the type and make sure it is correct. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
 
@@ -346,7 +352,9 @@ object SNumericType extends STypeCompanion {
   override def typeId: TypeCode = 106: Byte
 
   /** Since this object is not used in SMethod instances. */
-  override def reprClass: RClass[_] = sys.error(s"Shouldn't be called.")
+  override def reprClass: RClass[_] = sys.error("Please avoid using the reprClass method. " +
+    "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
+
 }
 
 /** Descriptor of ErgoTree type `Boolean` holding `true` or `false` values. */
@@ -368,14 +376,19 @@ case object SByte extends SPrimType with SEmbeddable with SNumericType with SMon
   override def numericTypeIndex: Int = 0
   override def upcast(v: AnyVal): Byte = v match {
     case b: Byte => b
-    case _ => sys.error(s"Cannot upcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
+
   }
   override def downcast(v: AnyVal): Byte = v match {
     case b: Byte => b
     case s: Short => s.toByteExact
     case i: Int => i.toByteExact
     case l: Long => l.toByteExact
-    case _ => sys.error(s"Cannot downcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 
@@ -390,13 +403,17 @@ case object SShort extends SPrimType with SEmbeddable with SNumericType with SMo
   override def upcast(v: AnyVal): Short = v match {
     case x: Byte => x.toShort
     case x: Short => x
-    case _ => sys.error(s"Cannot upcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
   override def downcast(v: AnyVal): Short = v match {
     case s: Short => s
     case i: Int => i.toShortExact
     case l: Long => l.toShortExact
-    case _ => sys.error(s"Cannot downcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 
@@ -412,14 +429,18 @@ case object SInt extends SPrimType with SEmbeddable with SNumericType with SMono
     case x: Byte => x.toInt
     case x: Short => x.toInt
     case x: Int => x
-    case _ => sys.error(s"Cannot upcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
   override def downcast(v: AnyVal): Int = v match {
     case b: Byte => b.toInt
     case s: Short => s.toInt
     case i: Int => i
     case l: Long => l.toIntExact
-    case _ => sys.error(s"Cannot downcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 
@@ -437,14 +458,18 @@ case object SLong extends SPrimType with SEmbeddable with SNumericType with SMon
     case x: Short => x.toLong
     case x: Int => x.toLong
     case x: Long => x
-    case _ => sys.error(s"Cannot upcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
   override def downcast(v: AnyVal): Long = v match {
     case b: Byte => b.toLong
     case s: Short => s.toLong
     case i: Int => i.toLong
     case l: Long => l
-    case _ => sys.error(s"Cannot downcast value $v to the type $this")
+    case _ => sys.error(s"We cannot convert value $v to type $this. " +
+      "Please check compatibility between the value and the expected type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 
@@ -470,7 +495,9 @@ case object SBigInt extends SPrimType with SEmbeddable with SNumericType with SM
       case x: Short => BigInteger.valueOf(x.toLong)
       case x: Int => BigInteger.valueOf(x.toLong)
       case x: Long => BigInteger.valueOf(x)
-      case _ => sys.error(s"Cannot upcast value $v to the type $this")
+      case _ => sys.error(s"We cannot convert value $v to type $this. " +
+        "Please check compatibility between the value and the expected type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
     CBigInt(bi)
   }
@@ -480,7 +507,9 @@ case object SBigInt extends SPrimType with SEmbeddable with SNumericType with SM
       case x: Short => BigInteger.valueOf(x.toLong)
       case x: Int => BigInteger.valueOf(x.toLong)
       case x: Long => BigInteger.valueOf(x)
-      case _ => sys.error(s"Cannot downcast value $v to the type $this")
+      case _ => sys.error(s"We cannot convert value $v to type $this. " +
+        "Please check compatibility between the value and the expected type. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
     CBigInt(bi)
   }

--- a/core/shared/src/main/scala/sigma/data/CSigmaProp.scala
+++ b/core/shared/src/main/scala/sigma/data/CSigmaProp.scala
@@ -15,7 +15,9 @@ case class CSigmaProp(sigmaTree: SigmaBoolean) extends SigmaProp with WrapperOf[
   // TODO refactor: remove this (it shouldn't be used in interpreter)
   override def isValid: Boolean = sigmaTree match {
     case p: TrivialProp => p.condition
-    case _ => sys.error(s"Method CostingSigmaProp.isValid is not defined for $sigmaTree")
+    case _ => sys.error(s"The method CostingSigmaProp.isValid does not apply to $sigmaTree. " +
+      "Please make sure to use the correct method for $sigmaTree. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
   override def propBytes: Coll[Byte] = {

--- a/core/shared/src/main/scala/sigma/kiama/rewriting/Rewriter.scala
+++ b/core/shared/src/main/scala/sigma/kiama/rewriting/Rewriter.scala
@@ -248,7 +248,9 @@ trait Rewriter {
           case _ : NoSuchFieldException =>
             val ctors = clazz.getConstructors
             if (ctors.length == 0)
-              sys.error(s"dup no constructors for ${clazz.getName}")
+              sys.error(s"No constructors found for ${clazz.getName}. " +
+                "Please ensure the class has accessible constructors. " +
+                "If the problem persists, reach out to <a href=\"#\">Customer Care</a> for assistance.")
             else
               (_ : Any, children : Array[AnyRef]) =>
                 makeInstance(ctors(0), children)
@@ -260,8 +262,10 @@ trait Rewriter {
           ctor.newInstance(unboxPrimitives(ctor, children) : _*)
         } catch {
           case _ : IllegalArgumentException =>
-            sys.error(s"""dup illegal arguments: $ctor got (${children.mkString(",")})
-                        |Common cause: term classes are nested in another class, move them to the top level""".stripMargin)
+            sys.error(s"The function $ctor received the same arguments more than once: ${children.mkString(", ")}. " +
+              "This usually happens when functions or methods are inside another class. " +
+              "Try moving them outside the class to fix the problem. " +
+              "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
         }
 
       /** Unbox primitive values in the given array of children using type information of
@@ -620,7 +624,9 @@ trait Rewriter {
                 b += ti
                 false
               case Some(ti) =>
-                sys.error(s"oneMap: got non-pair $ti")
+                sys.error(s"We received a non-key-value pair ($ti) in the oneMap function. " +
+                  "Please ensure all inputs to oneMap are in key-value pair format. " +
+                  "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
               case None =>
                 b += ct
                 true

--- a/core/shared/src/main/scala/sigma/kiama/util/Comparison.scala
+++ b/core/shared/src/main/scala/sigma/kiama/util/Comparison.scala
@@ -42,7 +42,9 @@ object Comparison {
         case (r1 : AnyRef, r2 : AnyRef) =>
           r1 eq r2
         case _ =>
-          sys.error(s"same: comparison of $v1 and $v2, should not be reached")
+          sys.error(s"An unexpected issue occurred with the values $v1 and $v2. " +
+            "This should not happen during regular use. " +
+            "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       }
 
   /**

--- a/core/shared/src/main/scala/sigma/serialization/CoreDataSerializer.scala
+++ b/core/shared/src/main/scala/sigma/serialization/CoreDataSerializer.scala
@@ -63,7 +63,9 @@ class CoreDataSerializer {
       val len = arr.length
       assert(arr.length == t.items.length, s"Type $t doesn't correspond to value $arr")
       if (len > 0xFFFF)
-        sys.error(s"Length of tuple ${arr.length} exceeds ${0xFFFF} limit.")
+        sys.error(s"The tuple length (${arr.length}) is too long (maximum limit is ${0xFFFF}). " +
+          "Please shorten the tuple to meet the limit. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       var i = 0
       while (i < arr.length) {
         serialize[SType](arr(i), t.items(i), w)

--- a/core/shared/src/main/scala/sigma/serialization/TypeSerializer.scala
+++ b/core/shared/src/main/scala/sigma/serialization/TypeSerializer.scala
@@ -85,7 +85,9 @@ class TypeSerializer {
         serialize(t2, w)
     }
     case STuple(items) if items.length < 2 =>
-      sys.error(s"Invalid Tuple type with less than 2 items $items")
+      sys.error(s"The Tuple with fewer than 2 items ($items) is invalid. " +
+        "Please ensure tuples contain at least 2 items for proper functionality. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     case tup: STuple => tup.items.length match {
       case 3 =>
         // Triple of types

--- a/data/shared/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
+++ b/data/shared/src/main/scala/org/ergoplatform/ErgoBoxCandidate.scala
@@ -151,7 +151,9 @@ object ErgoBoxCandidate {
         val amount = amounts(i)
         if (tokensInTx.isDefined) {
           val tokenIndex = tokensInTx.get.indexWhere(_ == id, 0) // using equality on Coll
-          if (tokenIndex == -1) sys.error(s"failed to find token id ($id) in tx's digest index")
+          if (tokenIndex == -1) sys.error(s"Token ID ($id) not found in the transaction's digest index. " +
+            "Please check the token ID and try again. " +
+            "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
           w.putUInt(tokenIndex)
         } else {
           w.putBytes(id.toArray)
@@ -161,7 +163,9 @@ object ErgoBoxCandidate {
 
       val nRegs = box.additionalRegisters.keys.size
       if (nRegs + ErgoBox.startingNonMandatoryIndex > 255)
-        sys.error(s"The number of non-mandatory indexes $nRegs exceeds ${255 - ErgoBox.startingNonMandatoryIndex} limit.")
+        sys.error(s"The number of non-mandatory indexes ($nRegs) exceeds the maximum limit (${255 - ErgoBox.startingNonMandatoryIndex}). " +
+          "Please decrease the number of non-mandatory indexes to stay within the limit. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       w.putUByte(nRegs)
       // we assume non-mandatory indexes are densely packed from startingNonMandatoryIndex
       // this convention allows to save 1 bite for each register
@@ -173,8 +177,9 @@ object ErgoBoxCandidate {
           case Some(v) =>
             w.putValue(v)
           case None =>
-            sys.error(s"Set of non-mandatory indexes is not densely packed: " +
-              s"register R$regId is missing in the range [$startReg .. $endReg]")
+            sys.error(s"The non-mandatory indexes are not densely packed: register R$regId is missing in the range [$startReg .. $endReg]. " +
+              "Please fill all registers in this range sequentially. " +
+              "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
         }
       }
     }
@@ -207,7 +212,9 @@ object ErgoBoxCandidate {
           // in v4.x r.getUInt().toInt is used and may return negative Int in which case
           // the error below is thrown
           if (digestIndex < 0 || digestIndex >= nDigests)
-            sys.error(s"failed to find token id with index $digestIndex")
+            sys.error(s"We couldn't find the token ID linked to the index $digestIndex. " +
+              "Please make sure the index value is correct. " +
+              "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
           val amount = r.getULong()           // READ
           tokenIds(i) = digestsInTx(digestIndex)
           tokenAmounts(i) = amount

--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -153,7 +153,9 @@ object SigmaPredef {
         { case (_, Seq(arg: EvaluatedValue[SString.type]@unchecked)) =>
           ErgoAddressEncoder(networkPrefix).fromString(arg.value).get match {
             case a: P2PKAddress => SigmaPropConstant(a.pubkey)
-            case a => sys.error(s"unsupported address $a")
+            case a => sys.error(s"The address $a is not supported. " +
+              "Please make sure the address is correct and try again. " +
+              "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
           }
         }),
       OperationInfo(Constant, "",
@@ -165,16 +167,22 @@ object SigmaPredef {
       PredefFuncInfo(
       { case (Ident(_, SFunc(_, tpe, _)), args) =>
         if (args.length != 1)
-          throw new InvalidArguments(s"Wrong number of arguments in $args: expected one argument")
+          throw new InvalidArguments(s"The provided inputs ($args) are incorrect. This operation requires only one input. " +
+            "Please adjust your input to include just one item and try again. " +
+            "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
         val str = args.head match {
           case StringConstant(s) => s
           case _ =>
-            throw new InvalidArguments(s"invalid argument in $args: expected a string constant")
+            throw new InvalidArguments(s"The input provided ($args) is invalid. This operation requires a text value. " +
+              "Please make sure the input is a valid text and try again. " +
+              "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
         }
         val bytes = Base58.decode(str).get
         val res = ValueSerializer.deserialize(bytes)
         if (res.tpe != tpe)
-          throw new InvalidArguments(s"Wrong type after deserialization, expected $tpe, got ${res.tpe}")
+          throw new InvalidArguments(s"The data type is incorrect. Expected: $tpe, but received: ${res.tpe}. " +
+            "Please make sure the data matches the expected type. " +
+            "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
         res
       }),
       OperationInfo(Constant, "Deserializes values from Base58 encoded binary data at compile time into a value of type T.",

--- a/data/shared/src/main/scala/sigma/ast/syntax.scala
+++ b/data/shared/src/main/scala/sigma/ast/syntax.scala
@@ -58,7 +58,9 @@ object syntax {
     def length: Int = matchCase(_.items.length, _.value.length, _.items.length)
 
     /** Returns a sequence of items in the collection expression. */
-    def items: Seq[Value[SType]] = matchCase(_.items, _ => sys.error(s"Cannot get 'items' property of node $coll"), _.items)
+    def items: Seq[Value[SType]] = matchCase(_.items, _ => sys.error(s"Cannot access the 'items' property of node $coll. " +
+      "Please ensure the node is properly initialized and includes the 'items' property. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."), _.items)
 
     /** Abstracts from details of pattern matching collection expressions.
       * Folds over given `coll` structure.
@@ -71,7 +73,9 @@ object syntax {
       case cc: ConcreteCollection[T]@unchecked => whenConcrete(cc)
       case const: CollectionConstant[T]@unchecked => whenConstant(const)
       case tuple: Tuple => whenTuple(tuple)
-      case _ => sys.error(s"Unexpected node $coll")
+      case _ => sys.error(s"We found an unexpected element: $coll. " +
+        "Please review your input for errors or unsupported elements. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
   }
 

--- a/data/shared/src/main/scala/sigma/ast/transformers.scala
+++ b/data/shared/src/main/scala/sigma/ast/transformers.scala
@@ -289,7 +289,9 @@ case class SelectField(input: Value[STuple], fieldIndex: Byte)
       case p: Tuple2[_,_] =>
         if (fieldIndex == 1) p._1
         else if (fieldIndex == 2) p._2
-        else sys.error(s"Unknown fieldIndex $fieldIndex to select from $p: evaluating tree $this")
+        else sys.error(s"We found an unknown field index ($fieldIndex) while trying to select from $p in the structure evaluation. " +
+          "Please check that the field index is correct. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       case _ =>
         Value.typeError(input, inputV)
     }

--- a/data/shared/src/main/scala/sigma/ast/trees.scala
+++ b/data/shared/src/main/scala/sigma/ast/trees.scala
@@ -881,7 +881,9 @@ object ArithOp {
   /** Returns operation name for the given opCode. */
   def opcodeToArithOpName(opCode: Byte): String = operations.get(opCode) match {
     case Some(c)  => c.name
-    case _ => sys.error(s"Cannot find ArithOpName for opcode $opCode")
+    case _ => sys.error(s"We couldn't find the arithmetic operation name for opcode $opCode. " +
+      "Please check that the opcode is correct and supported. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 
@@ -956,7 +958,10 @@ object BitOp {
 
   def opcodeToName(opCode: Byte): String = operations.get(opCode) match {
     case Some(c)  => c.name
-    case _ => sys.error(s"Cannot find BitOpName for opcode $opCode")
+    case _ => sys.error(s"We couldn't find the bitwise operation name for opcode $opCode. " +
+      "Please check that the opcode is correct and supported. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."
+    )
   }
 }
 
@@ -1002,7 +1007,9 @@ object ModQArithOp extends OpGroup[ModQArithOpCompanion] {
 
   def opcodeToName(opCode: Byte): String = operations.get(opCode) match {
     case Some(c)  => c.name
-    case _ => sys.error(s"Cannot find ModQArithOp operation name for opcode $opCode")
+    case _ => sys.error(s"We couldn't find the modular Q arithmetic operation for opcode $opCode. " +
+      "Please verify that the opcode is correct and supported. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 }
 /**

--- a/data/shared/src/main/scala/sigma/ast/values.scala
+++ b/data/shared/src/main/scala/sigma/ast/values.scala
@@ -60,7 +60,9 @@ abstract class Value[+S <: SType] extends SigmaNode {
   def toSigmaProp: SigmaPropValue = this match {
     case b if b.tpe == SBoolean => BoolToSigmaProp(this.asBoolValue)
     case p if p.tpe == SSigmaProp => p.asSigmaProp
-    case _ => sys.error(s"Expected SBoolean or SSigmaProp typed value, but was: $this")
+    case _ => sys.error(s"The expected value type is SBoolean or SSigmaProp, but the provided type was: $this. " +
+      "Please make sure the value matches the required type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
   /** Parser has some source information like line,column in the text. We need to keep it up until RuntimeCosting.
@@ -85,7 +87,9 @@ abstract class Value[+S <: SType] extends SigmaNode {
     if (_sourceContext.isEmpty) {
       _sourceContext = srcCtx
     } else {
-      sys.error("_sourceContext can be set only once")
+      sys.error("The _sourceContext can only be set once. " +
+        "Please ensure it is set correctly the first time. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
 
   /** Defines an evaluation semantics of this tree node (aka Value or expression) in the given data environment.
@@ -98,7 +102,10 @@ abstract class Value[+S <: SType] extends SigmaNode {
     * @return the data value which is the result of evaluation
     */
   protected def eval(env: DataEnv)(implicit E: ErgoTreeEvaluator): Any =
-    sys.error(s"Should be overriden in ${this.getClass}: $this")
+    sys.error(s"This method should be overridden in ${this.getClass}. Current implementation: $this. " +
+      "Please ensure the method is correctly overridden. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."
+    )
 
   /** Evaluates this node to the value of the given expected type.
     * This method should called from all `eval` implementations.
@@ -275,7 +282,10 @@ trait ValueCompanion extends SigmaNodeCompanion {
 
   def init() {
     if (this.opCode != 0 && _allOperations.contains(this.opCode))
-      throw sys.error(s"Operation $this already defined")
+      throw sys.error(s"The operation $this is already defined. " +
+        "Please ensure each operation is uniquely defined. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."
+      )
     _allOperations += (this.opCode -> this)
   }
 
@@ -363,7 +373,9 @@ case class ConstantNode[S <: SType](value: S#WrappedType, tpe: S) extends Consta
     case SGroupElement if value.isInstanceOf[GroupElement] =>
       s"ConstantNode(${value.asInstanceOf[GroupElement].showToString},$tpe)"
     case SGroupElement =>
-      sys.error(s"Invalid value in Constant($value, $tpe)")
+      sys.error(s"The value $value is invalid for the constant of type $tpe. " +
+        "Please ensure the value matches the expected type and format. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     case SInt => s"IntConstant($value)"
     case SLong => s"LongConstant($value)"
     case SBoolean if value == true => "TrueLeaf"

--- a/data/shared/src/main/scala/sigma/data/CBox.scala
+++ b/data/shared/src/main/scala/sigma/data/CBox.scala
@@ -49,7 +49,9 @@ case class CBox(ebox: ErgoBox) extends Box with WrapperOf[ErgoBox] {
       case ConstantNode(arr: Array[Any], STuple(IndexedSeq(SInt, SByteArray))) if arr.length == 2 =>
         (arr(0).asInstanceOf[Int], builder.Colls.fromArray(arr(1).asInstanceOf[Array[Byte]]))
       case v =>
-        sys.error(s"Invalid value $v of creationInfo register R3")
+        sys.error(s"The value $v assigned to creationInfo register R3 is not valid. " +
+          "Please check that the value meets the required format and type. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
   }
 

--- a/data/shared/src/main/scala/sigma/data/CSigmaDslBuilder.scala
+++ b/data/shared/src/main/scala/sigma/data/CSigmaDslBuilder.scala
@@ -31,7 +31,9 @@ class CSigmaDslBuilder extends SigmaDslBuilder { dsl =>
   /** Wraps the given elliptic curve point into GroupElement type. */
   def GroupElement(p: Ecp): GroupElement = p match {
     case ept: EcPointType => CGroupElement(ept)
-    case m => sys.error(s"Point of type ${m.getClass} is not supported")
+    case m => sys.error(s"The point type ${m.getClass} is not supported in this context. " +
+      "Please make sure you are using a supported point type. " +
+      "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
   }
 
   /** Wraps the given sigma proposition into SigmaDsl value of type SigmaProp. */

--- a/data/shared/src/main/scala/sigma/data/DataValueComparer.scala
+++ b/data/shared/src/main/scala/sigma/data/DataValueComparer.scala
@@ -404,7 +404,10 @@ object DataValueComparer {
         okEqual = r.isInstanceOf[Unit]
 
       case _ =>
-        sys.error(s"Cannot compare $l and $r: unknown type")
+        sys.error(s"We cannot compare $l and $r because their types are unknown. " +
+          "Please ensure both values have compatible types for comparison. " +
+          "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."
+        )
     }
     okEqual
   }

--- a/interpreter/shared/src/test/scala/sigma/serialization/DataSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/DataSerializerSpecification.scala
@@ -116,7 +116,7 @@ class DataSerializerSpecification extends SerializationSpecification {
       },
       { t =>
         t.isInstanceOf[RuntimeException] &&
-        t.getMessage.contains(s"Length of tuple $len exceeds ${0xFFFF} limit.")
+        t.getMessage.contains("The tuple length (65536) is too long (maximum limit is 65535).")
       })
 
     val tooBigBytes  = Helpers.decodeBytes(

--- a/interpreter/shared/src/test/scala/sigma/serialization/TypeSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/TypeSerializerSpecification.scala
@@ -104,7 +104,7 @@ class TypeSerializerSpecification extends SerializationSpecification {
       SigmaSerializer.startWriter().putType(STuple(SInt)),
       { t =>
         t.isInstanceOf[RuntimeException] &&
-        t.getMessage.contains("Invalid Tuple type with less than 2 items")
+        t.getMessage.contains("The Tuple with fewer than 2 items (ArraySeq(SInt$)) is invalid.")
       })
   }
 }

--- a/sc/shared/src/main/scala/org/ergoplatform/dsl/ContractSyntax.scala
+++ b/sc/shared/src/main/scala/org/ergoplatform/dsl/ContractSyntax.scala
@@ -43,7 +43,9 @@ trait ContractSyntax { contract: SigmaContract =>
           val itemTag = ClassTag[Any](itemClass)
           RType.fromClassTag(itemTag)
         } else
-          sys.error(s"Cannot compute rtypeOf($value): non-primitive type of array items")
+          sys.error(s"We can't determine the data type of $value because it includes non-basic types in its array items. " +
+            "Please make sure all array elements are basic types (like strings or numbers) for correct calculation. " +
+            "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
       case coll: Coll[_] => collRType(coll.tItem)
 
       // all primitive types

--- a/sc/shared/src/test/scala/sigma/SigmaDslSpecification.scala
+++ b/sc/shared/src/test/scala/sigma/SigmaDslSpecification.scala
@@ -2274,7 +2274,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     // It makes sense to fix this inconsistency as part of upcoming forks
     assertExceptionThrown(
       SBigInt.upcast(CBigInt(new BigInteger("0", 16)).asInstanceOf[AnyVal]),
-      _.getMessage.contains("Cannot upcast value")
+      _.getMessage.contains("We cannot convert value")
     )
 
     // TODO v6.0: the behavior of `downcast` for BigInt is different from all other Numeric types (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/877)
@@ -2282,7 +2282,7 @@ class SigmaDslSpecification extends SigmaDslTesting
     // It makes sense to fix this inconsistency as part of HF
     assertExceptionThrown(
       SBigInt.downcast(CBigInt(new BigInteger("0", 16)).asInstanceOf[AnyVal]),
-      _.getMessage.contains("Cannot downcast value")
+      _.getMessage.contains("We cannot convert value")
     )
 
     val toByte = newFeature((x: BigInt) => x.toByte,

--- a/sc/shared/src/test/scala/sigma/SigmaDslTesting.scala
+++ b/sc/shared/src/test/scala/sigma/SigmaDslTesting.scala
@@ -843,7 +843,9 @@ class SigmaDslTesting extends AnyPropSpec
   )(implicit IR: IRContext, override val evalSettings: EvalSettings, val tA: RType[A], val tB: RType[B])
     extends Feature[A, B] {
     override def scalaFunc: A => B = { x =>
-      sys.error(s"Semantic Scala function is not defined for old implementation: $this")
+      sys.error(s"The Semantic Scala function is not available for this implementation: $this. " +
+        "Please update to the latest version for support. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>.")
     }
     implicit val cs = compilerSettingsInTests
 

--- a/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/ErgoTreeSpecification.scala
@@ -39,7 +39,7 @@ class ErgoTreeSpecification extends SigmaDslTesting with ContractsTestkit {
 
     assertExceptionThrown(
       value.withSrcCtx(Nullable(srcCtx)),
-      t => t.isInstanceOf[RuntimeException] && t.getMessage.contains("can be set only once"))
+      t => t.isInstanceOf[RuntimeException] && t.getMessage.contains("can only be set once."))
   }
 
   property("Value.opType") {

--- a/sc/shared/src/test/scala/sigmastate/TypesSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/TypesSpecification.scala
@@ -111,7 +111,7 @@ class TypesSpecification extends SigmaTestingData {
     assertValidType((1, Some(1)), STuple(SInt, SOption(SLong))) // because type check is shallow
     assertExceptionThrown(
       assertValidType((1, 1L, Some(1)), STuple(SInt, SLong, SOption(SInt))),
-      exceptionLike[RuntimeException](s"Unsupported tuple type")
+      exceptionLike[RuntimeException](" is not supported.")
     )
 
     assertValidType((x: Any) => x, SFunc(SInt, SLong))  // note, arg and result types not checked
@@ -119,12 +119,12 @@ class TypesSpecification extends SigmaTestingData {
     assertInvalidType(1, SFunc(SInt, SLong))
     assertExceptionThrown(
       assertValidType((x: Any) => x, SFunc(Array(SInt, SLong), SOption(SInt))),
-      exceptionLike[RuntimeException](s"Unsupported function type")
+      exceptionLike[RuntimeException](" is not supported.")
     )
 
     assertExceptionThrown(
       assertValidType("", SString),
-      exceptionLike[RuntimeException](s"Unknown type")
+      exceptionLike[RuntimeException]("We don't recognize the type")
     )
   }
 }

--- a/sc/shared/src/test/scala/sigmastate/helpers/SigmaPPrint.scala
+++ b/sc/shared/src/test/scala/sigmastate/helpers/SigmaPPrint.scala
@@ -55,7 +55,10 @@ object SigmaPPrint extends PPrinter {
     case _: STuple =>
       "STuple"
     case _ =>
-      sys.error(s"Cannot get typeName($tpe)")
+      sys.error(s"We encountered an issue while retrieving the type name for $tpe. " +
+        "Please ensure the type is correctly specified and supported. " +
+        "If the issue keeps happening, contact <a href=\"#\">Customer care</a>."
+      )
   }
 
   /** Valid Scala type of the Value with the given underlying SType. */


### PR DESCRIPTION
**### Changes Made:**

- Switched to clearer explanations: Updated error messages to explicitly state what went wrong and why.
- Used empathy and politeness: Maintained a polite and empathetic tone.
- Added actionable guidance: Included specific instructions on how users can resolve issues or contact support.
- Reduced technical jargon and blame: Reduced technical language and avoided blaming users or third parties.
Note: Currently using “#” in place for a link to contact customer support