### PR TITLE
[6.0] Serialize SFunc in TypeSerializer

### DIFF
--- a/core/shared/src/main/scala/sigma/ast/SType.scala
+++ b/core/shared/src/main/scala/sigma/ast/SType.scala
@@ -587,7 +587,7 @@ case class SFunc(tDom: IndexedSeq[SType],  tRange: SType, tpeParams: Seq[STypePa
 }
 
 object SFunc {
-  final val FuncTypeCode: TypeCode = TypeCodes.FirstFuncType
+  final val FuncTypeCode: TypeCode = TypeCodes.FuncType
   def apply(tDom: SType, tRange: SType): SFunc = SFunc(Array(tDom), tRange) // HOTSPOT:
   val identity = { x: Any => x }
 }
@@ -653,7 +653,6 @@ object SOption extends STypeCompanion {
 
   def apply[T <: SType](implicit elemType: T, ov: Overloaded1): SOption[T] = SOption(elemType)
 }
-
 
 /** Base class for descriptors of `Coll[T]` ErgoTree type for some elemType T. */
 trait SCollection[T <: SType] extends SProduct with SGenericType {

--- a/core/shared/src/main/scala/sigma/ast/STypeParam.scala
+++ b/core/shared/src/main/scala/sigma/ast/STypeParam.scala
@@ -2,18 +2,10 @@ package sigma.ast
 
 /** Represents a type parameter in a type system.
   *
-  * @param ident       The identifier for this type parameter.
-  * @param upperBound  The upper bound of this type parameter, if exists.
-  * @param lowerBound  The lower bound of this type parameter, if exists.
-  * @note Type parameters with bounds are currently not supported.
+  * @param ident       The identifier for this type parameter
   */
-case class STypeParam(
-    ident: STypeVar,
-    upperBound: Option[SType] = None,
-    lowerBound: Option[SType] = None) {
-  assert(upperBound.isEmpty && lowerBound.isEmpty, s"Type parameters with bounds are not supported, but found $this")
-
-  override def toString = ident.toString + upperBound.fold("")(u => s" <: $u") + lowerBound.fold("")(l => s" >: $l")
+case class STypeParam(ident: STypeVar) {
+  override def toString = ident.toString
 }
 
 object STypeParam {

--- a/core/shared/src/main/scala/sigma/ast/TypeCodes.scala
+++ b/core/shared/src/main/scala/sigma/ast/TypeCodes.scala
@@ -14,10 +14,8 @@ object TypeCodes {
 
   val LastDataType : TypeCode = TypeCode @@ 111.toByte
 
-  /** SFunc types occupy remaining space of byte values [FirstFuncType .. 255] */
-  val FirstFuncType: TypeCode = TypeCode @@ (LastDataType + 1).toByte
-
-  val LastFuncType : TypeCode = TypeCode @@ 255.toByte
+  /** SFunc type */
+  val FuncType: TypeCode = TypeCode @@ (LastDataType + 1).toByte
 
   /** We use optimized encoding of constant values to save space in serialization.
     * Since Box registers are stored as Constant nodes we save 1 byte for each register.

--- a/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
@@ -24,28 +24,6 @@ class MethodCallSerializerSpecification extends SerializationSpecification {
     roundTripTest(expr)
   }
 
-  property("MethodCall deserialization round trip for BigInt.nbits") {
-    def code = {
-      val bi = BigIntConstant(5)
-      val expr = MethodCall(bi,
-        SBigIntMethods.ToNBits,
-        Vector(),
-        Map()
-      )
-      roundTripTest(expr)
-    }
-
-    VersionContext.withVersions(VersionContext.V6SoftForkVersion, 1) {
-      code
-    }
-
-    an[ValidationException] should be thrownBy (
-      VersionContext.withVersions((VersionContext.V6SoftForkVersion - 1).toByte, 1) {
-        code
-      }
-      )
-  }
-
   property("MethodCall deserialization round trip for Header.checkPow") {
     def code = {
       val bi = HeaderConstant(headerGen.sample.get)

--- a/interpreter/shared/src/test/scala/sigma/serialization/generators/ObjectGenerators.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/generators/ObjectGenerators.scala
@@ -26,7 +26,7 @@ import sigma.util.Extensions.EcpOps
 import sigma.validation.{ChangedRule, DisabledRule, EnabledRule, ReplacedRule, RuleStatus}
 import sigma.validation.ValidationRules.FirstRuleId
 import ErgoTree.ZeroHeader
-import sigma.data.{AvlTreeData, AvlTreeFlags, CAND, CBox, COR, CTHRESHOLD, Digest32Coll, ProveDHTuple, ProveDlog, RType, SigmaBoolean}
+import sigma.data.{AvlTreeData, AvlTreeFlags, CAND, CBox, CHeader, COR, CTHRESHOLD, Digest32Coll, ProveDHTuple, ProveDlog, RType, SigmaBoolean}
 import sigma.eval.Extensions.{EvalIterableOps, SigmaBooleanOps}
 import sigma.eval.SigmaDsl
 import sigma.interpreter.{ContextExtension, ProverResult}

--- a/parsers/shared/src/test/scala/sigmastate/helpers/SigmaPPrint.scala
+++ b/parsers/shared/src/test/scala/sigmastate/helpers/SigmaPPrint.scala
@@ -52,6 +52,8 @@ object SigmaPPrint extends PPrinter {
       s"SOption[${typeName(ot.elemType)}]"
     case _: STuple =>
       "STuple"
+    case _: SFunc =>
+      s"SFunc"
     case _ =>
       sys.error(s"Cannot get typeName($tpe)")
   }

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
@@ -9820,30 +9820,6 @@ class LanguageSpecificationV5 extends LanguageSpecificationBase { suite =>
     }
   }
 
-  property("higher order lambdas") {
-    val f = existingFeature(
-      { (xs: Coll[Int]) =>
-        val inc = { (x: Int) => x + 1 }
-
-        def apply(in: (Int => Int, Int)) = in._1(in._2)
-
-        xs.map { (x: Int) => apply((inc, x)) }
-      },
-      """{(xs: Coll[Int]) =>
-       |   val inc = { (x: Int) => x + 1 }
-       |   def apply(in: (Int => Int, Int)) = in._1(in._2)
-       |   xs.map { (x: Int) => apply((inc, x)) }
-       | }
-       |""".stripMargin
-    )
-
-    // TODO v6.0: Add support of SFunc in TypeSerializer (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/847)
-    assertExceptionThrown(
-      f.verifyCase(Coll[Int](), Expected(Success(Coll[Int]()), 0)),
-      exceptionLike[MatchError]("(SInt$) => SInt$ (of class sigma.ast.SFunc)")
-    )
-  }
-
   override protected def afterAll(): Unit = {
     printDebug(CErgoTreeEvaluator.DefaultProfiler.generateReport)
     printDebug("==========================================================")

--- a/sc/shared/src/test/scala/sigma/SigmaDslTesting.scala
+++ b/sc/shared/src/test/scala/sigma/SigmaDslTesting.scala
@@ -261,6 +261,7 @@ class SigmaDslTesting extends AnyPropSpec
             s"""Should succeed with the same value or fail with the same exception, but was:
               |First result: $b1
               |Second result: $b2
+              |Input: $x
               |Root cause: $cause
               |""".stripMargin)
       }
@@ -715,11 +716,17 @@ class SigmaDslTesting extends AnyPropSpec
     override def checkEquality(input: A, logInputOutput: Boolean = false): Try[(B, CostDetails)] = {
       // check the old implementation against Scala semantic function
       var oldRes: Try[(B, CostDetails)] = null
-      if (ergoTreeVersionInTests < VersionContext.JitActivationVersion)
         oldRes = VersionContext.withVersions(activatedVersionInTests, ergoTreeVersionInTests) {
           try checkEq(scalaFunc)(oldF)(input)
           catch {
-            case e: TestFailedException => throw e
+            case e: TestFailedException =>
+              if(activatedVersionInTests < changedInVersion) {
+                throw e
+              } else {
+                // old ergoscript may succeed in new version while old scalafunc may fail,
+                // see e.g. "Option.getOrElse with lazy default" test
+                Failure(e)
+              }
             case t: Throwable =>
               Failure(t)
           }

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -458,6 +458,32 @@ class BasicOpsSpecification extends CompilerTestingCommons
       rootCause(_).isInstanceOf[NoSuchElementException])
   }
 
+  property("higher order lambdas") {
+    def holTest() = test("HOL", env, ext,
+      """
+        | {
+        |   val c = Coll(Coll(1))
+        |   def fn(xs: Coll[Int]) = {
+        |     val inc = { (x: Int) => x + 1 }
+        |     def apply(in: (Int => Int, Int)) = in._1(in._2)
+        |     val ys = xs.map { (x: Int) => apply((inc, x)) }
+        |     ys.size == xs.size && ys != xs
+        |   }
+        |
+        |   c.exists(fn)
+        | }
+        |""".stripMargin,
+      null,
+      true
+    )
+
+    if(VersionContext.current.isV6SoftForkActivated) {
+      holTest()
+    } else {
+      an[Exception] shouldBe thrownBy(holTest())
+    }
+  }
+
   property("OptionGetOrElse") {
     test("OptGet1", env, ext,
       "{ SELF.R5[Int].getOrElse(3) == 1 }",


### PR DESCRIPTION
This PR is adding higher-order lambdas support in serialization, thus making them useful.

Example:
```
{
   val c = Coll(Coll(1))
   def fn(xs: Coll[Int]) = {
     val inc = { (x: Int) => x + 1 }
     def apply(in: (Int => Int, Int)) = in._1(in._2)
     val ys = xs.map { (x: Int) => apply((inc, x)) }
     ys.size == xs.size && ys != xs
   }
   c.exists(fn)
 }
```
Close #847