### PR TITLE
Add compiler support for Global.serialize method

### DIFF
--- a/sc/shared/src/main/scala/sigma/compiler/ir/TreeBuilding.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/TreeBuilding.scala
@@ -292,6 +292,12 @@ trait TreeBuilding extends Base { IR: IRContext =>
         val method = SGlobalMethods.deserializeToMethod.withConcreteTypes(typeSubst)
         builder.mkMethodCall(recurse(g), method, IndexedSeq(recurse(bytes)), typeSubst)
 
+      case SDBM.serialize(g, value) =>
+        val valueTpe = elemToSType(value.elem)
+        val typeSubst = Map(tT -> valueTpe): STypeSubst
+        val method = SGlobalMethods.serializeMethod.withConcreteTypes(typeSubst)
+        builder.mkMethodCall(recurse(g), method, IndexedSeq(recurse(value)), Map.empty)
+
       case BIM.subtract(In(x), In(y)) =>
         mkArith(x.asNumValue, y.asNumValue, MinusCode)
       case BIM.add(In(x), In(y)) =>

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
@@ -2752,6 +2752,16 @@ object SigmaDslBuilder extends EntityObject("SigmaDslBuilder") {
       def unapply(exp: Sym): Nullable[(Ref[SigmaDslBuilder], Ref[Coll[Byte]], Elem[T]) forSome {type T}] = unapply(exp.node)
     }
 
+    object serialize {
+      def unapply(d: Def[_]): Nullable[(Ref[SigmaDslBuilder], Ref[Any])] = d match {
+        case MethodCall(receiver, method, args, _) if method.getName == "serialize" && receiver.elem.isInstanceOf[SigmaDslBuilderElem[_]] =>
+          val res = (receiver, args(0))
+          Nullable(res).asInstanceOf[Nullable[(Ref[SigmaDslBuilder], Ref[Any])]]
+        case _ => Nullable.None
+      }
+      def unapply(exp: Sym): Nullable[(Ref[SigmaDslBuilder], Ref[Any])] = unapply(exp.node)
+    }
+
     /** This is necessary to handle CreateAvlTree in GraphBuilding (v6.0) */
     object avlTree {
       def unapply(d: Def[_]): Nullable[(Ref[SigmaDslBuilder], Ref[Byte], Ref[Coll[Byte]], Ref[Int], Ref[WOption[Int]])] = d match {

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
@@ -115,6 +115,91 @@ class LanguageSpecificationV6 extends LanguageSpecificationBase { suite =>
     verifyCases(cases, serializeShort, preGeneratedSamples = None)
   }
 
+  property("Global.serialize[Int]") {
+    lazy val serializeInt = mkSerializeFeature[Int]
+    val expectedCostTrace = TracedCost(
+      baseTrace ++ Array(
+        FixedCostItem(Global),
+        FixedCostItem(MethodCall),
+        FixedCostItem(ValUse),
+        FixedCostItem(NamedDesc("SigmaByteWriter.startWriter"), FixedCost(JitCost(10))),
+        FixedCostItem(NamedDesc("SigmaByteWriter.putNumeric"), FixedCost(JitCost(3)))
+      )
+    )
+    val cases = Seq(
+      (Int.MinValue, Expected(Success(Coll[Byte](-1, -1, -1, -1, -1, -1, -1, -1, -1, 1)), expectedCostTrace)),
+      (-1, Expected(Success(Coll(1.toByte)), expectedCostTrace)),
+      (0, Expected(Success(Coll(0.toByte)), expectedCostTrace)),
+      (1, Expected(Success(Coll(2.toByte)), expectedCostTrace)),
+      (Int.MaxValue, Expected(Success(Coll[Byte](-2, -1, -1, -1, -1, -1, -1, -1, -1, 1)), expectedCostTrace))
+    )
+    verifyCases(cases, serializeInt, preGeneratedSamples = None)
+  }
+
+  property("Global.serialize[Long]") {
+    lazy val serializeLong = mkSerializeFeature[Long]
+    val expectedCostTrace = TracedCost(
+      baseTrace ++ Array(
+        FixedCostItem(Global),
+        FixedCostItem(MethodCall),
+        FixedCostItem(ValUse),
+        FixedCostItem(NamedDesc("SigmaByteWriter.startWriter"), FixedCost(JitCost(10))),
+        FixedCostItem(NamedDesc("SigmaByteWriter.putNumeric"), FixedCost(JitCost(3)))
+      )
+    )
+    val cases = Seq(
+      (-1L, Expected(Success(Coll(1.toByte)), expectedCostTrace)),
+      (0L, Expected(Success(Coll(0.toByte)), expectedCostTrace)),
+      (1L, Expected(Success(Coll(2.toByte)), expectedCostTrace))
+    )
+    verifyCases(cases, serializeLong, preGeneratedSamples = None)
+  }
+
+  property("Global.serialize[Coll[Byte]]") {
+    lazy val serializeCollByte = mkSerializeFeature[Coll[Byte]]
+    val baseCostItems = baseTrace ++ Array(
+      FixedCostItem(Global),
+      FixedCostItem(MethodCall),
+      FixedCostItem(ValUse),
+      FixedCostItem(NamedDesc("SigmaByteWriter.startWriter"), FixedCost(JitCost(10))),
+      FixedCostItem(NamedDesc("SigmaByteWriter.putUNumeric"), FixedCost(JitCost(3)))
+    )
+    val emptyCostTrace = TracedCost(
+      baseCostItems ++ Array(
+        SeqCostItem(NamedDesc("SigmaByteWriter.putChunk"), PerItemCost(JitCost(3), JitCost(1), 1), 0)
+      )
+    )
+    val threeByteCostTrace = TracedCost(
+      baseCostItems ++ Array(
+        SeqCostItem(NamedDesc("SigmaByteWriter.putChunk"), PerItemCost(JitCost(3), JitCost(1), 1), 3)
+      )
+    )
+    val cases = Seq(
+      (Coll[Byte](), Expected(Success(Coll(0.toByte)), emptyCostTrace)),
+      (Coll[Byte](1, 2, 3), Expected(Success(Coll[Byte](3, 1, 2, 3)), threeByteCostTrace))
+    )
+    verifyCases(cases, serializeCollByte, preGeneratedSamples = None)
+  }
+
+  property("Global.serialize[(Long, Long)]") {
+    lazy val serializePair = mkSerializeFeature[(Long, Long)]
+    val expectedCostTrace = TracedCost(
+      baseTrace ++ Array(
+        FixedCostItem(Global),
+        FixedCostItem(MethodCall),
+        FixedCostItem(ValUse),
+        FixedCostItem(NamedDesc("SigmaByteWriter.startWriter"), FixedCost(JitCost(10))),
+        FixedCostItem(NamedDesc("SigmaByteWriter.putNumeric"), FixedCost(JitCost(3))),
+        FixedCostItem(NamedDesc("SigmaByteWriter.putNumeric"), FixedCost(JitCost(3)))
+      )
+    )
+    val cases = Seq(
+      ((0L, 0L), Expected(Success(Coll[Byte](0, 0)), expectedCostTrace)),
+      ((42L, 100L), Expected(Success(Coll[Byte](84, -56.toByte, 1)), expectedCostTrace))
+    )
+    verifyCases(cases, serializePair, preGeneratedSamples = None)
+  }
+
   property("Boolean.toByte") {
     val toByte = newFeature((x: Boolean) => x.toByte, "{ (x: Boolean) => x.toByte }",
       sinceVersion = V6SoftForkVersion


### PR DESCRIPTION
## Summary

`Global.serialize` was defined in the type system and handled in `GraphBuilding`, but missing from `TreeBuilding` and `SigmaDslImpl` extractors. This caused ErgoScript compilation to fail with `Cannot find method serialize` when using `serialize()` in contracts, even though the interpreter could evaluate it correctly.

The sibling method `Global.deserializeTo` already had both pieces — this PR adds the same for `serialize`.

## Changes

- **SigmaDslImpl.scala**: Add `serialize` extractor object (mirrors existing `deserializeTo` extractor)
- **TreeBuilding.scala**: Add `SDBM.serialize` case to convert graph nodes back to `MethodCall` (mirrors `deserializeTo` case)
- **LanguageSpecificationV6.scala**: Add test coverage for `serialize[Int]`, `serialize[Long]`, `serialize[Coll[Byte]]`, and `serialize[(Long, Long)]`

## Test plan

- [x] All 90 LanguageSpecificationV6 tests pass (82 existing + 8 new)
- [x] Verified with primitives (Byte, Short, Int, Long, BigInt)
- [x] Verified with collection type (Coll[Byte])
- [x] Verified with tuple type ((Long, Long))
- [x] Existing serialize/deserialize roundtrip tests pass
- [x] MCLowering variants all pass