### PR TITLE
Extend declared/actual type check to composite types

### DIFF
--- a/core/shared/src/main/scala/sigma/ast/SType.scala
+++ b/core/shared/src/main/scala/sigma/ast/SType.scala
@@ -212,23 +212,6 @@ object SType {
     case _ => sys.error(s"Unknown type $tpe")
   }
 
-  def isAssignableTo(tpe: SType): Boolean = tpe match {
-    case SBoolean => true
-    case SByte => true
-    case SShort => true
-    case SInt => true
-    case SLong => true
-    case SBigInt => true
-    case SString => true
-    case NoType => false
-    case _ => false
-  }
-
-  def getResultType(tpe: SType): SType = tpe match {
-    case SFunc(_, rangeType, _) => rangeType
-    case _ => tpe
-  }
-
   implicit class AnyOps(val x: Any) extends AnyVal {
     /** Helper method to simplify type casts. */
     def asWrappedType: SType#WrappedType = x.asInstanceOf[SType#WrappedType]

--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaBinder.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaBinder.scala
@@ -92,7 +92,7 @@ class SigmaBinder(env: ScriptEnv, builder: SigmaBuilder,
         if (env.contains(n)) error(s"Variable $n already defined ($n = ${env(n)}", v.sourceContext)
         val b1 = eval(b, env)
         builder.currentSrcCtx.withValue(v.sourceContext) {
-          mkVal(n, if (t != NoType) t else b1.tpe, b1)
+          mkVal(n, t, b1)
         }
       }
       val t1 = eval(t, env)

--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
@@ -75,10 +75,23 @@ class SigmaTyper(val builder: SigmaBuilder,
         if (curEnv.contains(n))
           error(s"Variable $n already defined ($n = ${curEnv(n)}", v.sourceContext)
         val expectedForB = if (explicitType != NoType) Some(explicitType) else None
+        // `def f(args): R = body` is parsed as `Val(f, R, Lambda(.., givenResType = R, ..))`
+        // — the user's ascription is the *return type*, not the full function type.
+        // Detect this on the *pre-typing* body (the typer fills `givenResType` unconditionally)
+        // and compare against the lambda's range.
+        val isFunDef = b match {
+          case lam: Lambda => lam.givenResType != NoType
+          case _ => false
+        }
         val b1 = assignType(curEnv, b, expectedForB)
-        val resultType = SType.getResultType(b1.tpe)
-        if (SType.isAssignableTo(explicitType) && explicitType != resultType)
-          error(s"Expected type ${explicitType}, but got ${b1.tpe}", v.sourceContext)
+        val actualType = if (isFunDef) b1.tpe.asInstanceOf[SFunc].tRange else b1.tpe
+        explicitType match {
+          case NoType => ()
+          case tv: STypeVar => error(s"Unknown type ${tv.name}", v.sourceContext)
+          case t if t != actualType =>
+            error(s"Expected type $t, but got $actualType", v.sourceContext)
+          case _ => ()
+        }
         curEnv = curEnv + (n -> b1.tpe)
         builder.currentSrcCtx.withValue(v.sourceContext) {
           bs1 += mkVal(n, b1.tpe, b1)

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaBinderTest.scala
@@ -91,11 +91,11 @@ class SigmaBinderTest extends AnyPropSpec with ScalaCheckPropertyChecks with Mat
 
   property("val constructs") {
     bind(env, "{val X = 10; X > 2}") shouldBe
-      Block(Val("X", SInt, IntConstant(10)), GT(IntIdent("X"), 2))
+      Block(Val("X", NoType, IntConstant(10)), GT(IntIdent("X"), 2))
     bind(env, "{val X = 10; X >= X}") shouldBe
-      Block(Val("X", SInt, IntConstant(10)), GE(IntIdent("X"), IntIdent("X")))
+      Block(Val("X", NoType, IntConstant(10)), GE(IntIdent("X"), IntIdent("X")))
     bind(env, "{val X = 10 - 1; X >= X}") shouldBe
-      Block(Val("X", SInt, Minus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
+      Block(Val("X", NoType, Minus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
     bind(env, "{val X = 10 + 1; X >= X}") shouldBe
       Block(Val("X", NoType, plus(10, 1)), GE(IntIdent("X"), IntIdent("X")))
     bind(env,
@@ -103,11 +103,11 @@ class SigmaBinderTest extends AnyPropSpec with ScalaCheckPropertyChecks with Mat
         |val Y = 11
         |X > Y}
       """.stripMargin) shouldBe Block(
-      Seq(Val("X", SInt, IntConstant(10)), Val("Y", SInt, IntConstant(11))),
+      Seq(Val("X", NoType, IntConstant(10)), Val("Y", NoType, IntConstant(11))),
       GT(IntIdent("X"), IntIdent("Y")))
     bind(env, "{val X = (10, true); X._1 > 2 && X._2}") shouldBe
       Block(
-        Val("X", STuple(SInt, SBoolean), Tuple(IntConstant(10), TrueLeaf)),
+        Val("X", NoType, Tuple(IntConstant(10), TrueLeaf)),
         MethodCallLike(GT(Select(IntIdent("X"), "_1").asValue[SInt.type], 2), "&&", IndexedSeq(Select(IntIdent("X"), "_2").asValue[SBoolean.type])))
   }
 
@@ -154,7 +154,7 @@ class SigmaBinderTest extends AnyPropSpec with ScalaCheckPropertyChecks with Mat
       """if (true) { val A = x; 1 }
         |else if (x == y) 2 else 3""".stripMargin) shouldBe
       If(TrueLeaf,
-        Block(Val("A", SInt, IntConstant(10)), IntConstant(1)),
+        Block(Val("A", NoType, IntConstant(10)), IntConstant(1)),
         If(EQ(IntConstant(10), IntConstant(11)), IntConstant(2), IntConstant(3)))
   }
 
@@ -177,7 +177,13 @@ class SigmaBinderTest extends AnyPropSpec with ScalaCheckPropertyChecks with Mat
 
   property("function definitions") {
     bind(env, "{val f = {(a: Int) => a - 1}; f}") shouldBe
-      Block(Val("f", SFunc(IndexedSeq(SInt), NoType), Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))), Ident("f"))
+      Block(Val("f", NoType, Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))), Ident("f"))
+    // FunDef without return type — givenType stays NoType
+    bind(env, "{def f(a: Int) = a - 1; f}") shouldBe
+      Block(Val("f", NoType, Lambda(IndexedSeq("a" -> SInt), NoType, mkMinus(IntIdent("a"), 1))), Ident("f"))
+    // FunDef with explicit return type — givenType = R preserved (not lifted to SFunc)
+    bind(env, "{def f(a: Int): Int = a - 1; f}") shouldBe
+      Block(Val("f", SInt, Lambda(IndexedSeq("a" -> SInt), SInt, mkMinus(IntIdent("a"), 1))), Ident("f"))
   }
 
   property("predefined primitives") {

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -178,10 +178,9 @@ class SigmaTyperTest extends AnyPropSpec
     typecheck(env, "{val X: Int = 5 + 5; X}") shouldBe SInt
     typefail(env, "{val X: Long = 5 + 5; X}", 1, 6)  // Int expression assigned to Long
 
-    // Test with functions - should extract return type
+    // Test with functions - extract return type
     typecheck(env, "{val f: Int => Int = { (x: Int) => x + 1 }; f}") shouldBe SFunc(IndexedSeq(SInt), SInt)
-    // NOTE: Function type annotation validation not enforced strictly
-    // typefail(env, "{val f: Int => Long = { (x: Int) => x }; f}", 1, 6)  // Function returns Int, annotated as Long
+    typefail(env, "{val f: Int => Long = { (x: Int) => x }; f}", 1, 6)  // Function returns Int, annotated as Long
 
     // Test with nested vals
     typecheck(env, "{val X: Int = {val Y = 10; Y}; X}") shouldBe SInt
@@ -190,34 +189,59 @@ class SigmaTyperTest extends AnyPropSpec
     // Test NoType (no explicit annotation) - should work as before
     typecheck(env, "{val X = 10; X}") shouldBe SInt
     typecheck(env, "{val X = true; X}") shouldBe SBoolean
-    
-    // Test Coll[] type annotations
-    // Valid Coll type annotations
+
+    // Coll[] type annotations - valid
     typecheck(env, "{val X: Coll[Int] = Coll(1,2,3); X}") shouldBe SCollection(SInt)
     typecheck(env, "{val X: Coll[Byte] = Coll(1.toByte, 2.toByte); X}") shouldBe SCollection(SByte)
     typecheck(env, "{val X: Coll[Long] = Coll(1L, 2L); X}") shouldBe SCollection(SLong)
     typecheck(env, "{val X: Coll[Boolean] = Coll(true, false); X}") shouldBe SCollection(SBoolean)
     typecheck(env, "{val X: Coll[SigmaProp] = Coll(p1, p2); X}") shouldBe SCollection(SSigmaProp)
-    
-    // NOTE: Coll[] type annotations are NOT strictly validated by the new feature
-    // because isAssignableTo only checks primitive types (Boolean, Byte, Short, Int, Long, BigInt, String)
-    // The following typefail tests would pass if Coll[] validation was added in the future:
-    // typefail(env, "{val X: Coll[Int] = Coll(1L, 2L); X}", 1, 6)  // Coll[Long] assigned to Coll[Int]
-    // typefail(env, "{val X: Coll[Long] = Coll(1, 2); X}", 1, 6)  // Coll[Int] assigned to Coll[Long]
-    
-    // Nested Coll types - valid annotations
+
+    // Coll[] type annotations - invalid (inner-type mismatch)
+    typefail(env, "{val X: Coll[Int] = Coll(1L, 2L); X}", 1, 6)
+    typefail(env, "{val X: Coll[Long] = Coll(1, 2); X}", 1, 6)
+
+    // Nested Coll types - valid
     typecheck(env, "{val X: Coll[Coll[Int]] = Coll(Coll(1), Coll(2)); X}") shouldBe SCollection(SCollection(SInt))
     typecheck(env, "{val X: Coll[Coll[Byte]] = Coll(Coll(1.toByte), Coll(2.toByte)); X}") shouldBe SCollection(SCollection(SByte))
-    
-    // Test Option[] type annotations
+
+    // Nested Coll types - invalid
+    typefail(env, "{val X: Coll[Coll[Int]] = Coll(Coll(1L)); X}", 1, 6)
+
+    // Option[] type annotations - valid
     typecheck(env, "{val X: Option[Int] = getVar[Int](1); X}") shouldBe SOption(SInt)
     typecheck(env, "{val X: Option[Long] = getVar[Long](1); X}") shouldBe SOption(SLong)
     typecheck(env, "{val X: Option[Boolean] = getVar[Boolean](1); X}") shouldBe SOption(SBoolean)
     typecheck(env, "{val X: Option[Byte] = getVar[Byte](1); X}") shouldBe SOption(SByte)
     typecheck(env, "{val X: Option[Coll[Int]] = getVar[Coll[Int]](1); X}") shouldBe SOption(SCollection(SInt))
-    
-    // NOTE: Option[] type annotations are NOT strictly validated for mismatches
-    // because isAssignableTo only checks primitive types (Boolean, Byte, Short, Int, Long, BigInt)
+
+    // Option[] type annotations - invalid (inner-type mismatch)
+    typefail(env, "{val X: Option[Int] = getVar[Long](1); X}", 1, 6)
+    typefail(env, "{val X: Option[Coll[Int]] = getVar[Coll[Long]](1); X}", 1, 6)
+
+    // Tuple type annotations - invalid (element-type mismatch)
+    typefail(env, "{val X: (Int, Boolean) = (1, 2); X}", 1, 6)
+    typefail(env, "{val X: (Coll[Int], Int) = (Coll(1L), 1); X}", 1, 6)
+
+    // SigmaProp vs Boolean
+    typefail(env, "{val X: SigmaProp = true; X}", 1, 6)
+
+    // Composite type mismatches
+    typefail(env, "{val X: Box = INPUTS; X}", 1, 6)
+    typefail(env, "{val X: GroupElement = 1; X}", 1, 6)
+
+    // Undeclared type name — parsed as STypeVar (issue #404 example 1)
+    typefail(env, "{val f: XYZ = INPUTS.map({(box: Box) => box.value == 1L}); f}", 1, 6)
+
+    // FunDef syntax (`def f(args): R = body`) — explicit return type compared
+    // against the lambda's range (isFunDef discriminator)
+    typecheck(env, "{ def f(x: Int): Int = x + 1; f }") shouldBe SFunc(IndexedSeq(SInt), SInt)
+    typefail(env, "{ def f(x: Int): Boolean = x + 1; f }", 1, 7)
+    typecheck(env, "{ def f(x: Int) = x + 1; f }") shouldBe SFunc(IndexedSeq(SInt), SInt)
+
+    // ValVarDef with lambda body but non-function annotation — isFunDef=false,
+    // so the equality check compares against the full SFunc and errors.
+    typefail(env, "{ val f: Int = { (x: Int) => x + 1 }; f }", 1, 7)
   }
 
   property("generic methods of arrays") {


### PR DESCRIPTION
Drops the `isAssignableTo` / `getResultType` allowlist helpers from `SType` in favour of structural equality on the user's ascription. The `SigmaBinder` no longer overwrites `Val.givenType` with the body's partial type, so the typer can tell user-written ascriptions from binder scaffolding (`Val.tpe` still falls back to `body.tpe` for any downstream consumer). `def f(args): R = body` is handled via an `isFunDef` discriminator that compares against the lambda's range.

PR #1061 caught `val x: Boolean = 10` and `val price: Long = bigInt`, but only for 7 primitive types. `Coll[T]` / `Option[T]` inner mismatches, tuple element mismatches, `SFunc` return mismatches, `SigmaProp`/`Box` mismatches, and undeclared type names (issue #404 ex 1: `val f: XYZ = …`) were silently accepted.

Closes #404 and #915