### PR TITLE
Add placeholder[T](index) primitive in ErgoScript

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/ErgoTree.scala
+++ b/data/shared/src/main/scala/sigma/ast/ErgoTree.scala
@@ -1,11 +1,12 @@
 package sigma.ast
 
 import scorex.util.encode.Base16
+import sigma.{Colls, Evaluation}
 import sigma.VersionContext
 import sigma.ast.ErgoTree.{HeaderType, substConstants}
 import sigma.ast.syntax._
-import sigma.data.{CSigmaProp, SigmaBoolean}
-import sigma.kiama.rewriting.Rewriter.{everywherebu, strategy}
+import sigma.data.{CSigmaProp, RType, SigmaBoolean, TrivialProp}
+import sigma.kiama.rewriting.Rewriter.{everywhere, everywherebu, query, strategy}
 import sigma.validation.ValidationException
 import sigma.ast.syntax.ValueOps
 import sigma.eval.Extensions.SigmaBooleanOps
@@ -211,6 +212,27 @@ case class ErgoTree private[sigma](
     }
   }
 
+  /** Return a copy of this tree with the constant at `index` replaced by `c`.
+    *
+    * Use this when the tree was built from a script containing
+    * `placeholder[T](index)` calls (or from any other code path that produced an
+    * ErgoTree with template slots): supply the actual constants for those slots
+    * before evaluation.
+    *
+    * @throws IndexOutOfBoundsException if `index` is outside `constants`
+    * @throws IllegalArgumentException  if `c.tpe` does not equal `constants(index).tpe`
+    */
+  def withConstant(index: Int, c: Constant[SType]): ErgoTree = {
+    if (index < 0 || index >= constants.length)
+      throw new IndexOutOfBoundsException(
+        s"Cannot replace constant at index $index: tree has ${constants.length} constants")
+    val existing = constants(index)
+    if (existing.tpe != c.tpe)
+      throw new IllegalArgumentException(
+        s"Cannot replace constant at index $index: expected type ${existing.tpe}, got ${c.tpe}")
+    new ErgoTree(header, constants.updated(index, c), root)
+  }
+
   /** The default equality of case class is overridden to exclude `complexity`. */
   override def canEqual(that: Any): Boolean = that.isInstanceOf[ErgoTree]
 
@@ -377,12 +399,21 @@ object ErgoTree {
     * 3) write the `tree` to the Writer's buffer obtaining `treeBytes`;
     * 4) deserialize `tree` with ConstantPlaceholders.
     *
+    * If `prop` already contains `ConstantPlaceholder` nodes (e.g. emitted from
+    * `placeholder[T](id)` in source), the segregation step reserves slots
+    * `0..max(id)` for those user-supplied placeholders and allocates new
+    * indices for the inline constants starting at `max(id) + 1`. The resulting
+    * `constants` array has `defaultZero(T)` filled into each user slot, so the
+    * caller is expected to overwrite those with `ErgoTree.withConstant` before
+    * evaluating the tree.
+    *
     * @param header      additional header flags to combine with
     *                    ConstantSegregationHeader flag.
     * @param prop        expression to be transformed into ErgoTree
     * */
   def withSegregation(header: HeaderType, prop: SigmaPropValue): ErgoTree = {
-    val constantStore = new ConstantStore()
+    val reserved = reservedConstantsFromPlaceholders(prop)
+    val constantStore = new ConstantStore(reserved)
     val w             = SigmaSerializer.startWriter(Some(constantStore))
     // serialize value and segregate constants into constantStore
     ValueSerializer.serialize(prop, w)
@@ -395,6 +426,68 @@ object ErgoTree {
       header = setRequiredBits(setConstantSegregation(header)),
       constants = extractedConstants,
       root = Right(valueWithPlaceholders))
+  }
+
+  /** Walk `prop` collecting every existing `ConstantPlaceholder`'s declared
+    * type, validate that all references to the same id agree on a type, and
+    * build a dense `IndexedSeq` of dummy constants of length `max(id) + 1`
+    * suitable for seeding a `ConstantStore` so that segregated indices start
+    * after the user-supplied ones. Returns `EmptyConstants` when the tree has
+    * no placeholders (preserves the legacy behaviour of `withSegregation`).
+    */
+  private def reservedConstantsFromPlaceholders(
+      prop: SigmaPropValue): IndexedSeq[Constant[SType]] = {
+    val byId = scala.collection.mutable.Map.empty[Int, SType]
+    val recordPlaceholder = query[Any] {
+      case ph: ConstantPlaceholder[_] =>
+        byId.get(ph.id) match {
+          case Some(prev) if prev != ph.tpe =>
+            throw new IllegalArgumentException(
+              s"Inconsistent placeholder types for index ${ph.id}: $prev vs ${ph.tpe}")
+          case _ => byId(ph.id) = ph.tpe
+        }
+    }
+    everywhere(recordPlaceholder)(prop)
+    if (byId.isEmpty) return EmptyConstants
+    val maxId = byId.keysIterator.max
+    (0 to maxId).map(i => defaultZero(byId.getOrElse(i, SInt))).toIndexedSeq
+  }
+
+  /** A typed zero-valued `Constant` used to seed user placeholder slots during
+    * segregation. The value is a placeholder for the caller to overwrite via
+    * [[ErgoTree.withConstant]] before evaluating the tree.
+    *
+    * The `tpe` matters for the deserialization round-trip in [[withSegregation]];
+    * the `value` matters when the resulting `ErgoTree` itself is serialized
+    * (e.g. via [[ErgoTreeSerializer]]) — if the caller hasn't filled the slot
+    * yet, the serializer will write this placeholder value to the bytes.
+    *
+    * Currently throws on types this helper doesn't know how to default. The set
+    * of supported types covers what templates need today (numerics, booleans,
+    * collections, options, sigma props); add more cases here as the need
+    * arises.
+    */
+  private def defaultZero(tpe: SType): Constant[SType] = {
+    val v: Any = tpe match {
+      case SBoolean         => false
+      case SByte            => 0.toByte
+      case SShort           => 0.toShort
+      case SInt             => 0
+      case SLong            => 0L
+      case SBigInt          => sigma.data.CBigInt(java.math.BigInteger.ZERO)
+      case SUnit            => ()
+      case SSigmaProp       => CSigmaProp(TrivialProp.FalseProp)
+      case SCollectionType(elemType) =>
+        implicit val tElement: RType[Any] =
+          Evaluation.stypeToRType(elemType).asInstanceOf[RType[Any]]
+        Colls.fromArray(tElement.emptyArray)
+      case SOption(_)       => None
+      case other =>
+        throw new IllegalArgumentException(
+          s"placeholder of type $other has no built-in default; build the " +
+          "ErgoTree directly with a manually-constructed `constants` array.")
+    }
+    Constant(v.asInstanceOf[SType#WrappedType], tpe)
   }
 
   /** Deserializes an ErgoTree instance from a hexadecimal string.

--- a/data/shared/src/main/scala/sigma/ast/Operations.scala
+++ b/data/shared/src/main/scala/sigma/ast/Operations.scala
@@ -148,7 +148,7 @@ object Operations {
   }
 
   object ConstantPlaceholderInfo extends InfoObject {
-    private val func = predefinedOps.specialFuncs("placeholder")
+    private val func = predefinedOps.funcs("placeholder")
     val indexArg: ArgInfo = func.argInfo("index")
     val argInfos: Seq[ArgInfo] = Array(indexArg)
   }

--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -416,6 +416,25 @@ object SigmaPredef {
         Seq(ArgInfo("id", "identifier of the context variable")))
     )
 
+    val PlaceholderFunc = PredefinedFunc("placeholder",
+      Lambda(Array(paramT), Array("index" -> SInt), tT, None),
+      PredefFuncInfo(
+        { case (Ident(_, SFunc(_, rtpe, _)), Seq(id: Constant[SNumericType]@unchecked)) =>
+          val idx = SInt.downcast(id.value.asInstanceOf[AnyVal])
+          if (idx < 0)
+            throw new InvalidArguments(
+              s"placeholder index must be non-negative, got: $idx", id.sourceContext.toOption)
+          mkConstantPlaceholder(idx, rtpe)
+        }),
+      OperationInfo(ConstantPlaceholder,
+        """Reference a constant in the \lst{ErgoTree.constants} array by its index.
+         | The constant at the given index must exist and have a type matching \lst{T}.
+         | Multiple \lst{placeholder} calls with the same index refer to the same constant slot,
+         | which lets the same ErgoTree be reused as a template parameterised by its constants.
+        """.stripMargin,
+        Seq(ArgInfo("index", "index of the constant in the ErgoTree.constants array")))
+    )
+
     val ExecuteFromSelfRegWithDefaultFunc = PredefinedFunc("executeFromSelfRegWithDefault",
       Lambda(
         Seq(paramT),
@@ -559,6 +578,7 @@ object SigmaPredef {
       ExecuteFromVarFunc,
       ExecuteFromSelfRegFunc,
       ExecuteFromSelfRegWithDefaultFunc,
+      PlaceholderFunc,
       SerializeFunc,
       DeserializeToFunc,
       GetVarFromInputFunc,
@@ -726,13 +746,6 @@ object SigmaPredef {
           "Apply the function to the arguments. ",
           Seq(ArgInfo("func", "function which is applied"),
             ArgInfo("args", "list of arguments")))
-      ),
-      PredefinedFunc("placeholder",
-        Lambda(Array(paramT), Array("id" -> SInt), tT, None),
-        PredefFuncInfo(undefined),
-        OperationInfo(ConstantPlaceholder,
-          "Create special ErgoTree node which can be replaced by constant with given id.",
-          Seq(ArgInfo("index", "index of the constant in ErgoTree header")))
       )
     ).map(f => f.name -> f).toMap
 

--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
@@ -535,6 +535,7 @@ class SigmaTyper(val builder: SigmaBuilder,
     case LastBlockUtxoRootHash => LastBlockUtxoRootHash
     case v: GetVar[_] => v
     case v: OptionGet[_] => v
+    case v: ConstantPlaceholder[_] => v
     case v: EvaluatedValue[_] => v
     case v: SigmaBoolean => v
     case v: Upcast[_, _] => v

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -4,6 +4,7 @@ import org.ergoplatform.ErgoAddressEncoder.TestnetNetworkPrefix
 import org.ergoplatform._
 import scorex.util.encode.Base58
 import sigma.ast.{ByIndex, ExtractAmount, GetVar, _}
+import sigma.ast.SCollection.SByteArray
 import sigma.ast.syntax._
 import sigmastate._
 import sigmastate.helpers.CompilerTestingCommons
@@ -118,6 +119,89 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     comp("getVar[Byte](10).get") shouldBe GetVar(10.toByte, SByte).get
     comp("getVar[Byte](10L).get") shouldBe GetVar(10.toByte, SByte).get
     an[TyperException] should be thrownBy comp("getVar[Byte](\"ha\")")
+  }
+
+  property("placeholder") {
+    // Bypass `checkSerializationRoundTrip` because a tree containing a
+    // `ConstantPlaceholder` cannot round-trip through `ValueSerializer` without
+    // a populated `ConstantStore`. End-to-end round-tripping is exercised via
+    // `ErgoTree.withSegregation` in the segregation tests below.
+    def buildTree(env: ScriptEnv, code: String): SValue =
+      compiler.compile(env, code).buildTree
+
+    buildTree(env, "placeholder[Int](0)") shouldBe ConstantPlaceholder(0, SInt)
+    buildTree(env, "placeholder[Long](2)") shouldBe ConstantPlaceholder(2, SLong)
+    buildTree(env, "placeholder[Coll[Byte]](1)") shouldBe ConstantPlaceholder(1, SByteArray)
+
+    // Negative index is rejected at IR-builder time.
+    an[InvalidArguments] should be thrownBy buildTree(env, "placeholder[Int](-1)")
+
+    // Non-literal index is rejected by the typer (no overload matches).
+    an[Exception] should be thrownBy buildTree(env, "{ val i = 0; placeholder[Int](i) }")
+  }
+
+  property("placeholder segregation: pure template") {
+    // `placeholder[T](id)` with no inline constants leaves the constants array
+    // empty for the user-supplied slots; `withSegregation` seeds typed dummies
+    // so the round-trip works and the caller can fill via `withConstant`.
+    val buildTree = compiler.compile(env, "placeholder[Int](0) > HEIGHT").buildTree
+    val tree = ErgoTree.fromProposition(buildTree.asSigmaProp)
+
+    tree.isConstantSegregation shouldBe true
+    tree.constants should have size 1
+    tree.constants(0).tpe shouldBe SInt
+
+    val withReal = tree.withConstant(0, IntConstant(42))
+    withReal.constants(0) shouldBe IntConstant(42)
+  }
+
+  property("placeholder segregation: shared slot") {
+    // Two `placeholder[T](0)` references share the same slot — the resulting
+    // tree has one constant in `constants` and two `ConstantPlaceholder(0, _)`
+    // nodes in the body.
+    val buildTree = compiler.compile(env, "placeholder[Int](0) + placeholder[Int](0) > 1").buildTree
+    val tree = ErgoTree.fromProposition(buildTree.asSigmaProp)
+
+    tree.isConstantSegregation shouldBe true
+    // slot 0: user placeholder (Int dummy); slot 1: extracted IntConstant(1)
+    tree.constants should have size 2
+    tree.constants(0).tpe shouldBe SInt
+    tree.constants(1) shouldBe IntConstant(1)
+  }
+
+  property("placeholder segregation: type inconsistency") {
+    val buildTree = compiler.compile(env, "placeholder[Int](0) + placeholder[Long](0).toInt > 0").buildTree
+    an[IllegalArgumentException] should be thrownBy
+      ErgoTree.fromProposition(buildTree.asSigmaProp)
+  }
+
+  property("placeholder segregation: ErgoTreeSerializer round-trip") {
+    import sigma.serialization.ErgoTreeSerializer.DefaultSerializer
+    val buildTree = compiler.compile(env, "sigmaProp(placeholder[Long](0) > 1000L)").buildTree
+    val tree = ErgoTree.fromProposition(buildTree.asSigmaProp)
+    val filled = tree.withConstant(0, LongConstant(2000L))
+
+    val bytes = DefaultSerializer.serializeErgoTree(filled)
+    val parsed = DefaultSerializer.deserializeErgoTree(bytes)
+    parsed shouldBe filled
+    parsed.constants(0) shouldBe LongConstant(2000L)
+  }
+
+  property("placeholder segregation: Coll[Byte] template") {
+    // Templates often parameterise on byte arrays (hashes, pubkey bytes).
+    // The dummy slot must be a serialisable Coll so the unfilled tree can
+    // round-trip through ErgoTreeSerializer.
+    import sigma.serialization.ErgoTreeSerializer.DefaultSerializer
+    val buildTree = compiler.compile(env, "sigmaProp(placeholder[Coll[Byte]](0).size == 32)").buildTree
+    val tree = ErgoTree.fromProposition(buildTree.asSigmaProp)
+    tree.constants(0).tpe shouldBe SByteArray
+
+    val pubkey = ByteArrayConstant(Array.fill[Byte](32)(0x42))
+    val filled = tree.withConstant(0, pubkey)
+
+    val parsed = DefaultSerializer.deserializeErgoTree(DefaultSerializer.serializeErgoTree(filled))
+    parsed shouldBe filled
+    parsed.constants(0) shouldBe pubkey
   }
 
   property("PK (testnet network prefix)") {


### PR DESCRIPTION
Move the existing predef stub from specialFuncs to globalFuncs with an IR builder that emits ConstantPlaceholder(index, T). withSegregation now reserves slots for any user-supplied placeholders (validating type-consistency per id) and starts auto-segregated indices after max(userId). Adds ErgoTree.withConstant for filling template slots.

Closes #381