### PR TITLE
Lower n-ary functions to tupled form

### DIFF
--- a/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/SigmaCompiler.scala
@@ -13,7 +13,7 @@ import sigma.ast._
 import sigma.ast.syntax.SValue
 import SCollectionMethods.{ExistsMethod, ForallMethod, MapMethod}
 import sigma.compiler.ir.{GraphIRReflection, IRContext}
-import sigma.compiler.phases.{SigmaBinder, SigmaTyper}
+import sigma.compiler.phases.{NAryFunctionLowering, SigmaBinder, SigmaTyper}
 import sigmastate.InterpreterReflection
 import sigmastate.lang.SigmaParser
 
@@ -98,7 +98,8 @@ class SigmaCompiler private(settings: CompilerSettings) {
         .zipWithIndex
         .map { case ((name, t), index) => name -> ConstantPlaceholder(index, t) }
         .toMap
-    val compiledGraph = IR.buildGraph(env ++ placeholdersEnv, typedExpr)
+    val loweredExpr = NAryFunctionLowering.lower(typedExpr)
+    val compiledGraph = IR.buildGraph(env ++ placeholdersEnv, loweredExpr)
     val compiledTree = IR.buildTree(compiledGraph)
     CompilerResult(env, "<no source code>", compiledGraph, compiledTree)
   }

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
@@ -907,21 +907,16 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
         val y = eval(rel.right)
         binop.apply(x, asRep[t#WrappedType](y))
 
+      // Single-argument case. The NAryFunctionLowering compiler phase
+      // (run by SigmaCompiler before buildGraph) rewrites n-ary lambdas
+      // into 1-arg lambdas over right-nested pairs, so this is the only
+      // AST Lambda shape that reaches GraphBuilding.
       case sigma.ast.Lambda(_, Seq((n, argTpe)), _, Some(body)) =>
         val eArg = stypeToElem(argTpe).asInstanceOf[Elem[Any]]
         val f = fun(removeIsProven({ x: Ref[Any] =>
           buildNode(ctx, env + (n -> x), body)
         }))(Lazy(eArg))
         f
-
-      case sigma.ast.Lambda(_, Seq((accN, accTpe), (n, tpe)), _, Some(body)) =>
-        (stypeToElem(accTpe), stypeToElem(tpe)) match { case (eAcc: Elem[s], eA: Elem[a]) =>
-          val eArg = pairElement(eAcc, eA)
-          val f = fun { x: Ref[(s, a)] =>
-            buildNode(ctx, env + (accN -> x._1) + (n -> x._2), body)
-          }(Lazy(eArg))
-          f
-        }
 
       case FuncValue(Seq((n, argTpe)), body) =>
         val eArg = stypeToElem(argTpe).asInstanceOf[Elem[Any]]

--- a/sc/shared/src/main/scala/sigma/compiler/phases/NAryFunctionLowering.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/NAryFunctionLowering.scala
@@ -1,0 +1,117 @@
+package sigma.compiler.phases
+
+import sigma.VersionContext
+import sigma.ast._
+import sigma.ast.syntax._
+import sigma.exceptions.BuilderException
+import sigma.kiama.rewriting.Rewriter.{everywherebu, rewrite, rule}
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Desugars n-ary functions and applications into single-argument form over
+  * right-nested pairs.
+  *
+  * ErgoTree's runtime supports only single-argument [[FuncValue]]s and only
+  * 2-element [[Tuple]]s / [[SelectField]]s. To allow ErgoScript users to write
+  * `def f(a, b, c) = ...; f(x, y, z)` we lower:
+  *
+  *  - n-ary lambda definitions into a 1-arg lambda taking a right-nested pair,
+  *    with a [[Block]] that re-binds each parameter to a [[SelectField]] chain;
+  *  - n-ary applications into a 1-arg application whose single argument is the
+  *    right-nested pair built from the original arguments.
+  *
+  * Example (n=3):
+  * {{{
+  *   Lambda([(a, A), (b, B), (c, C)], R, body)
+  * }}}
+  * is rewritten to:
+  * {{{
+  *   Lambda([($tup, (A, (B, C)))], R,
+  *     Block(
+  *       Val(a, A, SelectField($tup, 1)),
+  *       Val(b, B, SelectField(SelectField($tup, 2), 1)),
+  *       Val(c, C, SelectField(SelectField($tup, 2), 2)),
+  *       body
+  *     )
+  *   )
+  * }}}
+  *
+  * Identifier references in the body are left untouched — the inserted
+  * [[Block]] reintroduces the same names, so lexical scoping and inner-lambda
+  * shadowing keep working.
+  */
+object NAryFunctionLowering {
+
+  private val freshNamePrefix = "$tup"
+
+  /** Lower n-ary lambdas and applications in `expr` to their single-argument
+    * tuple-based equivalents. Other nodes are returned unchanged.
+    */
+  def lower(expr: SValue): SValue = {
+    val counter = new AtomicInteger(0)
+    def freshName(): String = freshNamePrefix + counter.getAndIncrement()
+
+    val r = rule[Any]({
+      case lam @ Lambda(tparams, args, givenResType, Some(body)) if args.length >= 2 =>
+        val tupName = freshName()
+        val tupTpe = nestPairType(args.map(_._2))
+        val tupRef = Ident(tupName, tupTpe)
+        val bindings: Seq[Val] = args.zipWithIndex.map { case ((name, tpe), i) =>
+          ValNode(name, tpe, projectAt(tupRef, i, args.length))
+        }
+        val newBody = Block(bindings, body)
+        Lambda(tparams, IndexedSeq((tupName, tupTpe)), givenResType, Some(newBody))
+          .withPropagatedSrcCtx(lam.sourceContext)
+
+      case app @ Apply(f, args) if args.length >= 2 && f.tpe.isFunc =>
+        if (!VersionContext.current.isV6Activated) {
+          throw new BuilderException(
+            "n-ary user-defined functions require ErgoTree v6+ " +
+              "(activated script version 3 or later)",
+            app.sourceContext.toOption)
+        }
+        Apply(f, IndexedSeq(nestPairValue(args)))
+          .withPropagatedSrcCtx(app.sourceContext)
+    })
+
+    rewrite(everywherebu(r))(expr).asInstanceOf[SValue]
+  }
+
+  /** Right-nested pair type for `types`. Pre: `types.length >= 1`. */
+  private[phases] def nestPairType(types: IndexedSeq[SType]): SType = {
+    require(types.nonEmpty, "nestPairType requires at least one type")
+    types.reduceRight((t, acc) => STuple(t, acc))
+  }
+
+  /** Right-nested pair value for `items`. Pre: `items.length >= 1`. */
+  private[phases] def nestPairValue(items: IndexedSeq[SValue]): SValue = {
+    require(items.nonEmpty, "nestPairValue requires at least one item")
+    items.reduceRight((v, acc) => Tuple(IndexedSeq(v, acc)))
+  }
+
+  /** SelectField chain projecting the `index`-th of `count` items out of the
+    * right-nested pair `root`. Indices are 0-based; `count >= 2`.
+    *
+    * For (A, (B, (C, D))):
+    *   index=0 → root._1
+    *   index=1 → root._2._1
+    *   index=2 → root._2._2._1
+    *   index=3 → root._2._2._2
+    *
+    * Walk `_2` `min(index, count-2)` times into the nested pair, then pick
+    * `_2` if `index` is the last element, otherwise `_1`.
+    */
+  private[phases] def projectAt(root: SValue, index: Int, count: Int): SValue = {
+    require(count >= 2, "projectAt expects nested pair (count >= 2)")
+    require(0 <= index && index < count, s"index $index out of bounds for count $count")
+    val walks = math.min(index, count - 2)
+    var node: Value[STuple] = root.asInstanceOf[Value[STuple]]
+    var i = 0
+    while (i < walks) {
+      node = SelectField(node, 2.toByte).asInstanceOf[Value[STuple]]
+      i += 1
+    }
+    val fieldIdx: Byte = if (index == count - 1) 2 else 1
+    SelectField(node, fieldIdx)
+  }
+}

--- a/sc/shared/src/test/scala/sigma/compiler/phases/NAryFunctionLoweringTest.scala
+++ b/sc/shared/src/test/scala/sigma/compiler/phases/NAryFunctionLoweringTest.scala
@@ -1,0 +1,195 @@
+package sigma.compiler.phases
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import sigma.VersionContext
+import sigma.ast._
+import sigma.ast.syntax.SValue
+
+class NAryFunctionLoweringTest extends AnyPropSpec with Matchers {
+
+  private def id(n: String, t: SType): Ident = Ident(n, t)
+
+  /** Run `block` with the v6 protocol version active.
+    *
+    * `NAryFunctionLowering` gates the Apply rewrite behind v6+, so any unit
+    * test that constructs an n-arg `Apply` must be wrapped in this. Tests that
+    * only exercise the (always-on) Lambda rewrite can run at any version.
+    */
+  private def atV6[A](block: => A): A =
+    VersionContext.withVersions(
+      activatedVersion = VersionContext.V6SoftForkVersion,
+      ergoTreeVersion = VersionContext.V6SoftForkVersion)(block)
+
+  property("1-arg lambda is unchanged") {
+    val lam = Lambda(IndexedSeq("x" -> SInt), SInt, Some(id("x", SInt)))
+    NAryFunctionLowering.lower(lam) shouldBe lam
+  }
+
+  property("2-arg lambda lowers to single tuple-arg with Block of two projections") {
+    val body = id("a", SInt)
+    val lam = Lambda(IndexedSeq("a" -> SInt, "b" -> SInt), SInt, Some(body))
+
+    val lowered = NAryFunctionLowering.lower(lam).asInstanceOf[Lambda]
+    lowered.args.length shouldBe 1
+
+    val (tupName, tupTpe) = lowered.args.head
+    tupTpe shouldBe STuple(SInt, SInt)
+
+    val block = lowered.body.get.asInstanceOf[Block]
+    block.bindings should have size 2
+    val Seq(va, vb) = block.bindings
+    va.name shouldBe "a"
+    va.body shouldBe SelectField(Ident(tupName, tupTpe).asInstanceOf[Value[STuple]], 1.toByte)
+    vb.name shouldBe "b"
+    vb.body shouldBe SelectField(Ident(tupName, tupTpe).asInstanceOf[Value[STuple]], 2.toByte)
+    block.result shouldBe body
+  }
+
+  property("3-arg lambda lowers to right-nested pair type and chained SelectFields") {
+    val body = id("a", SInt)
+    val lam = Lambda(IndexedSeq("a" -> SInt, "b" -> SInt, "c" -> SInt), SInt, Some(body))
+
+    val lowered = NAryFunctionLowering.lower(lam).asInstanceOf[Lambda]
+    val (tupName, tupTpe) = lowered.args.head
+    tupTpe shouldBe STuple(SInt, STuple(SInt, SInt))
+
+    val block = lowered.body.get.asInstanceOf[Block]
+    val tupRef = Ident(tupName, tupTpe).asInstanceOf[Value[STuple]]
+    val proj0 = SelectField(tupRef, 1.toByte)
+    val proj1 = SelectField(SelectField(tupRef, 2.toByte).asInstanceOf[Value[STuple]], 1.toByte)
+    val proj2 = SelectField(SelectField(tupRef, 2.toByte).asInstanceOf[Value[STuple]], 2.toByte)
+
+    block.bindings.map(_.body) shouldBe Seq(proj0, proj1, proj2)
+    block.bindings.map(_.name) shouldBe Seq("a", "b", "c")
+  }
+
+  property("4-arg lambda projections match the right-nested pair shape") {
+    val lam = Lambda(
+      IndexedSeq("a" -> SLong, "b" -> SLong, "c" -> SLong, "d" -> SLong),
+      SLong,
+      Some(id("a", SLong)))
+
+    val lowered = NAryFunctionLowering.lower(lam).asInstanceOf[Lambda]
+    val (tupName, tupTpe) = lowered.args.head
+    tupTpe shouldBe STuple(SLong, STuple(SLong, STuple(SLong, SLong)))
+
+    val tupRef = Ident(tupName, tupTpe).asInstanceOf[Value[STuple]]
+    def sel2(v: SValue): Value[STuple] =
+      SelectField(v.asInstanceOf[Value[STuple]], 2.toByte).asInstanceOf[Value[STuple]]
+    val expected = Seq(
+      SelectField(tupRef, 1.toByte),
+      SelectField(sel2(tupRef), 1.toByte),
+      SelectField(sel2(sel2(tupRef)), 1.toByte),
+      SelectField(sel2(sel2(tupRef)), 2.toByte)
+    )
+    val block = lowered.body.get.asInstanceOf[Block]
+    block.bindings.map(_.body) shouldBe expected
+  }
+
+  property("n-arg Apply is tupled into a single right-nested pair argument") {
+    atV6 {
+      val f = Ident("f", SFunc(IndexedSeq(SInt, SInt, SInt), SInt))
+      val a1 = IntConstant(1)
+      val a2 = IntConstant(2)
+      val a3 = IntConstant(3)
+      val app = Apply(f, IndexedSeq(a1, a2, a3))
+      val lowered = NAryFunctionLowering.lower(app).asInstanceOf[Apply]
+      lowered.func shouldBe f
+      lowered.args.length shouldBe 1
+      lowered.args.head shouldBe Tuple(IndexedSeq(a1, Tuple(IndexedSeq(a2, a3))))
+    }
+  }
+
+  property("1-arg Apply is unchanged") {
+    val f = Ident("f", SFunc(IndexedSeq(SInt), SInt))
+    val app = Apply(f, IndexedSeq(IntConstant(7)))
+    NAryFunctionLowering.lower(app) shouldBe app
+  }
+
+  property("lowering of n-arg Apply is gated to v6+") {
+    val f = Ident("f", SFunc(IndexedSeq(SInt, SInt), SInt))
+    val app = Apply(f, IndexedSeq(IntConstant(1), IntConstant(2)))
+    // Pre-v6: throw a clear BuilderException.
+    VersionContext.withVersions(activatedVersion = 2, ergoTreeVersion = 2) {
+      val ex = the [sigma.exceptions.BuilderException] thrownBy
+        NAryFunctionLowering.lower(app)
+      ex.getMessage should include ("require ErgoTree v6+")
+    }
+    // v6+: the rewrite succeeds.
+    atV6 {
+      NAryFunctionLowering.lower(app).asInstanceOf[Apply].args.length shouldBe 1
+    }
+  }
+
+  property("Lambda rewrite is not gated — n-ary lambdas lower at every version") {
+    // The Lambda rule is plumbing required by HOF lambdas (e.g. fold's
+    // 2-arg lambda) and must work at every protocol version.
+    val lam = Lambda(IndexedSeq("a" -> SInt, "b" -> SInt), SInt, Some(id("a", SInt)))
+    VersionContext.withVersions(activatedVersion = 2, ergoTreeVersion = 2) {
+      val lowered = NAryFunctionLowering.lower(lam).asInstanceOf[Lambda]
+      lowered.args.length shouldBe 1
+      lowered.args.head._2 shouldBe STuple(SInt, SInt)
+    }
+  }
+
+  property("lowering is idempotent") {
+    val lam = Lambda(IndexedSeq("a" -> SInt, "b" -> SInt, "c" -> SInt), SInt, Some(id("a", SInt)))
+    val once = NAryFunctionLowering.lower(lam)
+    val twice = NAryFunctionLowering.lower(once)
+    twice shouldBe once
+  }
+
+  property("1-arg lambda whose param is already an STuple passes through unchanged") {
+    val tupTpe = STuple(SInt, SInt)
+    val lam = Lambda(
+      IndexedSeq("t" -> tupTpe),
+      SInt,
+      Some(SelectField(id("t", tupTpe).asInstanceOf[Value[STuple]], 1.toByte)))
+    NAryFunctionLowering.lower(lam) shouldBe lam
+  }
+
+  property("sibling n-ary lambdas get distinct fresh tuple names") {
+    val lam1 = Lambda(IndexedSeq("a" -> SInt, "b" -> SInt), SInt, Some(id("a", SInt)))
+    val lam2 = Lambda(IndexedSeq("c" -> SInt, "d" -> SInt), SInt, Some(id("c", SInt)))
+    val pair = Tuple(IndexedSeq(lam1, lam2))
+    val lowered = NAryFunctionLowering.lower(pair).asInstanceOf[Tuple]
+    val l1 = lowered.items(0).asInstanceOf[Lambda]
+    val l2 = lowered.items(1).asInstanceOf[Lambda]
+    l1.args.head._1 should not equal l2.args.head._1
+  }
+
+  property("mixed-type 3-arg lambda nests pairs left-to-right by argument order") {
+    val lam = Lambda(
+      IndexedSeq("a" -> SInt, "b" -> SLong, "c" -> SBoolean),
+      SBoolean,
+      Some(id("c", SBoolean)))
+    val lowered = NAryFunctionLowering.lower(lam).asInstanceOf[Lambda]
+    val (_, tupTpe) = lowered.args.head
+    tupTpe shouldBe STuple(SInt, STuple(SLong, SBoolean))
+  }
+
+  property("nested lambdas lower independently and inner-lambda shadowing is preserved") {
+    atV6 {
+      val inner = Lambda(
+        IndexedSeq("c" -> SInt, "d" -> SInt),
+        SInt,
+        Some(id("c", SInt)))
+      val outer = Lambda(
+        IndexedSeq("a" -> SInt, "b" -> SInt),
+        SInt,
+        Some(Apply(inner, IndexedSeq(id("a", SInt), id("b", SInt)))))
+
+      val lowered = NAryFunctionLowering.lower(outer).asInstanceOf[Lambda]
+      lowered.args.length shouldBe 1
+      val outerBlock = lowered.body.get.asInstanceOf[Block]
+      outerBlock.bindings.map(_.name) shouldBe Seq("a", "b")
+
+      val innerApp = outerBlock.result.asInstanceOf[Apply]
+      val innerLam = innerApp.func.asInstanceOf[Lambda]
+      innerLam.args.length shouldBe 1
+      val innerBlock = innerLam.body.get.asInstanceOf[Block]
+      innerBlock.bindings.map(_.name) shouldBe Seq("c", "d")
+    }
+  }
+}

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -9,7 +9,8 @@ import sigmastate._
 import sigmastate.helpers.CompilerTestingCommons
 import sigmastate.interpreter.Interpreter.ScriptEnv
 import sigma.ast.{Apply, MethodCall, ZKProofBlock}
-import sigma.exceptions.{GraphBuildingException, InvalidArguments, TyperException}
+import sigma.VersionContext
+import sigma.exceptions.{BuilderException, GraphBuildingException, InvalidArguments, TyperException}
 import sigma.serialization.ValueSerializer
 import sigma.serialization.generators.ObjectGenerators
 
@@ -91,6 +92,44 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     comp("{ def f(i: Int) = { i + 1 }; f(2) }") shouldBe Apply(
       FuncValue(Vector((1,SInt)),Plus(ValUse(1,SInt), IntConstant(1))),
       Vector(IntConstant(2)))
+  }
+
+  property("1-arg function with explicit tuple parameter is not affected by the lowering") {
+    // 1-arg lambda whose param happens to be an STuple: the Apply rule's
+    // `args.length >= 2` guard does not fire, so the call site is unchanged.
+    // Verifies the lowering does NOT double-tuple already-tuple-typed calls.
+    val tree = comp("{ def f(t: (Int, Int)) = t._1 + t._2; f((1, 2)) }")
+    val app = tree.asInstanceOf[Apply]
+    val fv = app.func.asInstanceOf[FuncValue]
+    fv.args.length shouldBe 1
+    fv.args.head._2 shouldBe STuple(SInt, SInt)
+    app.args.length shouldBe 1
+    val arg = app.args.head.asInstanceOf[Tuple]
+    arg.items.length shouldBe 2
+    arg.items.foreach(_ shouldBe an [IntConstant])
+  }
+
+  property("n-ary user-defined functions require v6+") {
+    // Pre-v6 (activated v5 == version 2): the gate in NAryFunctionLowering
+    // refuses to rewrite a multi-arg user-function call.
+    VersionContext.withVersions(activatedVersion = 2, ergoTreeVersion = 2) {
+      val ex = the [BuilderException] thrownBy comp("{ def f(a: Int, b: Int) = a + b; f(1, 2) }")
+      ex.getMessage should include ("require ErgoTree v6+")
+    }
+  }
+
+  property("higher-order method with 2-arg lambda still compiles at pre-v6 typer") {
+    // fold/forall/exists pass a 2-arg lambda via MethodCall, not Apply.
+    // The lowering's Apply gate must NOT affect this path. Here we only
+    // exercise typing (not the full IR), since the SigmaCompilerTest IR
+    // context is initialized at the default version and re-entering a
+    // different version mid-class breaks the IR. Typing is enough to
+    // demonstrate the Apply gate doesn't reject the fold lambda.
+    VersionContext.withVersions(activatedVersion = 2, ergoTreeVersion = 2) {
+      val sc = sigma.compiler.SigmaCompiler(TestnetNetworkPrefix)
+      noException should be thrownBy sc.typecheck(env,
+        "OUTPUTS.fold(0L, { (acc: Long, b: Box) => acc + b.value })")
+    }
   }
 
   property("allOf") {

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -4604,6 +4604,54 @@ $lrFoldScript
     )
   }
 
+  property("user defined 2-arg function") {
+    test("function2", env, ext,
+      "{ def add(a: Int, b: Int) = a + b; add(2, 3) == 5 }",
+      null,
+      true
+    )
+  }
+
+  property("user defined 3-arg function") {
+    test("function3", env, ext,
+      "{ def sum3(a: Int, b: Int, c: Int) = a + b + c; sum3(1, 2, 3) == 6 }",
+      null,
+      true
+    )
+  }
+
+  property("user defined function with heterogeneous arg types") {
+    test("functionMixed", env, ext,
+      "{ def f(a: Int, b: Long, c: Boolean) = if (c) a.toLong + b else b; f(1, 2L, true) == 3L }",
+      null,
+      true
+    )
+  }
+
+  property("user defined 5-arg function") {
+    test("function5", env, ext,
+      "{ def sum5(a: Int, b: Int, c: Int, d: Int, e: Int) = a + b + c + d + e; sum5(1, 2, 3, 4, 5) == 15 }",
+      null,
+      true
+    )
+  }
+
+  property("user defined n-ary function captures outer val") {
+    test("functionClosure", env, ext,
+      "{ val x = 10; def f(a: Int, b: Int) = x + a + b; f(1, 2) == 13 }",
+      null,
+      true
+    )
+  }
+
+  property("2-arg lambda passed to a higher-order method (fold)") {
+    test("functionFold", env, ext,
+      "{ OUTPUTS.fold(0L, { (acc: Long, b: Box) => acc + b.value }) >= 0L }",
+      null,
+      true
+    )
+  }
+
   property("missing variable in env buildValue error") {
     test("missingVar", env, ext,
       """


### PR DESCRIPTION
Closes #616.

ErgoScript users can now write `def f(a, b, c) = …; f(x, y, z)` and `(a, b) => …`. The feature is purely compile-time and gated to ErgoTree v6+.

## How it works

A new compiler phase, `NAryFunctionLowering`, runs between `SigmaTyper`
and `IR.buildGraph`. It rewrites:

- n-ary `Lambda([(a, A), (b, B), (c, C)], R, body)` → 1-arg `Lambda([($tup, (A, (B, C)))], R, Block(Val(a, …), Val(b, …), Val(c, …), body))` using **right-nested pairs** and `SelectField` chains.
- n-arg `Apply(f, [a, b, c])` → `Apply(f, [Tuple([a, Tuple([b, c])])])`.

Right-nested pairs are required because the ErgoTree runtime only evaluates 2-element `Tuple`s / `SelectField`s (see `Tuple.eval` and `SelectField.eval` in `values.scala`).

## Version gating

The `Apply` rewrite is gated behind `VersionContext.current.isV6Activated` - compiling `def f(a, b) = …; f(1, 2)` against a pre-v6 context throws`BuilderException("…require ErgoTree v6+…")`.

The `Lambda` rewrite stays **unconditional**: 2-arg lambdas passed to HOF methods (`fold`, `forall`, `exists`) have always worked at every script version, and that path goes through `MethodCall`, not `Apply`.
