### PR TITLE
reject negative-id vars in ContextExtension deserializer

### DIFF
--- a/data/shared/src/main/scala/sigma/interpreter/ContextExtension.scala
+++ b/data/shared/src/main/scala/sigma/interpreter/ContextExtension.scala
@@ -56,6 +56,8 @@ object ContextExtension {
       val values = (0 until extSize)
           .map{_ =>
             val k = r.getByte()
+            if (k < 0)
+              error(s"Negative id of context extension variable: $k")
             val v = r.getValue().asInstanceOf[EvaluatedValue[_ <: SType]]
             CheckV6Type(v)
             (k, v)

--- a/sc/shared/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
+++ b/sc/shared/src/test/scala/org/ergoplatform/ErgoLikeTransactionSpec.scala
@@ -311,7 +311,7 @@ import sigmastate.utils.Helpers.EitherOps  // required for Scala 2.11
           restored.inputs.head.extension.values.size shouldBe tx2.inputs.head.extension.values.size
         }
 
-        if(idRange < 127) {
+        if(startIndex >= 0 && idRange < 127) {
           roundtrip()
         } else {
           assertExceptionThrown(

--- a/sc/shared/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
+++ b/sc/shared/src/test/scala/sigmastate/serialization/DeserializationResilience.scala
@@ -494,4 +494,14 @@ class DeserializationResilience extends DeserializationResilienceTesting {
 
   }
 
+  property("ContextExtension: negative variable id rejected during deserialization") {
+    val ce = ContextExtension(Map((-1).toByte -> IntConstant(1)))
+    val w = SigmaSerializer.startWriter()
+    ContextExtension.serializer.serialize(ce, w)
+    assertExceptionThrown(
+      ContextExtension.serializer.parse(SigmaSerializer.startReader(w.toBytes)),
+      { case SerializerException(msg, _) => msg.contains("Negative id") }
+    )
+  }
+
 }


### PR DESCRIPTION
Negative byte ids are already rejected at the node level (ergoplatform/ergo#2104), so making the deserializer throw SerializerException moves that check earlier and gives a cleaner error. Non-breaking: such transactions were never valid.

Closes #952 