### PR TITLE
Add DownCast for register id in executeFromSelfReg()

### DIFF
--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
@@ -244,6 +244,12 @@ class SigmaTyper(val builder: SigmaBuilder,
             case (Ident(GetVarFunc.name | ExecuteFromVarFunc.name, _), Seq(id: Constant[SNumericType]@unchecked))
               if id.tpe.isNumType =>
                 Seq(ByteConstant(SByte.downcast(id.value.asInstanceOf[AnyVal])).withSrcCtx(id.sourceContext))
+            case (Ident(ExecuteFromSelfRegFunc.name, _), Seq(id: Constant[SNumericType]@unchecked))
+              if id.tpe.isNumType =>
+                Seq(IntConstant(SInt.downcast(id.value.asInstanceOf[AnyVal])).withSrcCtx(id.sourceContext))
+            case (Ident(ExecuteFromSelfRegWithDefaultFunc.name, _), Seq(id: Constant[SNumericType]@unchecked, default))
+              if id.tpe.isNumType =>
+                Seq(IntConstant(SInt.downcast(id.value.asInstanceOf[AnyVal])).withSrcCtx(id.sourceContext), default)
             case (Ident(SContextMethods.getVarFromInputMethod.name, _),
                   Seq(inputId: Constant[SNumericType]@unchecked, varId: Constant[SNumericType]@unchecked))
                   if inputId.tpe.isNumType && varId.tpe.isNumType =>

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -606,8 +606,24 @@ class SigmaTyperTest extends AnyPropSpec
     typecheck(env, "executeFromVar[Boolean](1)") shouldBe SBoolean
   }
 
+  property("executeFromSelfReg") {
+    // Test with Int literal (should work with automatic downcast)
+    typecheck(env, "executeFromSelfReg[Boolean](4)") shouldBe SBoolean
+    typecheck(env, "executeFromSelfReg[Int](5)") shouldBe SInt
+    typecheck(env, "executeFromSelfReg[Long](6)") shouldBe SLong
+    
+    // Test with numeric types that need downcast to Int
+    typecheck(env, "executeFromSelfReg[Boolean](4L)") shouldBe SBoolean
+    typecheck(env, "executeFromSelfReg[Int](5L)") shouldBe SInt
+  }
+
   property("executeFromSelfRegWithDefault") {
+    // Test with Int literal (should work with automatic downcast)
     typecheck(env, "executeFromSelfRegWithDefault[Boolean](4, getVar[Boolean](1).get)") shouldBe SBoolean
+    
+    // Test with numeric types that need downcast to Int
+    typecheck(env, "executeFromSelfRegWithDefault[Boolean](4L, getVar[Boolean](1).get)") shouldBe SBoolean
+    typecheck(env, "executeFromSelfRegWithDefault[Int](5L, 10)") shouldBe SInt
 
     an[TyperException] should be thrownBy {
       typecheck(env, "executeFromSelfRegWithDefault[Boolean](4, getVar[Int](1).get)")


### PR DESCRIPTION
Fixes #602

- Add automatic downcasting from numeric types to Int for register id parameter in executeFromSelfReg() and executeFromSelfRegWithDefault() functions
- This mirrors the existing downcast behavior for getVar and executeFromVar
- Users can now write executeFromSelfReg[T](4) or executeFromSelfReg[T](4L) without manual .toByte casting

Changes:
- SigmaTyper.scala: Added downcast logic for ExecuteFromSelfRegFunc and ExecuteFromSelfRegWithDefaultFunc in adaptedTypedArgs pattern matching
- SigmaTyperTest.scala: Added comprehensive test cases verifying downcast functionality with Int and Long literals

All tests passing (58 tests in SigmaTyperTest suite)