### PR TITLE
Add version-aware SigmaProp.propBytes for v7.0 soft-fork

### DIFF
--- a/core/shared/src/main/scala/sigma/SigmaDsl.scala
+++ b/core/shared/src/main/scala/sigma/SigmaDsl.scala
@@ -391,6 +391,10 @@ trait SigmaProp {
   /** Serialized bytes of this sigma proposition taken as ErgoTree and then serialized. */
   def propBytes: Coll[Byte]
 
+  /** Serialized bytes of this sigma proposition as a minimal ErgoTree of the given version,
+    * suitable for comparison against `box.propositionBytes` of v1+ ErgoTrees. */
+  def propBytes(version: Byte): Coll[Byte]
+
   /** Logical AND between this SigmaProp and other SigmaProp.
     * This constructs a new CAND node of sigma tree with two children. */
   def &&(other: SigmaProp): SigmaProp

--- a/core/shared/src/main/scala/sigma/VersionContext.scala
+++ b/core/shared/src/main/scala/sigma/VersionContext.scala
@@ -1,6 +1,6 @@
 package sigma
 
-import VersionContext.{JitActivationVersion, V6SoftForkVersion}
+import VersionContext.{JitActivationVersion, V6SoftForkVersion, V7SoftForkVersion}
 
 import scala.util.DynamicVariable
 
@@ -32,6 +32,13 @@ case class VersionContext(activatedVersion: Byte, ergoTreeVersion: Byte) {
     * including v6.0 update. */
   def isV6Activated: Boolean = activatedVersion >= V6SoftForkVersion
 
+  /** @return true if tree version is corresponding to 7.0 */
+  def isV4OrLaterErgoTreeVersion: Boolean = ergoTreeVersion >= V7SoftForkVersion
+
+  /** @return true, if the activated script version of Ergo protocol on the network is
+    * including v7.0 update. */
+  def isV7Activated: Boolean = activatedVersion >= V7SoftForkVersion
+
 }
 
 object VersionContext {
@@ -54,6 +61,13 @@ object VersionContext {
    * The version of ErgoTree corresponding to "evolution" (6.0) soft-fork
    */
   val V6SoftForkVersion: Byte = 3
+
+  /**
+   * The version of ErgoTree introduced by the 7.0 soft-fork.
+   * `MaxSupportedScriptVersion` stays at 3 until the activation rollout; this constant
+   * is a forward declaration so new ops/methods can be gated against it before flip.
+   */
+  val V7SoftForkVersion: Byte = 4
 
   private val _defaultContext = VersionContext(
     activatedVersion = 1 /* v4.x */,

--- a/core/shared/src/main/scala/sigma/data/CSigmaProp.scala
+++ b/core/shared/src/main/scala/sigma/data/CSigmaProp.scala
@@ -19,13 +19,32 @@ case class CSigmaProp(sigmaTree: SigmaBoolean) extends SigmaProp with WrapperOf[
   }
 
   override def propBytes: Coll[Byte] = {
-    // in order to have comparisons like  `box.propositionBytes == pk.propBytes` we need to make sure
-    // the same serialization method is used in both cases
-    // TODO v6.0: add `pk.propBytes(version)` (see https://github.com/ScorexFoundation/sigmastate-interpreter/issues/903)
+    // Always v0 header. Changing this would alter Fiat-Shamir for deployed contracts.
     val w = CoreSerializer.startWriter()
-    w.put(0)  // ErgoTree.header
+    w.put(0)
     w.putType(SSigmaProp)
     SigmaBoolean.serializer.serialize(wrappedValue, w)
+    Colls.fromArray(w.toBytes)
+  }
+
+  override def propBytes(version: Byte): Coll[Byte] = {
+    val w = CoreSerializer.startWriter()
+    if (version == 0) {
+      w.put(0)
+      w.putType(SSigmaProp)
+      SigmaBoolean.serializer.serialize(wrappedValue, w)
+    } else {
+      // ergoTree.bytes for v1+: header (SizeFlag | version), UInt size, content.
+      // SizeFlag (0x08) duplicated here to avoid a core->data dep on ErgoTree.SizeFlag.
+      val contentW = CoreSerializer.startWriter()
+      contentW.putType(SSigmaProp)
+      SigmaBoolean.serializer.serialize(wrappedValue, contentW)
+      val content = contentW.toBytes
+      val header = (0x08 | version).toByte
+      w.put(header)
+      w.putUInt(content.length)
+      w.putBytes(content)
+    }
     Colls.fromArray(w.toBytes)
   }
 

--- a/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
+++ b/core/shared/src/main/scala/sigma/reflection/ReflectionData.scala
@@ -93,6 +93,9 @@ object ReflectionData {
         mkMethod(clazz, "propBytes", Array[Class[_]]()) { (obj, _) =>
           obj.asInstanceOf[SigmaProp].propBytes
         },
+        mkMethod(clazz, "propBytes", Array[Class[_]](classOf[Byte])) { (obj, args) =>
+          obj.asInstanceOf[SigmaProp].propBytes(args(0).asInstanceOf[Byte])
+        },
         mkMethod(clazz, "$amp$amp", Array[Class[_]](classOf[SigmaProp])) { (obj, args) =>
           obj.asInstanceOf[SigmaProp].$amp$amp(args(0).asInstanceOf[SigmaProp])
         }

--- a/data/shared/src/main/scala/sigma/ast/methods.scala
+++ b/data/shared/src/main/scala/sigma/ast/methods.scala
@@ -155,7 +155,10 @@ sealed trait MethodsContainer {
 
 }
 object MethodsContainer {
-  private val methodsV5 = Array(
+  // Visible inside `sigma.ast` so MethodsContainerSpec can iterate every container
+  // and force reflection lookups across all script versions. Keeps a single source
+  // of truth so a new container automatically participates in the cross-platform check.
+  private[ast] val methodsV5 = Array(
     SByteMethods,
     SShortMethods,
     SIntMethods,
@@ -178,7 +181,7 @@ object MethodsContainer {
     SAnyMethods
   )
 
-  private val methodsV6 = methodsV5 ++ Seq(SUnsignedBigIntMethods)
+  private[ast] val methodsV6 = methodsV5 ++ Seq(SUnsignedBigIntMethods)
 
   private val containersV5 = new SparseArrayContainer[MethodsContainer](methodsV5.map(m => (m.typeId, m)))
 

--- a/data/shared/src/main/scala/sigma/ast/methods.scala
+++ b/data/shared/src/main/scala/sigma/ast/methods.scala
@@ -64,6 +64,7 @@ sealed trait MethodsContainer {
 
   private var _v5Methods: Seq[SMethod] = null
   private var _v6Methods: Seq[SMethod] = null
+  private var _v7Methods: Seq[SMethod] = null
 
   /** Returns all the methods of this type. */
   def methods: Seq[SMethod] = {
@@ -76,7 +77,12 @@ sealed trait MethodsContainer {
       ms
     }
 
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      if (_v7Methods == null) {
+        _v7Methods = calc()
+      }
+      _v7Methods
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       if (_v6Methods == null) {
         _v6Methods = calc()
       }
@@ -91,6 +97,7 @@ sealed trait MethodsContainer {
 
   private var _v5MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
   private var _v6MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
+  private var _v7MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
 
   private def _methodsMap: Map[Byte, Map[Byte, SMethod]] = {
     def calc() = {
@@ -98,7 +105,12 @@ sealed trait MethodsContainer {
         .groupBy(_.objType.typeId)
         .map { case (typeId, ms) => (typeId -> ms.map(m => m.methodId -> m).toMap) }
     }
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      if (_v7MethodsMap == null) {
+        _v7MethodsMap = calc()
+      }
+      _v7MethodsMap
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       if (_v6MethodsMap == null) {
         _v6MethodsMap = calc()
       }
@@ -699,6 +711,7 @@ case object SSigmaPropMethods extends MonoTypeMethods {
   val MaxSizeInBytes: Long = SigmaConstants.MaxSigmaPropSizeInBytes.value
 
   val PropBytes = "propBytes"
+  val PropBytesV2 = "propBytesV2"
   val IsProven = "isProven"
   lazy val PropBytesMethod = SMethod(
     this, PropBytes, SFunc(this.ownerType, SByteArray), 1, SigmaPropBytes.costKind)
@@ -708,9 +721,32 @@ case object SSigmaPropMethods extends MonoTypeMethods {
       .withInfo(// available only at frontend of ErgoScript
         "Verify that sigma proposition is proven.")
 
-  protected override def getMethods() = super.getMethods() ++ Seq(
+  // Source name is "propBytesV2" so `pk.propBytes` keeps resolving to methodId 1 on V0..V6
+  // contracts; the V7 overload picks up a distinct registry entry.
+  lazy val PropBytesMethodV2 = SMethod(
+    this, PropBytesV2, SFunc(Array(this.ownerType, SByte), SByteArray), 3, SigmaPropBytes.costKind)
+    .withIRInfo(MethodCallIrBuilder, javaMethodOf[SigmaProp, Byte]("propBytes"))
+    .withInfo(MethodCall,
+      "Serialized bytes of this sigma proposition as ErgoTree of the given version.",
+      ArgInfo("version", "ErgoTree version (0..7) to embed in the output header."))
+
+  private lazy val commonMethods = super.getMethods() ++ Seq(
     PropBytesMethod, IsProvenMethod
   )
+
+  private lazy val v6Methods = commonMethods
+
+  private lazy val v7Methods = commonMethods ++ Seq(
+    PropBytesMethodV2
+  )
+
+  protected override def getMethods(): Seq[SMethod] = {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      v7Methods
+    } else {
+      v6Methods
+    }
+  }
 }
 
 /** Any other type is implicitly subtype of this type. */

--- a/interpreter/shared/src/test/scala/sigma/ast/MethodsContainerSpec.scala
+++ b/interpreter/shared/src/test/scala/sigma/ast/MethodsContainerSpec.scala
@@ -1,0 +1,57 @@
+package sigma.ast
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import sigma.VersionContext
+
+/** Cross-platform safety net for the JS reflection registry in
+  * [[sigma.reflection.ReflectionData]].
+  *
+  * Most new `SMethod` declarations resolve their Java handler eagerly via
+  * `.withIRInfo(MethodCallIrBuilder, javaMethodOf[T, A]("name"))`. On JVM that
+  * goes through `java.lang.reflect`; on JS it goes through the hand-written
+  * `sigma.reflection` registry. A missing registry entry throws
+  * `NoSuchMethodException` the first time the enclosing `lazy val SMethod` is
+  * forced — which can be deep in serializer-spec land instead of here.
+  *
+  * Forcing `container.methods` under every supported `(activatedVersion,
+  * ergoTreeVersion)` combination — including the forward-declared
+  * [[VersionContext.V7SoftForkVersion]] which sits above
+  * `MaxSupportedScriptVersion` — triggers every per-version lazy method table,
+  * surfacing missing registry entries here rather than in a downstream consumer.
+  */
+class MethodsContainerSpec extends AnyPropSpec with Matchers {
+
+  // Range covers V5/V6 era (within MaxSupportedScriptVersion) plus the V7
+  // forward-declared version, which CrossVersionProps doesn't reach yet.
+  private val versions: Seq[Byte] =
+    (0 to VersionContext.V7SoftForkVersion).map(_.toByte)
+
+  private val combinations: Seq[(Byte, Byte)] =
+    for {
+      activated <- versions
+      ergoTree  <- versions if ergoTree <= activated
+    } yield (activated, ergoTree)
+
+  property("every MethodsContainer builds its method table on this platform") {
+    combinations.foreach { case (activated, ergoTree) =>
+      VersionContext.withVersions(activated, ergoTree) {
+        val containers =
+          if (VersionContext.current.isV3OrLaterErgoTreeVersion) MethodsContainer.methodsV6
+          else MethodsContainer.methodsV5
+
+        containers.foreach { container =>
+          try container.methods
+          catch {
+            case t: Throwable =>
+              fail(
+                s"Failed building method table for ${container.typeName} " +
+                  s"under (activated=$activated, ergoTree=$ergoTree): ${t.getMessage}",
+                t
+              )
+          }
+        }
+      }
+    }
+  }
+}

--- a/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
@@ -6,6 +6,8 @@ import sigma.VersionContext
 import sigma.ast.SCollection.SByteArray
 import sigma.ast.SType.tT
 import sigma.ast._
+import sigma.data.{CSigmaProp, ProveDlog}
+import sigma.crypto.CryptoConstants
 import sigma.validation.ValidationException
 
 class MethodCallSerializerSpecification extends SerializationSpecification {
@@ -200,6 +202,34 @@ class MethodCallSerializerSpecification extends SerializationSpecification {
         code
       }
       )
+  }
+
+  property("MethodCall deserialization round trip for SigmaProp.propBytes(version)") {
+    val sp = SigmaPropConstant(CSigmaProp(ProveDlog(CryptoConstants.dlogGroup.generator)))
+    def code = {
+      val expr = MethodCall(sp,
+        SSigmaPropMethods.PropBytesMethodV2,
+        Vector(ByteConstant(0)),
+        Map()
+      )
+      roundTripTest(expr)
+    }
+
+    VersionContext.withVersions(VersionContext.V7SoftForkVersion, VersionContext.V7SoftForkVersion) {
+      code
+    }
+
+    a[ValidationException] should be thrownBy (
+      VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+        code
+      }
+    )
+
+    a[ValidationException] should be thrownBy (
+      VersionContext.withVersions(VersionContext.V7SoftForkVersion, VersionContext.V6SoftForkVersion) {
+        code
+      }
+    )
   }
 
   property("eq") {

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
@@ -1066,6 +1066,13 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
               box.getReg(c1)(c2)
             case _ => throwError()
           }
+          case (sp: Ref[SigmaProp]@unchecked, SSigmaPropMethods) => method.name match {
+            case SSigmaPropMethods.PropBytesMethodV2.name
+                if argsV.nonEmpty && VersionContext.current.isV4OrLaterErgoTreeVersion =>
+              val versionV = asRep[Byte](argsV(0))
+              sp.propBytes(versionV)
+            case _ => throwError()
+          }
           case (ctx: Ref[Context]@unchecked, SContextMethods) => method.name match {
             case SContextMethods.dataInputsMethod.name =>
               ctx.dataInputs

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/SigmaDslUnit.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/SigmaDslUnit.scala
@@ -40,6 +40,7 @@ import scalan._
     trait SigmaProp extends Def[SigmaProp] {
       def isValid: Ref[Boolean];
       def propBytes: Ref[Coll[Byte]];
+      def propBytes(version: Ref[Byte]): Ref[Coll[Byte]];
       def &&(other: Ref[SigmaProp]): Ref[SigmaProp];
       def ||(other: Ref[SigmaProp]): Ref[SigmaProp];
     };

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
@@ -716,6 +716,13 @@ object SigmaProp extends EntityObject("SigmaProp") {
         true, false, element[Coll[Byte]]))
     }
 
+    override def propBytes(version: Ref[Byte]): Ref[Coll[Byte]] = {
+      asRep[Coll[Byte]](mkMethodCall(self,
+        SigmaPropClass.getMethod("propBytes", classOf[Byte]),
+        Array[AnyRef](version),
+        true, false, element[Coll[Byte]]))
+    }
+
     override def &&(other: Ref[SigmaProp]): Ref[SigmaProp] = {
       asRep[SigmaProp](mkMethodCall(self,
         SigmaPropClass.getMethod("$amp$amp", classOf[Sym]),
@@ -760,6 +767,13 @@ object SigmaProp extends EntityObject("SigmaProp") {
       asRep[Coll[Byte]](mkMethodCall(source,
         SigmaPropClass.getMethod("propBytes"),
         ArraySeq.empty,
+        true, true, element[Coll[Byte]]))
+    }
+
+    def propBytes(version: Ref[Byte]): Ref[Coll[Byte]] = {
+      asRep[Coll[Byte]](mkMethodCall(source,
+        SigmaPropClass.getMethod("propBytes", classOf[Byte]),
+        Array[AnyRef](version),
         true, true, element[Coll[Byte]]))
     }
 

--- a/sc/shared/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/serialization/ErgoTreeSerializerSpecification.scala
@@ -5,7 +5,8 @@ import org.ergoplatform.validation.ValidationRules.CheckDeserializedScriptIsSigm
 import sigma.{SigmaProp, VersionContext}
 import sigma.ast._
 import sigma.ast.syntax.SigmaPropValue
-import sigma.data.CBigInt
+import sigma.data.{CAND, CBigInt, CSigmaProp, ProveDHTuple, ProveDlog}
+import sigmastate.utils.Helpers
 import sigma.util.Extensions.SigmaPropOps
 import sigma.validation.ValidationException
 import ErgoTree.EmptyConstants
@@ -223,6 +224,81 @@ class ErgoTreeSerializerSpecification extends SerializationSpecification
       val ergoTree = new ErgoTree(ErgoTree.DefaultHeader, EmptyConstants, Right(sp.toSigmaBoolean.toSigmaPropValue), null, None, None)
       val treeBytes = DefaultSerializer.serializeErgoTree(ergoTree)
       treeBytes shouldBe propBytes.toArray
+    }
+  }
+
+  property("SigmaProp.propBytes(version) vs ErgoTree.serializer equivalence (v0..v4)") {
+    forAll(MinSuccessful(50)) { sp: SigmaProp =>
+      (0 to 4).foreach { vInt =>
+        val v = vInt.toByte
+        val activated = (VersionContext.MaxSupportedScriptVersion: Byte).max(v)
+        VersionContext.withVersions(activated, v) {
+          val header = ErgoTree.defaultHeaderWithVersion(v)
+          val tree = new ErgoTree(
+            header, EmptyConstants,
+            Right(sp.toSigmaBoolean.toSigmaPropValue),
+            null, None, None)
+          val treeBytes = DefaultSerializer.serializeErgoTree(tree)
+          sp.propBytes(v).toArray shouldBe treeBytes
+        }
+      }
+    }
+  }
+
+  property("SigmaProp.propBytes (no-arg) == SigmaProp.propBytes(0)") {
+    forAll(MinSuccessful(100)) { sp: SigmaProp =>
+      sp.propBytes.toArray shouldBe sp.propBytes(0.toByte).toArray
+    }
+  }
+
+  // Golden vectors covering the SigmaBoolean shapes that matter on-chain: bare ProveDlog,
+  // ProveDHTuple, and a CAND composition. v0 bytes are reused from `LanguageSpecificationV5
+  // / "SigmaProp.propBytes equivalence"`. v1..v4 bytes are derived from the v0 content via
+  // the documented header layout, so any drift in either layer breaks the test.
+  property("SigmaProp.propBytes(version) golden vectors (v0..v4)") {
+    val pk = ProveDlog(
+      Helpers.decodeECPoint("039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6f"))
+    val dht = ProveDHTuple(
+      Helpers.decodeECPoint("03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb"),
+      Helpers.decodeECPoint("023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d03"),
+      Helpers.decodeECPoint("03d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72"),
+      Helpers.decodeECPoint("037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441"))
+    val and = CAND(Array(pk, dht))
+
+    val cases: Seq[(SigmaProp, Array[Byte])] = Seq(
+      CSigmaProp(pk) -> Helpers.decodeBytes(
+        "0008cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6f").toArray,
+      CSigmaProp(dht) -> Helpers.decodeBytes(
+        "0008ce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441").toArray,
+      CSigmaProp(and) -> Helpers.decodeBytes(
+        "00089602cd039d0b1e46c21540d033143440d2fb7dd5d650cf89981c99ee53c6e0374d2b1b6fce03c046fccb95549910767d0543f5e8ce41d66ae6a8720a46f4049cac3b3d26dafb023479c9c3b86a0d3c8be3db0a2d186788e9af1db76d55f3dad127d15185d83d0303d7898641cb6653585a8e1dabfa7f665e61e0498963e329e6e3744bd764db2d72037ae057d89ec0b46ff8e9ff4c37e85c12acddb611c3f636421bef1542c11b0441").toArray
+    )
+
+    cases.foreach { case (sp, v0Bytes) =>
+      sp.propBytes(0.toByte).toArray shouldBe v0Bytes
+      val content = v0Bytes.tail  // drop the 0x00 v0 header
+      (1 to 4).foreach { vInt =>
+        val v = vInt.toByte
+        val w = CoreSerializer.startWriter()
+        w.put((0x08 | v).toByte)  // SizeFlag | version
+        w.putUInt(content.length)
+        w.putBytes(content)
+        sp.propBytes(v).toArray shouldBe w.toBytes
+      }
+    }
+  }
+
+  property("PropBytesMethodV2 is gated by V7SoftForkVersion (ergoTree v4+)") {
+    val v2MethodId = SSigmaPropMethods.PropBytesMethodV2.methodId
+
+    VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+      SSigmaPropMethods.methods.map(_.methodId) should not contain v2MethodId
+    }
+
+    VersionContext.withVersions(VersionContext.V7SoftForkVersion, VersionContext.V7SoftForkVersion) {
+      val ids = SSigmaPropMethods.methods.map(_.methodId)
+      ids should contain (v2MethodId)
+      ids should contain (SSigmaPropMethods.PropBytesMethod.methodId)
     }
   }
 

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -13,7 +13,7 @@ import scorex.util.serialization.VLQByteBufferWriter
 import scorex.utils.Longs
 import sigma.{Coll, Colls, GroupElement, SigmaTestingData, VersionContext}
 import sigma.Extensions.ArrayOps
-import sigma.VersionContext.{V6SoftForkVersion, withVersions}
+import sigma.VersionContext.{V6SoftForkVersion, V7SoftForkVersion, withVersions}
 import sigma.ast.SCollection.SByteArray
 import sigma.ast.SType.{AnyOps, tD}
 import sigma.data.{AvlTreeData, AvlTreeFlags, CAND, CAnyValue, CBigInt, CGroupElement, CHeader, CSigmaDslBuilder, CSigmaProp}
@@ -1993,6 +1993,26 @@ class BasicOpsSpecification extends CompilerTestingCommons
       an [sigma.validation.ValidationException] should be thrownBy deserTest()
     } else {
       deserTest()
+    }
+  }
+
+  // propBytesV2(0) at the source level should be byte-identical to the no-arg propBytes.
+  // The framework iterates only up to MaxSupportedScriptVersion (=3) so the positive branch
+  // is currently unreachable; the if/else auto-promotes once MaxSupportedScriptVersion bumps.
+  property("propBytesV2 - propBytes correspondence") {
+    def runTest() = test("propBytesV2", env, ext,
+      s"""{
+            val p1 = getVar[SigmaProp]($propVar1).get
+            p1.propBytesV2(0.toByte) == p1.propBytes
+          }""",
+      null,
+      true
+    )
+
+    if (ergoTreeVersionInTests < V7SoftForkVersion) {
+      an [Exception] should be thrownBy runTest()
+    } else {
+      runTest()
     }
   }
 


### PR DESCRIPTION
Closes #903.

## Summary

Adds `SigmaProp.propBytes(version: Byte)` so ErgoScript can compute propBytes matching a box's actual ErgoTree header. Existing no-arg `propBytes` always emits a v0 header (`0x00`); `box.propositionBytes` carries the box's real
header (`0x09` / `0x0A` / `0x0B` for v1/v2/v3 trees, etc.), so the canonical `OUTPUTS(0).propositionBytes == pk.propBytes` idiom silently fails for any wallet-produced box at v1+.

## Why this is a soft fork (not a hard fork)

The 7.0 milestone is structural, not policy. The fix is **additive** — new method (`methodId = 3`, source name `propBytesV2`), gated by `V7SoftForkVersion`. The existing `propBytes` (methodId 1, opcode `SigmaPropBytes` / 96) is untouched, so:
  - Fiat-Shamir inputs for already-deployed contracts are unchanged.
  - V0–V6 source recompiling against this branch still resolves`pk.propBytes` to methodId 1 (unchanged bytes).
  - Old nodes encountering V4+ trees with this method fall through the coarse `checkSoftForkCondition` gate, relying on ≥90% upgraded nodes.

The byte layout produced by `propBytes(version)`:

- `v = 0`: `0x00 || SSigmaProp-type || SigmaBoolean-bytes` (identical to no-arg)
- `v ≥ 1`: `(0x08 | v) || UInt(contentLength) || SSigmaProp-type || SigmaBoolean-bytes`

— byte-for-byte equal to `ErgoTree(headerFor(version), [], SigmaPropConstant(sp)).bytes`.

## What's in the diff

Source-level name is `propBytesV2` (not `propBytes`) so the per-container uniqueness assertion in `MethodsContainer.methods` is satisfied without renaming the old method — V0–V6 source still compiles `pk.propBytes` unchanged. Note this differs from the SBox `getReg`/`getRegV5` convention, which renamed the *old* method; renaming `propBytes` would have broken recompilation of every existing contract that calls it.

## Reviewer guidance (consensus-critical)

- The no-arg `propBytes` body in `CSigmaProp.scala` is unchanged. Please verify line-by-line: writer call sequence, the hardcoded `0x00` header,  no `VersionContext` reads.
- `PropBytesMethod` definition in `methods.scala` is unchanged (methodId, signature, IR info, withInfo target).
- The cache extension in `MethodsContainer.methods` adds a new branch but is structurally identical to the existing V5/V6 split; the V6 branch semantics are preserved verbatim.