### PR TITLE
Fixed compilation errors and code quality issue

### DIFF
--- a/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
+++ b/parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala
@@ -156,7 +156,7 @@ object ContractParser {
 
     def word[_: P] = CharsWhile(c => c != ' ')
 
-    def charUntilNewLine[_: P] = CharsWhile(c => c != '\n')
+    def charUntilNewLine[A: P] = CharsWhile(c => c != '\n')
 
     def unsupportedTag[_: P] = P("@" ~ charUntilNewLine.?).map(_ => DocumentationToken(UnsupportedTag))
 

--- a/sc/shared/src/main/scala/sigma/compiler/ir/primitives/Functions.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/primitives/Functions.scala
@@ -405,7 +405,6 @@ trait Functions extends Base with ProgramGraphs { self: IRContext =>
   /** Composition of two functions (in mathematical notation), where first `g` is applied and them `f`. */
   def compose[A, B, C](f: Ref[B => C], g: Ref[A => B]): Ref[A => C] = {
     implicit val eA = g.elem.eDom
-    implicit val eC = f.elem.eRange
     fun { x => f(g(x)) }
   }
 

--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/DataJsonEncoder.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/DataJsonEncoder.scala
@@ -46,7 +46,7 @@ object DataJsonEncoder {
   }
 
   def encodeData[T <: SType](v: T#WrappedType, tpe: T): Json = tpe match {
-    case SUnit => Json.fromFields(ArraySeq.empty)
+    case SUnit => Json.obj()
     case SBoolean => v.asInstanceOf[Boolean].asJson
     case SByte => v.asInstanceOf[Byte].asJson
     case SShort => v.asInstanceOf[Short].asJson


### PR DESCRIPTION
Fixes #1103 
I have applied the following fixes to the sigmastate-interpreter repository to resolve compilation errors and code quality issues.

## Changes
1. Fix Top-level Wildcard Compilation Error
File: `parsers/shared/src/main/scala/sigmastate/lang/ContractParser.scala`

Added a named type parameter `A` to `charUntilNewLine` to satisfy Scala 2.13+ requirements for context bounds.

```
// Before
def charUntilNewLine[_: P] = CharsWhile(c => c != '\n')
// After
def charUntilNewLine[A: P] = CharsWhile(c => c != '\n')
```
2. Remove Unused Implicit Variable
File: `sc/shared/src/main/scala/sigma/compiler/ir/primitives/Functions.scala`

Removed the unused implicit variable `eC` in the `compose` function.

```
// Before
def compose[A, B, C](<f: Ref[B => C], g: Ref[A => B]>): Ref[A => C] = {
  implicit val eA = g.elem.eDom
  implicit val eC = f.elem.eRange // Unused
  fun { x => f(g(x)) }
}
// After
def compose[A, B, C](<f: Ref[B => C], g: Ref[A => B]>): Ref[A => C] = {
  implicit val eA = g.elem.eDom
  fun { x => f(g(x)) }
}
```
3. Fix SUnit JSON Encoding
File: `sdk/shared/src/main/scala/org/ergoplatform/sdk/DataJsonEncoder.scala`

Corrected the JSON encoding for `SUnit` to use `Json.obj()` instead of `Json.fromFields(ArraySeq.empty)`.

```
// Before
case SUnit => Json.fromFields(ArraySeq.empty)
// After
case SUnit => Json.obj()
```