### PR TITLE
Fix ContractTemplate deserialization for v6 expression trees

### DIFF
--- a/sdk/shared/src/main/scala/org/ergoplatform/sdk/ContractTemplate.scala
+++ b/sdk/shared/src/main/scala/org/ergoplatform/sdk/ContractTemplate.scala
@@ -305,7 +305,14 @@ object ContractTemplate {
       constants.foreach(c => r.constantStore.put(c)(DeserializationSigmaBuilder))
 
       val _ = r.getUInt().toInt
-      val expressionTree = ValueSerializer.deserialize(r)
+      // Use the template's treeVersion for deserialization context so that
+      // version-gated methods (e.g. serialize in v6) are recognized.
+      // Falls back to JitActivationVersion when treeVersion is not specified,
+      // which is conservative — v6 templates must set treeVersion explicitly.
+      val deserVersion = treeVersion.getOrElse(sigma.VersionContext.JitActivationVersion)
+      val expressionTree = sigma.VersionContext.withVersions(deserVersion, deserVersion) {
+        ValueSerializer.deserialize(r)
+      }
       if (!expressionTree.tpe.isSigmaProp) {
         throw SerializerException(
           s"Failed deserialization, expected deserialized script to have type SigmaProp; got ${expressionTree.tpe}")
@@ -387,14 +394,24 @@ object ContractTemplate {
             name <- cursor.downField("name").as[String]
             description <- cursor.downField("description").as[String]
             parameters <- cursor.downField("parameters").as[IndexedSeq[Parameter]]
-          } yield new ContractTemplate(
-            treeVersion,
-            name,
-            description,
-            constTypes,
-            constValuesOpt,
-            parameters,
-            ValueSerializer.deserialize(r).toSigmaProp)
+          } yield {
+            // Use the template's treeVersion for deserialization context so that
+            // version-gated methods (e.g. serialize in v6) are recognized.
+            // Falls back to JitActivationVersion when treeVersion is not specified,
+            // which is conservative — v6 templates must set treeVersion explicitly.
+            val deserVersion = treeVersion.getOrElse(sigma.VersionContext.JitActivationVersion)
+            val expressionTree = sigma.VersionContext.withVersions(deserVersion, deserVersion) {
+              ValueSerializer.deserialize(r)
+            }
+            new ContractTemplate(
+              treeVersion,
+              name,
+              description,
+              constTypes,
+              constValuesOpt,
+              parameters,
+              expressionTree.toSigmaProp)
+          }
         case _ => Left(DecodingFailure("Failed to decode contract template", cursor.history))
       }
     })


### PR DESCRIPTION
## Summary

`ContractTemplate.fromJsonString()` and `serializer.parse()` fail when the expression tree contains v6 methods (e.g. `serialize`) because `ValueSerializer.deserialize()` runs under the default v2 version context, which doesn't recognize v6 method IDs.

**Fix:** Wrap `ValueSerializer.deserialize()` in `VersionContext.withVersions()` using the template's `treeVersion` field. Falls back conservatively to `JitActivationVersion` (v2) when `treeVersion` is not specified — v6 templates must set `treeVersion` explicitly.

Both deserialization paths are fixed:
- JSON decoder (circe) — used by `fromJsonString()`
- Binary serializer — used by `serializer.parse()`

## Context

Discovered while building sigmastate-js contracts that use `serialize()`. The JAR compiler produces valid EIP-5 JSON with `treeVersion: 3`, but `ContractTemplate$.fromJsonString()` in sigmastate-js failed with `ValidationRule(1011, Check the type has the declared method) with args ArraySeq(SGlobalMethods, 3)`.