### PR TITLE
Drop unused args argument from SigmaException.

### DIFF
--- a/core/shared/src/main/scala/sigma/SigmaException.scala
+++ b/core/shared/src/main/scala/sigma/SigmaException.scala
@@ -10,6 +10,3 @@ class SigmaException(
   val message: String,
   val cause: Option[Throwable] = None
 ) extends Exception(message, cause.orNull)
-
-
-

--- a/core/shared/src/main/scala/sigma/SigmaException.scala
+++ b/core/shared/src/main/scala/sigma/SigmaException.scala
@@ -1,7 +1,5 @@
 package sigma
 
-import scala.collection.compat.immutable.ArraySeq
-
 /** Base class for Sigma-related exceptions.
   *
   * @param message the error message
@@ -9,9 +7,9 @@ import scala.collection.compat.immutable.ArraySeq
   * @param args an optional sequence of arguments to be passed with the exception
   */
 class SigmaException(
-    val message: String,
-    val cause: Option[Throwable] = None,
-    val args: Seq[Any] = ArraySeq.empty) extends Exception(message, cause.orNull)
+  val message: String,
+  val cause: Option[Throwable] = None
+) extends Exception(message, cause.orNull)
 
 
 

--- a/core/shared/src/main/scala/sigma/serialization/CoreSerializer.scala
+++ b/core/shared/src/main/scala/sigma/serialization/CoreSerializer.scala
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 /** Implementation of [[Serializer]] provided by `sigma-core` module. */
 abstract class CoreSerializer[TFamily, T <: TFamily] extends Serializer[TFamily, T, CoreByteReader, CoreByteWriter] {
 
-  def error(msg: String) = throw SerializerException(msg, None)
+  def error(msg: String) = throw SerializerException(msg)
 
   /** Serializes the given 'obj' to a new array of bytes using this serializer. */
   final def toBytes(obj: T): Array[Byte] = {

--- a/core/shared/src/main/scala/sigma/serialization/SerializerException.scala
+++ b/core/shared/src/main/scala/sigma/serialization/SerializerException.scala
@@ -2,8 +2,6 @@ package sigma.serialization
 
 import sigma.SigmaException
 
-import scala.collection.compat.immutable.ArraySeq
-
 /** Exception thrown during serialization.
   *
   * @param message the error message
@@ -11,10 +9,8 @@ import scala.collection.compat.immutable.ArraySeq
   */
 case class SerializerException(
     override val message: String,
-    override val cause: Option[Throwable] = None,
-    override val args: Seq[Any] = ArraySeq.empty
-)
-    extends SigmaException(message, cause, args)
+    override val cause: Option[Throwable] = None
+) extends SigmaException(message, cause)
 
 /** Thrown by TypeSerializer when type prefix <= 0. */
 final class InvalidTypePrefix(message: String, cause: Option[Throwable] = None)

--- a/core/shared/src/main/scala/sigma/serialization/SerializerException.scala
+++ b/core/shared/src/main/scala/sigma/serialization/SerializerException.scala
@@ -13,8 +13,8 @@ case class SerializerException(
 ) extends SigmaException(message, cause)
 
 /** Thrown by TypeSerializer when type prefix <= 0. */
-final class InvalidTypePrefix(message: String, cause: Option[Throwable] = None)
-    extends SerializerException(message, cause)
+final class InvalidTypePrefix(message: String)
+    extends SerializerException(message)
 
 /** Thrown when the current reader position > positionLimit which is set in the Reader.
   * @see [[org.ergoplatform.validation.ValidationRules.CheckPositionLimit]]
@@ -22,14 +22,13 @@ final class InvalidTypePrefix(message: String, cause: Option[Throwable] = None)
 final class ReaderPositionLimitExceeded(
     message: String,
     val position: Int,
-    val positionLimit: Int,
-    cause: Option[Throwable] = None)
-    extends SerializerException(message, cause)
+    val positionLimit: Int
+) extends SerializerException(message)
 
 /** Thrown when the current depth level > maxDepthLevel which is set in the Reader. */
-final class DeserializeCallDepthExceeded(message: String, cause: Option[Throwable] = None)
-    extends SerializerException(message, cause)
+final class DeserializeCallDepthExceeded(message: String)
+    extends SerializerException(message)
 
 /** Thrown by [[org.ergoplatform.validation.ValidationRules.CheckValidOpCode]] validation rule. */
-final class InvalidOpCode(message: String, cause: Option[Throwable] = None)
-    extends SerializerException(message, cause)
+final class InvalidOpCode(message: String)
+    extends SerializerException(message)

--- a/data/shared/src/main/scala/sigma/exceptions/CompilerExceptions.scala
+++ b/data/shared/src/main/scala/sigma/exceptions/CompilerExceptions.scala
@@ -7,10 +7,9 @@ import sigma.ast.SourceContext
   *
   * @param message the error message
   * @param source an optional source context with location information
-  * @param cause an optional cause for the exception
   */
-class CompilerException(message: String, val source: Option[SourceContext] = None, cause: Option[Throwable] = None)
-    extends SigmaException(message, cause) {
+class CompilerException(message: String, val source: Option[SourceContext] = None)
+    extends SigmaException(message, None) {
 
   override def getMessage: String = source.map { srcCtx =>
     val lineNumberStrPrefix = s"line ${srcCtx.line}: "
@@ -43,8 +42,8 @@ class TyperException(message: String, source: Option[SourceContext] = None)
 class BuilderException(message: String, source: Option[SourceContext] = None)
   extends CompilerException(message, source)
 
-class GraphBuildingException(message: String, source: Option[SourceContext], cause: Option[Throwable] = None)
-    extends CompilerException(message, source, cause)
+class GraphBuildingException(message: String, source: Option[SourceContext])
+    extends CompilerException(message, source)
 
 
 

--- a/data/shared/src/main/scala/sigma/exceptions/SigmaExceptions.scala
+++ b/data/shared/src/main/scala/sigma/exceptions/SigmaExceptions.scala
@@ -18,10 +18,9 @@ class InterpreterException(message: String, cause: Option[Throwable] = None)
   * @param cause an optional cause for the exception
   */
 class CostLimitException(
-    val estimatedCost: Long,
-    message: String,
-    cause: Option[Throwable] = None)
-    extends SigmaException(message, cause)
+  val estimatedCost: Long,
+  message: String
+) extends SigmaException(message, None)
 
 object CostLimitException {
   /** Generates a cost limit error message.

--- a/data/shared/src/main/scala/sigma/serialization/SigmaSerializer.scala
+++ b/data/shared/src/main/scala/sigma/serialization/SigmaSerializer.scala
@@ -65,7 +65,7 @@ object SigmaSerializer {
 
 abstract class SigmaSerializer[TFamily, T <: TFamily] extends Serializer[TFamily, T, SigmaByteReader, SigmaByteWriter] {
 
-  def error(msg: String) = throw new SerializerException(msg, None)
+  def error(msg: String) = throw new SerializerException(msg)
 
   final def toBytes(obj: T): Array[Byte] = {
     val w = SigmaSerializer.startWriter()

--- a/interpreter/shared/src/main/scala/sigmastate/eval/package.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/eval/package.scala
@@ -47,8 +47,8 @@ package object eval {
         message = {
           val suffix = if (msgSuffix.isEmpty) "" else s": $msgSuffix"
           msgCostLimitError(newCost, limit) + suffix
-        },
-        cause = None)
+        }
+      )
     }
     newCost
   }

--- a/interpreter/shared/src/main/scala/sigmastate/interpreter/CostAccumulator.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/interpreter/CostAccumulator.scala
@@ -62,7 +62,9 @@ class CostAccumulator(initialCost: JitCost, costLimit: Option[JitCost]) {
       val accumulatedCost = currentScope.currentCost
       if (accumulatedCost > limit) {
         throw new CostLimitException(
-          accumulatedCost.value, CostLimitException.msgCostLimitError(accumulatedCost, limit), None)
+          accumulatedCost.value,
+          CostLimitException.msgCostLimitError(accumulatedCost, limit)
+        )
       }
     }
   }

--- a/sc/shared/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/sc/shared/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -136,9 +136,10 @@ class DeserializationResilience extends DeserializationResilienceTesting {
         assertExceptionThrown(
           ErgoBoxCandidate.serializer.parse(SigmaSerializer.startReader(w.toBytes)),
           {
-            case SerializerException(_,
-                   Some(ValidationException(_,CheckPositionLimit,_,
-                          Some(_: ReaderPositionLimitExceeded))), _) => true
+            case SerializerException(
+              _,
+              Some(ValidationException(_, CheckPositionLimit, _, Some(_: ReaderPositionLimitExceeded)))
+            ) => true
             case _ => false
           })
       case _ =>

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/ReducingInterpreter.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/ReducingInterpreter.scala
@@ -34,8 +34,10 @@ class ReducingInterpreter(params: BlockchainParameters) extends ErgoLikeInterpre
     val initCost = context.initCost
     val remainingLimit = context.costLimit - initCost
     if (remainingLimit <= 0)
-      throw new CostLimitException(initCost,
-        s"Estimated execution cost $initCost exceeds the limit ${context.costLimit}", None)
+      throw new CostLimitException(
+        initCost,
+        s"Estimated execution cost $initCost exceeds the limit ${context.costLimit}"
+      )
     val ctxUpdInitCost = context.withInitCost(initCost)
     val res = fullReduction(ergoTree, ctxUpdInitCost, env)
     ReducedInputData(res, ctxUpdInitCost.extension)


### PR DESCRIPTION
Found during scala 3 cross compile work. This will simplify migration as we are dropping `scala.collection.compat.immutable.ArraySeq`.