### PR TITLE
add static MerkleTree type for v7.0

### DIFF
--- a/core/js/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/js/src/main/scala/sigma/crypto/Platform.scala
@@ -258,6 +258,7 @@ object Platform {
     case _: GroupElement => tpe.isGroupElement
     case _: SigmaProp => tpe.isSigmaProp
     case _: AvlTree => tpe.isAvlTree
+    case _: MerkleTree => tpe.isMerkleTree
     case _: Box => tpe.isBox
     case _: PreHeader => tpe == SPreHeader
     case _: Header => tpe == SHeader

--- a/core/jvm/src/main/scala/sigma/crypto/Platform.scala
+++ b/core/jvm/src/main/scala/sigma/crypto/Platform.scala
@@ -190,6 +190,7 @@ object Platform {
     case _: GroupElement => tpe.isGroupElement
     case _: SigmaProp => tpe.isSigmaProp
     case _: AvlTree => tpe.isAvlTree
+    case _: MerkleTree => tpe.isMerkleTree
     case _: Box => tpe.isBox
     case _: PreHeader => tpe == SPreHeader
     case _: Header => tpe == SHeader

--- a/core/shared/src/main/scala/sigma/Evaluation.scala
+++ b/core/shared/src/main/scala/sigma/Evaluation.scala
@@ -33,6 +33,7 @@ object Evaluation {
     case SPreHeader => PreHeaderRType
     case SGroupElement => GroupElementRType
     case SAvlTree => AvlTreeRType
+    case SMerkleTree => MerkleTreeRType
     case SSigmaProp => SigmaPropRType
     case tup: STuple if tup.items.length == 2 =>
       val tpeA = tup.items(0)
@@ -71,6 +72,7 @@ object Evaluation {
     case UnsignedBigIntRType => SUnsignedBigInt
     case GroupElementRType => SGroupElement
     case AvlTreeRType => SAvlTree
+    case MerkleTreeRType => SMerkleTree
     case ot: OptionType[_] => SOption(rtypeToSType(ot.tA))
     case BoxRType => SBox
     case ContextRType => SContext

--- a/core/shared/src/main/scala/sigma/SigmaDsl.scala
+++ b/core/shared/src/main/scala/sigma/SigmaDsl.scala
@@ -588,6 +588,25 @@ trait AvlTree {
   def updateOperations(newOperations: Byte): AvlTree
 }
 
+/** Static (unauthenticated) Merkle tree, introduced in v7.0.
+  *
+  * Unlike [[AvlTree]], a `MerkleTree` doesn't support insertions/updates/removals — it
+  * stores only the root digest. Membership of one or more leaves is verified against
+  * that digest by ErgoTree method calls (`containsLeaf`, `containsLeaves`) which
+  * accept a proof produced by the sender. The proof byte format matches
+  * `scorex.crypto.authds.merkle.serialization.BatchMerkleProofSerializer` (compact
+  * multiproof / Lum Ramabaja's algorithm).
+  */
+trait MerkleTree {
+  /** Root hash of the tree. 32 bytes (Blake2b256). */
+  def digest: Coll[Byte]
+
+  /** Replace digest of this tree producing a new tree.
+    * Since MerkleTree is immutable, this instance remains unchanged.
+    */
+  def updateDigest(newDigest: Coll[Byte]): MerkleTree
+}
+
 /** Only header fields that can be predicted by a miner. */
 trait PreHeader {
   /** Block version, to be increased on every soft and hardfork. */

--- a/core/shared/src/main/scala/sigma/VersionContext.scala
+++ b/core/shared/src/main/scala/sigma/VersionContext.scala
@@ -1,6 +1,6 @@
 package sigma
 
-import VersionContext.{JitActivationVersion, V6SoftForkVersion}
+import VersionContext.{JitActivationVersion, V6SoftForkVersion, V7SoftForkVersion}
 
 import scala.util.DynamicVariable
 
@@ -32,6 +32,13 @@ case class VersionContext(activatedVersion: Byte, ergoTreeVersion: Byte) {
     * including v6.0 update. */
   def isV6Activated: Boolean = activatedVersion >= V6SoftForkVersion
 
+  /** @return true if tree version is corresponding to 7.0 */
+  def isV4OrLaterErgoTreeVersion: Boolean = ergoTreeVersion >= V7SoftForkVersion
+
+  /** @return true, if the activated script version of Ergo protocol on the network is
+    * including v7.0 update. */
+  def isV7Activated: Boolean = activatedVersion >= V7SoftForkVersion
+
 }
 
 object VersionContext {
@@ -54,6 +61,13 @@ object VersionContext {
    * The version of ErgoTree corresponding to "evolution" (6.0) soft-fork
    */
   val V6SoftForkVersion: Byte = 3
+
+  /**
+   * The version of ErgoTree introduced by the 7.0 soft-fork.
+   * `MaxSupportedScriptVersion` stays at 3 until the activation rollout; this constant
+   * is a forward declaration so new ops/methods can be gated against it before flip.
+   */
+  val V7SoftForkVersion: Byte = 4
 
   private val _defaultContext = VersionContext(
     activatedVersion = 1 /* v4.x */,

--- a/core/shared/src/main/scala/sigma/ast/SType.scala
+++ b/core/shared/src/main/scala/sigma/ast/SType.scala
@@ -7,7 +7,7 @@ import sigma.data.OverloadHack.Overloaded1
 import sigma.data.{CBigInt, CUnsignedBigInt, Nullable, SigmaConstants}
 import sigma.reflection.{RClass, RMethod, ReflectionData}
 import sigma.util.Extensions.{IntOps, LongOps, ShortOps}
-import sigma.{AvlTree, BigInt, Box, Coll, Context, Evaluation, GroupElement, Header, PreHeader, SigmaDslBuilder, SigmaProp, UnsignedBigInt, VersionContext}
+import sigma.{AvlTree, BigInt, Box, Coll, Context, Evaluation, GroupElement, Header, MerkleTree, PreHeader, SigmaDslBuilder, SigmaProp, UnsignedBigInt, VersionContext}
 
 import java.math.BigInteger
 
@@ -111,10 +111,15 @@ object SType {
   // V6 types, see `allPredefTypes` scaladoc below. Contains SUnsignedBigInt type in addition to v5 types.
   private val v6PredefTypes = v5PredefTypes ++ Array(SUnsignedBigInt)
 
+  // V7 types, see `allPredefTypes` scaladoc below. Contains SMerkleTree type in addition to v6 types.
+  private val v7PredefTypes = v6PredefTypes ++ Array(SMerkleTree)
+
   /** All pre-defined types should be listed here. Note, NoType is not listed.
     * Should be in sync with sigmastate.lang.Types.predefTypes. */
   def allPredefTypes: Seq[SType] = {
-    if(VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      v7PredefTypes
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       v6PredefTypes
     } else {
       v5PredefTypes
@@ -126,10 +131,13 @@ object SType {
     SAvlTree, SBox, SOption, SCollection, SBigInt
   )
   private val v6Types = v5Types ++ Seq(SByte, SShort, SInt, SLong, SUnsignedBigInt)
+  private val v7Types = v6Types ++ Seq(SMerkleTree)
 
   private val v5TypesMap = v5Types.map { t => (t.typeId, t) }.toMap
 
   private val v6TypesMap = v6Types.map { t => (t.typeId, t) }.toMap
+
+  private val v7TypesMap = v7Types.map { t => (t.typeId, t) }.toMap
 
   /** A mapping of object types supporting MethodCall operations. For each serialized
     * typeId this map contains a companion object which can be used to access the list of
@@ -164,10 +172,14 @@ object SType {
     *
     * The regression tests in `property("MethodCall Codes")` should pass.
     */
-  def types: Map[Byte, STypeCompanion] = if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
-    v6TypesMap
-  } else {
-    v5TypesMap
+  def types: Map[Byte, STypeCompanion] = {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      v7TypesMap
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+      v6TypesMap
+    } else {
+      v5TypesMap
+    }
   }
 
   /** Checks that the type of the value corresponds to the descriptor `tpe`.
@@ -205,6 +217,7 @@ object SType {
       else sys.error(s"Unsupported function type $tF")
     case SContext => x.isInstanceOf[Context]
     case SAvlTree => x.isInstanceOf[AvlTree]
+    case SMerkleTree if VersionContext.current.isV4OrLaterErgoTreeVersion => x.isInstanceOf[MerkleTree]
     case SGlobal => x.isInstanceOf[SigmaDslBuilder]
     case SHeader => x.isInstanceOf[Header]
     case SPreHeader => x.isInstanceOf[PreHeader]
@@ -925,5 +938,20 @@ case object SGlobal extends SProduct with SPredefType with SMonoType {
   override val typeCode: TypeCode = 106: Byte
   override val reprClass: RClass[_] = RClass(classOf[SigmaDslBuilder])
   override def typeId = typeCode
+}
+
+/** Type descriptor of `MerkleTree` type of ErgoTree.
+  *
+  * Static (unauthenticated) Merkle tree introduced in v7.0. Unlike [[SAvlTree]] this
+  * type represents a tree that doesn't support insertions/updates/removals — only
+  * membership-proof verification against a fixed root digest. See issue
+  * https://github.com/ergoplatform/sigmastate-interpreter/issues/296 for motivation.
+  */
+case object SMerkleTree extends SProduct with SPredefType with SMonoType {
+  override type WrappedType = MerkleTree
+  override val typeCode: TypeCode = 107: Byte
+  override val reprClass: RClass[_] = RClass(classOf[MerkleTree])
+  override def typeId = typeCode
+  implicit def typeMerkleTree: SMerkleTree.type = this
 }
 

--- a/core/shared/src/main/scala/sigma/ast/package.scala
+++ b/core/shared/src/main/scala/sigma/ast/package.scala
@@ -122,6 +122,8 @@ package object ast {
 
     def isAvlTree: Boolean = tpe.isInstanceOf[SAvlTree.type]
 
+    def isMerkleTree: Boolean = tpe.isInstanceOf[SMerkleTree.type]
+
     def isFunc: Boolean = tpe.isInstanceOf[SFunc]
 
     def isTuple: Boolean = tpe.isInstanceOf[STuple]

--- a/core/shared/src/main/scala/sigma/data/CMerkleTree.scala
+++ b/core/shared/src/main/scala/sigma/data/CMerkleTree.scala
@@ -1,0 +1,18 @@
+package sigma.data
+
+import sigma.{Coll, MerkleTree}
+
+/** Default implementation of [[MerkleTree]] backed by [[MerkleTreeData]].
+  *
+  * @see [[MerkleTree]] for detailed descriptions
+  */
+case class CMerkleTree(treeData: MerkleTreeData) extends MerkleTree with WrapperOf[MerkleTreeData] {
+  override def wrappedValue: MerkleTreeData = treeData
+
+  override def digest: Coll[Byte] = treeData.digest
+
+  override def updateDigest(newDigest: Coll[Byte]): MerkleTree = {
+    val td = treeData.copy(digest = newDigest)
+    this.copy(treeData = td)
+  }
+}

--- a/core/shared/src/main/scala/sigma/data/MerkleTreeData.scala
+++ b/core/shared/src/main/scala/sigma/data/MerkleTreeData.scala
@@ -1,0 +1,42 @@
+package sigma.data
+
+import sigma.serialization.{CoreByteReader, CoreByteWriter, CoreSerializer}
+import sigma.{Coll, Colls, crypto}
+
+/**
+  * Type of data that authenticates membership in a static Merkle tree by storing only
+  * its root digest.
+  *
+  * A `MerkleTreeData` is fully described by its 32-byte Blake2b256 root hash; tree
+  * shape and leaf contents are not stored on-chain. Proofs are passed in at
+  * verification time (see [[sigma.MerkleTree.containsLeaf]] /
+  * [[sigma.MerkleTree.containsLeaves]]).
+  *
+  * @param digest root hash of the tree (exactly `crypto.hashLength` bytes).
+  */
+case class MerkleTreeData(digest: Coll[Byte])
+
+object MerkleTreeData {
+  /** Size of the root digest in bytes. */
+  val DigestSize: Int = crypto.hashLength
+
+  /** A placeholder tree with a zero-filled digest. Useful as a default constant or as
+    * the starting point for [[sigma.MerkleTree.updateDigest]].
+    */
+  val dummy: MerkleTreeData =
+    MerkleTreeData(Colls.fromArray(Array.fill(DigestSize)(0: Byte)))
+
+  /** Build a [[MerkleTreeData]] from a raw root digest. */
+  def merkleTreeFromDigest(digest: Coll[Byte]): MerkleTreeData = MerkleTreeData(digest)
+
+  object serializer extends CoreSerializer[MerkleTreeData, MerkleTreeData] {
+    override def serialize(data: MerkleTreeData, w: CoreByteWriter): Unit = {
+      w.putBytes(data.digest.toArray)
+    }
+
+    override def parse(r: CoreByteReader): MerkleTreeData = {
+      val digest = r.getBytes(DigestSize)
+      MerkleTreeData(Colls.fromArray(digest))
+    }
+  }
+}

--- a/core/shared/src/main/scala/sigma/data/package.scala
+++ b/core/shared/src/main/scala/sigma/data/package.scala
@@ -19,6 +19,7 @@ package object data {
   val SigmaPropClassTag = classTag[SigmaProp]
   val SigmaBooleanClassTag = classTag[SigmaBoolean]
   val AvlTreeClassTag = classTag[AvlTree]
+  val MerkleTreeClassTag = classTag[MerkleTree]
   val BoxClassTag = classTag[Box]
   val ContextClassTag = classTag[Context]
   val HeaderClassTag = classTag[Header]

--- a/core/shared/src/main/scala/sigma/package.scala
+++ b/core/shared/src/main/scala/sigma/package.scala
@@ -33,6 +33,7 @@ package object sigma {
 
 
   implicit val AvlTreeRType:   RType[AvlTree]   = GeneralType(AvlTreeClassTag)
+  implicit val MerkleTreeRType: RType[MerkleTree] = GeneralType(MerkleTreeClassTag)
 
   implicit val BoxRType:       RType[Box]       = GeneralType(BoxClassTag)
   implicit val ContextRType:   RType[Context]   = GeneralType(ContextClassTag)

--- a/core/shared/src/main/scala/sigma/serialization/CoreDataSerializer.scala
+++ b/core/shared/src/main/scala/sigma/serialization/CoreDataSerializer.scala
@@ -4,7 +4,7 @@ import debox.cfor
 import sigma.ast._
 import sigma.crypto.BigIntegers
 import sigma.data._
-import sigma.util.Extensions.{BigIntOps, BigIntegerOps, CoreAvlTreeOps, GroupElementOps, SigmaPropOps}
+import sigma.util.Extensions.{BigIntOps, BigIntegerOps, CoreAvlTreeOps, CoreMerkleTreeOps, GroupElementOps, SigmaPropOps}
 import sigma.validation.ValidationRules.CheckSerializableTypeCode
 import sigma.{Evaluation, _}
 
@@ -47,6 +47,8 @@ class CoreDataSerializer {
       SigmaBoolean.serializer.serialize(p.toSigmaBoolean, w)
     case SAvlTree =>
       AvlTreeData.serializer.serialize(v.asInstanceOf[AvlTree].toAvlTreeData, w)
+    case SMerkleTree if VersionContext.current.isV4OrLaterErgoTreeVersion =>
+      MerkleTreeData.serializer.serialize(v.asInstanceOf[MerkleTree].toMerkleTreeData, w)
     case tColl: SCollectionType[a] =>
       val coll = v.asInstanceOf[tColl.WrappedType]
       w.putUShort(coll.length)
@@ -128,6 +130,8 @@ class CoreDataSerializer {
         CSigmaProp(SigmaBoolean.serializer.parse(r))
       case SAvlTree =>
         CAvlTree(AvlTreeData.serializer.parse(r))
+      case SMerkleTree if VersionContext.current.isV4OrLaterErgoTreeVersion =>
+        CMerkleTree(MerkleTreeData.serializer.parse(r))
       case tColl: SCollectionType[a] =>
         val len = r.getUShort()
         deserializeColl(len, tColl.elemType, r)

--- a/core/shared/src/main/scala/sigma/serialization/TypeSerializer.scala
+++ b/core/shared/src/main/scala/sigma/serialization/TypeSerializer.scala
@@ -31,6 +31,7 @@ class TypeSerializer {
     case SUnit => w.put(SUnit.typeCode)
     case SBox => w.put(SBox.typeCode)
     case SAvlTree => w.put(SAvlTree.typeCode)
+    case SMerkleTree => w.put(SMerkleTree.typeCode)
     case SContext => w.put(SContext.typeCode)
     case SGlobal => w.put(SGlobal.typeCode)
     case SHeader => w.put(SHeader.typeCode)
@@ -197,6 +198,7 @@ class TypeSerializer {
         case SUnit.typeCode => SUnit
         case SBox.typeCode => SBox
         case SAvlTree.typeCode => SAvlTree
+        case SMerkleTree.typeCode if VersionContext.current.isV4OrLaterErgoTreeVersion => SMerkleTree
         case SContext.typeCode => SContext
         case SString.typeCode => SString
         case STypeVar.TypeCode => {

--- a/core/shared/src/main/scala/sigma/util/Extensions.scala
+++ b/core/shared/src/main/scala/sigma/util/Extensions.scala
@@ -3,7 +3,7 @@ package sigma.util
 import debox.{cfor, Buffer => DBuffer}
 import sigma.crypto.{CryptoFacade, Ecp}
 import sigma.data._
-import sigma.{AvlTree, GroupElement, SigmaProp}
+import sigma.{AvlTree, GroupElement, MerkleTree, SigmaProp}
 
 import java.math.BigInteger
 import java.nio.ByteBuffer
@@ -373,5 +373,15 @@ object Extensions {
   implicit class CoreAvlTreeOps(val tree: AvlTree) extends AnyVal {
     /** Extracts [[sigma.AvlTreeData]] from the AvlTree instance. */
     def toAvlTreeData: AvlTreeData = tree.asInstanceOf[CAvlTree].wrappedValue
+  }
+
+  implicit class MerkleTreeDataOps(val treeData: MerkleTreeData) extends AnyVal {
+    /** Wrap [[sigma.data.MerkleTreeData]] to [[sigma.MerkleTree]]. */
+    def toMerkleTree: MerkleTree = CMerkleTree(treeData)
+  }
+
+  implicit class CoreMerkleTreeOps(val tree: MerkleTree) extends AnyVal {
+    /** Extracts [[sigma.data.MerkleTreeData]] from the MerkleTree instance. */
+    def toMerkleTreeData: MerkleTreeData = tree.asInstanceOf[CMerkleTree].wrappedValue
   }
 }

--- a/data/js/src/main/scala/sigma/Platform.scala
+++ b/data/js/src/main/scala/sigma/Platform.scala
@@ -52,6 +52,7 @@ object Platform {
           Nullable.None // return the same result as in v4.x when there was no this case
       case avl: AvlTreeData if !VersionContext.current.isV3OrLaterErgoTreeVersion => Nullable(mkConstant[SAvlTree.type](CAvlTree(avl), SAvlTree))
       case avl: AvlTree => Nullable(mkConstant[SAvlTree.type](avl, SAvlTree))
+      case mt: MerkleTree if VersionContext.current.isV4OrLaterErgoTreeVersion => Nullable(mkConstant[SMerkleTree.type](mt, SMerkleTree))
       case sb: SigmaBoolean => Nullable(mkConstant[SSigmaProp.type](CSigmaProp(sb), SSigmaProp))
       case p: SigmaProp => Nullable(mkConstant[SSigmaProp.type](p, SSigmaProp))
       case coll: Coll[a] =>

--- a/data/jvm/src/main/scala/sigma/Platform.scala
+++ b/data/jvm/src/main/scala/sigma/Platform.scala
@@ -54,6 +54,7 @@ object Platform {
           Nullable.None // return the same result as in v4.x when there was no this case
       case avl: AvlTreeData if !VersionContext.current.isV3OrLaterErgoTreeVersion => Nullable(mkConstant[SAvlTree.type](SigmaDsl.avlTree(avl), SAvlTree))
       case avl: AvlTree => Nullable(mkConstant[SAvlTree.type](avl, SAvlTree))
+      case mt: MerkleTree if VersionContext.current.isV4OrLaterErgoTreeVersion => Nullable(mkConstant[SMerkleTree.type](mt, SMerkleTree))
       case sb: SigmaBoolean => Nullable(mkConstant[SSigmaProp.type](SigmaDsl.SigmaProp(sb), SSigmaProp))
       case p: SigmaProp => Nullable(mkConstant[SSigmaProp.type](p, SSigmaProp))
       case coll: Coll[a] =>

--- a/data/shared/src/main/scala/sigma/ast/methods.scala
+++ b/data/shared/src/main/scala/sigma/ast/methods.scala
@@ -64,6 +64,7 @@ sealed trait MethodsContainer {
 
   private var _v5Methods: Seq[SMethod] = null
   private var _v6Methods: Seq[SMethod] = null
+  private var _v7Methods: Seq[SMethod] = null
 
   /** Returns all the methods of this type. */
   def methods: Seq[SMethod] = {
@@ -76,7 +77,12 @@ sealed trait MethodsContainer {
       ms
     }
 
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      if (_v7Methods == null) {
+        _v7Methods = calc()
+      }
+      _v7Methods
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       if (_v6Methods == null) {
         _v6Methods = calc()
       }
@@ -91,6 +97,7 @@ sealed trait MethodsContainer {
 
   private var _v5MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
   private var _v6MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
+  private var _v7MethodsMap: Map[Byte, Map[Byte, SMethod]] = null
 
   private def _methodsMap: Map[Byte, Map[Byte, SMethod]] = {
     def calc() = {
@@ -98,7 +105,12 @@ sealed trait MethodsContainer {
         .groupBy(_.objType.typeId)
         .map { case (typeId, ms) => (typeId -> ms.map(m => m.methodId -> m).toMap) }
     }
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      if (_v7MethodsMap == null) {
+        _v7MethodsMap = calc()
+      }
+      _v7MethodsMap
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       if (_v6MethodsMap == null) {
         _v6MethodsMap = calc()
       }
@@ -168,12 +180,18 @@ object MethodsContainer {
 
   private val methodsV6 = methodsV5 ++ Seq(SUnsignedBigIntMethods)
 
+  private val methodsV7 = methodsV6 ++ Seq(SMerkleTreeMethods)
+
   private val containersV5 = new SparseArrayContainer[MethodsContainer](methodsV5.map(m => (m.typeId, m)))
 
   private val containersV6 = new SparseArrayContainer[MethodsContainer](methodsV6.map(m => (m.typeId, m)))
 
+  private val containersV7 = new SparseArrayContainer[MethodsContainer](methodsV7.map(m => (m.typeId, m)))
+
   def contains(typeId: TypeCode): Boolean = {
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      containersV7.contains(typeId)
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       containersV6.contains(typeId)
     } else {
       containersV5.contains(typeId)
@@ -181,7 +199,9 @@ object MethodsContainer {
   }
 
   def apply(typeId: TypeCode): MethodsContainer = {
-    if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      containersV7(typeId)
+    } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
       containersV6(typeId)
     } else {
       containersV5(typeId)
@@ -198,7 +218,9 @@ object MethodsContainer {
     case tup: STuple =>
       STupleMethods.getTupleMethod(tup, methodName)
     case _ =>
-      if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
+      if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+        containersV7.get(tpe.typeCode).flatMap(_.method(methodName))
+      } else if (VersionContext.current.isV3OrLaterErgoTreeVersion) {
         containersV6.get(tpe.typeCode).flatMap(_.method(methodName))
       } else {
         containersV5.get(tpe.typeCode).flatMap(_.method(methodName))
@@ -1724,6 +1746,106 @@ case object SAvlTreeMethods extends MonoTypeMethods {
     }
   }
 
+}
+
+/** Type descriptor of `MerkleTree` type of ErgoTree (v7.0+).
+  *
+  * Mirrors [[SAvlTreeMethods]] but for static (unauthenticated) Merkle trees. Only the
+  * root digest is stored; membership is proved by a serialized `BatchMerkleProof`
+  * (scrypto wire format) supplied as a `Coll[Byte]` argument to [[containsLeafMethod]]
+  * or [[containsLeavesMethod]].
+  *
+  * All methods are gated by [[VersionContext.isV4OrLaterErgoTreeVersion]] — they
+  * disappear under v5/v6 contexts so the v7 soft-fork is the only path through which
+  * scripts can call them.
+  */
+case object SMerkleTreeMethods extends MonoTypeMethods {
+  override def ownerType: SMonoType = SMerkleTree
+
+  lazy val digestMethod = SMethod(this, "digest", SFunc(SMerkleTree, SByteArray), 1, FixedCost(JitCost(15)))
+    .withIRInfo(MethodCallIrBuilder)
+    .withInfo(PropertyCall,
+      """Returns root hash of the Merkle tree (32 bytes, Blake2b256).
+      """.stripMargin)
+
+  lazy val updateDigestMethod = SMethod(this, "updateDigest",
+    SFunc(Array(SMerkleTree, SByteArray), SMerkleTree), 2, FixedCost(JitCost(40)))
+    .withIRInfo(MethodCallIrBuilder)
+    .withInfo(MethodCall,
+      """Replace the digest of this tree producing a new tree. Since MerkleTree is
+        |immutable, this instance remains unchanged.
+      """.stripMargin)
+
+  /** The proof may contain many leaf hashes, sibling hashes, and indices, and we don't
+    * know the exact split, but we assume the cost is O(proof.length).
+    * This descriptor is the same scale as AvlTree's [[SAvlTreeMethods.CreateAvlVerifier_Info]].
+    */
+  final val CreateMerkleVerifier_Info = OperationCostInfo(
+    PerItemCost(baseCost = JitCost(80), perChunkCost = JitCost(15), chunkSize = 64),
+    NamedDesc("CreateMerkleVerifier"))
+
+  /** Cost of validating a single (leaf, proof) pair against the root.
+    * The cost is O(log(tree_size)) but the verifier doesn't know the tree size,
+    * so we charge per-leaf as a constant approximation.
+    */
+  final val VerifyMerkleProof_Info = OperationCostInfo(
+    PerItemCost(baseCost = JitCost(35), perChunkCost = JitCost(8), chunkSize = 1),
+    NamedDesc("VerifyMerkleProof"))
+
+  lazy val containsLeafMethod = SMethod(this, "containsLeaf",
+    SFunc(Array(SMerkleTree, SByteArray, SByteArray), SBoolean), 3, DynamicCost)
+    .withIRInfo(MethodCallIrBuilder)
+    .withInfo(MethodCall,
+      """Verify single-leaf membership in this tree.
+        |
+        |Returns true iff the proof is well-formed and proves that `leafData` is a member
+        |of this tree under `this.digest`. Returns false on any verification failure or
+        |malformed proof (no exception is thrown).
+      """.stripMargin)
+
+  /** Implements evaluation of MerkleTree.containsLeaf method call ErgoTree node.
+    * Called via reflection based on naming convention.
+    * @see SMethod.evalMethod
+    */
+  def containsLeaf_eval(mc: MethodCall, tree: MerkleTree, leafData: Coll[Byte], proof: Coll[Byte])
+                       (implicit E: ErgoTreeEvaluator): Boolean = {
+    E.containsLeaf_eval(mc, tree, leafData, proof)
+  }
+
+  lazy val containsLeavesMethod = SMethod(this, "containsLeaves",
+    SFunc(Array(SMerkleTree, SByteArray2, SByteArray), SBoolean), 4, DynamicCost)
+    .withIRInfo(MethodCallIrBuilder)
+    .withInfo(MethodCall,
+      """Verify batch membership in this tree.
+        |
+        |Returns true iff the proof is well-formed and proves that all elements of
+        |`leaves` are members of this tree under `this.digest`. Returns false on any
+        |verification failure or malformed proof (no exception is thrown).
+      """.stripMargin)
+
+  /** Implements evaluation of MerkleTree.containsLeaves method call ErgoTree node.
+    * Called via reflection based on naming convention.
+    * @see SMethod.evalMethod
+    */
+  def containsLeaves_eval(mc: MethodCall, tree: MerkleTree, leaves: Coll[Coll[Byte]], proof: Coll[Byte])
+                         (implicit E: ErgoTreeEvaluator): Boolean = {
+    E.containsLeaves_eval(mc, tree, leaves, proof)
+  }
+
+  lazy val v7Methods: Seq[SMethod] = super.getMethods() ++ Seq(
+    digestMethod,
+    updateDigestMethod,
+    containsLeafMethod,
+    containsLeavesMethod
+  )
+
+  protected override def getMethods(): Seq[SMethod] = {
+    if (VersionContext.current.isV4OrLaterErgoTreeVersion) {
+      v7Methods
+    } else {
+      super.getMethods()
+    }
+  }
 }
 
 /** Type descriptor of `Context` type of ErgoTree. */

--- a/data/shared/src/main/scala/sigma/ast/values.scala
+++ b/data/shared/src/main/scala/sigma/ast/values.scala
@@ -9,7 +9,7 @@ import sigma.ast.syntax._
 import sigma.crypto.{CryptoConstants, EcPointType}
 import sigma.data.OverloadHack.Overloaded1
 import sigma.data.{CSigmaDslBuilder, CSigmaProp, CUnsignedBigInt, Nullable, RType, SigmaBoolean}
-import sigma.data.{AvlTreeData, CAvlTree, CSigmaDslBuilder, CSigmaProp, Nullable, RType, SigmaBoolean}
+import sigma.data.{AvlTreeData, CAvlTree, CMerkleTree, CSigmaDslBuilder, CSigmaProp, MerkleTreeData, Nullable, RType, SigmaBoolean}
 import sigma.eval.ErgoTreeEvaluator.DataEnv
 import sigma.eval.{ErgoTreeEvaluator, SigmaDsl}
 import sigma.exceptions.InterpreterException
@@ -552,6 +552,11 @@ object SigmaPropConstant {
 object AvlTreeConstant {
   def apply(value: AvlTree): Constant[SAvlTree.type] = Constant[SAvlTree.type](value, SAvlTree)
   def apply(value: AvlTreeData): Constant[SAvlTree.type] = Constant[SAvlTree.type](CAvlTree(value), SAvlTree)
+}
+
+object MerkleTreeConstant {
+  def apply(value: MerkleTree): Constant[SMerkleTree.type] = Constant[SMerkleTree.type](value, SMerkleTree)
+  def apply(value: MerkleTreeData): Constant[SMerkleTree.type] = Constant[SMerkleTree.type](CMerkleTree(value), SMerkleTree)
 }
 
 object PreHeaderConstant {

--- a/data/shared/src/main/scala/sigma/data/CSigmaDslBuilder.scala
+++ b/data/shared/src/main/scala/sigma/data/CSigmaDslBuilder.scala
@@ -20,8 +20,8 @@ import sigma.pow.Autolykos2PowValidation
 import sigma.util.Extensions.BigIntegerOps
 import sigma.util.NBitsUtils
 import sigma.validation.SigmaValidationSettings
-import sigma.{AvlTree, BigInt, Box, Coll, CollBuilder, Evaluation, GroupElement, SigmaDslBuilder, SigmaProp, VersionContext}
-import sigma.{AvlTree, BigInt, Box, Coll, CollBuilder, GroupElement, SigmaDslBuilder, SigmaProp, UnsignedBigInt, VersionContext}
+import sigma.{AvlTree, BigInt, Box, Coll, CollBuilder, Evaluation, GroupElement, MerkleTree, SigmaDslBuilder, SigmaProp, VersionContext}
+import sigma.{AvlTree, BigInt, Box, Coll, CollBuilder, GroupElement, MerkleTree, SigmaDslBuilder, SigmaProp, UnsignedBigInt, VersionContext}
 
 import java.math.BigInteger
 import java.nio.ByteBuffer
@@ -74,6 +74,11 @@ class CSigmaDslBuilder extends SigmaDslBuilder { dsl =>
   /** Wraps the given tree data into SigmaDsl value of type [[AvlTree]]. */
   def avlTree(treeData: AvlTreeData): AvlTree = {
     CAvlTree(treeData)
+  }
+
+  /** Wraps the given Merkle tree data into SigmaDsl value of type [[MerkleTree]]. */
+  def merkleTree(treeData: MerkleTreeData): MerkleTree = {
+    CMerkleTree(treeData)
   }
 
   /** Wraps the given [[ErgoBox]] into SigmaDsl value of type [[Box]].

--- a/data/shared/src/main/scala/sigma/data/DataValueComparer.scala
+++ b/data/shared/src/main/scala/sigma/data/DataValueComparer.scala
@@ -53,6 +53,13 @@ object DataValueComparer {
   final val OpDesc_EQ_AvlTree = NamedDesc("EQ_AvlTree")
   final val EQ_AvlTree = OperationCostInfo(CostKind_EQ_AvlTree, OpDesc_EQ_AvlTree)
 
+  /** Dedicated descriptor (not EQ_AvlTree) so AvlTree re-tuning never silently
+    * re-tunes MerkleTree and cost traces stay readable. Placeholder values: one field
+    * (digest) to compare instead of AvlTree's four — re-tune against benchmarks. */
+  final val CostKind_EQ_MerkleTree = FixedCost(JitCost(3 + (2 * CostOf_MatchType) / 2))
+  final val OpDesc_EQ_MerkleTree = NamedDesc("EQ_MerkleTree")
+  final val EQ_MerkleTree = OperationCostInfo(CostKind_EQ_MerkleTree, OpDesc_EQ_MerkleTree)
+
   final val CostKind_EQ_Box = FixedCost(JitCost(6))          // case 7
   final val OpDesc_EQ_Box = NamedDesc("EQ_Box")
   final val EQ_Box = OperationCostInfo(CostKind_EQ_Box, OpDesc_EQ_Box)
@@ -118,6 +125,14 @@ object DataValueComparer {
   final val OpDesc_EQ_COA_AvlTree = NamedDesc("EQ_COA_AvlTree")
   final val EQ_COA_AvlTree = OperationCostInfo(CostKind_EQ_COA_AvlTree, OpDesc_EQ_COA_AvlTree)
 
+  /** Equals two CollOverArray of MerkleTree type. Same shape as AvlTree's COA cost
+    * since both reduce to per-element digest comparisons; refine once benchmarked.
+    */
+  final val CostKind_EQ_COA_MerkleTree = PerItemCost(
+    baseCost = JitCost(15), perChunkCost = JitCost(5), chunkSize = 2)
+  final val OpDesc_EQ_COA_MerkleTree = NamedDesc("EQ_COA_MerkleTree")
+  final val EQ_COA_MerkleTree = OperationCostInfo(CostKind_EQ_COA_MerkleTree, OpDesc_EQ_COA_MerkleTree)
+
   /** Equals two CollOverArray of Box type. */
   final val CostKind_EQ_COA_Box = PerItemCost(
     baseCost = JitCost(15), perChunkCost = JitCost(5), chunkSize = 1)
@@ -142,6 +157,7 @@ object DataValueComparer {
       (UnsignedBigIntRType, (EQ_BigInt, EQ_COA_BigInt)),
       (GroupElementRType, (EQ_GroupElement, EQ_COA_GroupElement)),
       (AvlTreeRType, (EQ_AvlTree, EQ_COA_AvlTree)),
+      (MerkleTreeRType, (EQ_MerkleTree, EQ_COA_MerkleTree)),
       (BoxRType, (EQ_Box, EQ_COA_Box)),
       (PreHeaderRType, (EQ_PreHeader, EQ_COA_PreHeader)),
       (HeaderRType, (EQ_Header, EQ_COA_Header))
@@ -363,6 +379,11 @@ object DataValueComparer {
       case bi: AvlTree =>  /** case 6 (see [[EQ_AvlTree]]) */
         E.addFixedCost(EQ_AvlTree) {
           okEqual = bi == r
+        }
+
+      case mt: MerkleTree =>
+        E.addFixedCost(EQ_MerkleTree) {
+          okEqual = mt == r
         }
 
       case opt1: Option[_] => /** case 7 (see [[EQ_Option]]) */

--- a/data/shared/src/main/scala/sigma/eval/ErgoTreeEvaluator.scala
+++ b/data/shared/src/main/scala/sigma/eval/ErgoTreeEvaluator.scala
@@ -1,6 +1,6 @@
 package sigma.eval
 
-import sigma.{AvlTree, Coll, Context, Header}
+import sigma.{AvlTree, Coll, Context, Header, MerkleTree}
 import sigma.ast.{Constant, FixedCost, MethodCall, OperationCostInfo, OperationDesc, PerItemCost, SType, TypeBasedCost}
 import sigma.data.KeyValueColl
 
@@ -145,6 +145,20 @@ abstract class ErgoTreeEvaluator {
   def remove_eval(
       mc: MethodCall, tree: AvlTree,
       operations: Coll[Coll[Byte]], proof: Coll[Byte]): Option[AvlTree]
+
+  /** Implements evaluation of MerkleTree.containsLeaf method call ErgoTree node (v7.0+). */
+  def containsLeaf_eval(
+      mc: MethodCall,
+      tree: MerkleTree,
+      leafData: Coll[Byte],
+      proof: Coll[Byte]): Boolean
+
+  /** Implements evaluation of MerkleTree.containsLeaves method call ErgoTree node (v7.0+). */
+  def containsLeaves_eval(
+      mc: MethodCall,
+      tree: MerkleTree,
+      leaves: Coll[Coll[Byte]],
+      proof: Coll[Byte]): Boolean
 }
 
 object ErgoTreeEvaluator {

--- a/interpreter/shared/src/main/scala/sigmastate/eval/CMerkleTreeVerifier.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/eval/CMerkleTreeVerifier.scala
@@ -1,0 +1,89 @@
+package sigmastate.eval
+
+import scorex.crypto.authds.merkle.BatchMerkleProof
+import scorex.crypto.authds.merkle.serialization.BatchMerkleProofSerializer
+import scorex.crypto.hash.{Blake2b256, Digest32}
+import sigma.{Coll, MerkleTree}
+import sigma.data.CMerkleTree
+
+import scala.util.Try
+
+/** Verifier for static Merkle proofs introduced in v7.0.
+  *
+  * Wraps scrypto's [[BatchMerkleProof]] so the proof byte format is the same one used
+  * by the Ergo node. The verifier:
+  *   1. parses the proof bytes via [[BatchMerkleProofSerializer]];
+  *   2. computes prefixed leaf hashes from the supplied raw leaf bytes
+  *      (`Blake2b256(LeafPrefix || leafBytes)`); and
+  *   3. checks both that each computed leaf hash appears in the proof's claimed leaf
+  *      set AND that the proof reconstructs to the tree's root digest.
+  *
+  * Both checks are required: a proof that's `valid` against the root but doesn't
+  * actually claim the requested leaves must be rejected. Any malformed proof, leaf
+  * mismatch, or root mismatch yields `false` rather than throwing.
+  */
+class CMerkleTreeVerifier private (
+    rootDigest: Array[Byte],
+    parsedProof: Try[BatchMerkleProof[Digest32]]) {
+
+  /** Verify single-leaf membership.
+    *
+    * @param leafData raw leaf bytes (will be domain-separated hashed inside).
+    * @return true iff the proof is well-formed, claims exactly this leaf, and
+    *         reconstructs to the root digest.
+    */
+  def containsLeaf(leafData: Coll[Byte]): Boolean = {
+    parsedProof.fold(
+      _ => false,
+      bmp => {
+        val expectedHash = leafHash(leafData)
+        val claimsThisLeaf =
+          bmp.indices.length == 1 &&
+            java.util.Arrays.equals(bmp.indices.head._2, expectedHash)
+        claimsThisLeaf && Try(bmp.valid(Digest32 @@ rootDigest)).getOrElse(false)
+      }
+    )
+  }
+
+  /** Verify batch membership.
+    *
+    * @param leaves raw leaf bytes for each element. Order is irrelevant — the verifier
+    *               only requires set-equality between the supplied leaves' hashes and
+    *               the proof's claimed leaf hashes.
+    * @return true iff the proof is well-formed, claims exactly these leaves, and
+    *         reconstructs to the root digest.
+    */
+  def containsLeaves(leaves: Coll[Coll[Byte]]): Boolean = {
+    parsedProof.fold(
+      _ => false,
+      bmp => {
+        if (bmp.indices.length != leaves.length) {
+          false
+        } else {
+          val claimedHashes = bmp.indices.map(_._2.toSeq).toSet
+          val expectedHashes = (0 until leaves.length).map(i => leafHash(leaves(i)).toSeq).toSet
+          claimedHashes == expectedHashes && Try(bmp.valid(Digest32 @@ rootDigest)).getOrElse(false)
+        }
+      }
+    )
+  }
+
+  private def leafHash(data: Coll[Byte]): Array[Byte] =
+    Blake2b256.prefixedHash(scorex.crypto.authds.merkle.MerkleTree.LeafPrefix, data.toArray)
+}
+
+object CMerkleTreeVerifier {
+  /** scrypto serializer pinned to Blake2b256/Digest32 — the only hash function used by
+    * Ergo's Merkle constructions. */
+  private val proofSerializer = new BatchMerkleProofSerializer[Digest32, Blake2b256.type]()(Blake2b256)
+
+  /** Build a verifier for the given tree and proof. Proof bytes are parsed eagerly so
+    * verification calls become cheap; parse failure is captured in the returned
+    * verifier and surfaces as `false` from `containsLeaf` / `containsLeaves`.
+    */
+  def apply(tree: MerkleTree, proof: Coll[Byte]): CMerkleTreeVerifier = {
+    val treeData = tree.asInstanceOf[CMerkleTree].treeData
+    val parsed   = proofSerializer.deserialize(proof.toArray)
+    new CMerkleTreeVerifier(treeData.digest.toArray, parsed)
+  }
+}

--- a/interpreter/shared/src/main/scala/sigmastate/interpreter/CErgoTreeEvaluator.scala
+++ b/interpreter/shared/src/main/scala/sigmastate/interpreter/CErgoTreeEvaluator.scala
@@ -3,13 +3,14 @@ package sigmastate.interpreter
 import org.ergoplatform.ErgoLikeContext
 import sigma.ast._
 import sigma.ast.syntax._
-import sigmastate.eval.{CAvlTreeVerifier, CProfiler}
+import sigmastate.eval.{CAvlTreeVerifier, CMerkleTreeVerifier, CProfiler}
 import sigmastate.interpreter.Interpreter.ReductionResult
-import sigma.{AvlTree, Coll, Colls, Context, Header, VersionContext}
+import sigma.{AvlTree, Coll, Colls, Context, Header, MerkleTree, VersionContext}
 import sigma.util.Extensions._
 import debox.{cfor, Buffer => DBuffer}
 import scorex.crypto.authds.ADKey
 import sigma.ast.SAvlTreeMethods._
+import sigma.ast.SMerkleTreeMethods
 import sigma.ast.SType
 import sigma.data.{CSigmaProp, KeyValueColl, SigmaBoolean}
 import sigma.eval.{AvlTreeVerifier, ErgoTreeEvaluator, EvalSettings, Profiler}
@@ -251,6 +252,42 @@ class CErgoTreeEvaluator(
         case _ => None
       }
     }
+  }
+
+  /** Cost-tracking factory for [[CMerkleTreeVerifier]]. Charges the parse-proof cost up
+    * front (O(proof.length)), then `containsLeaf` / `containsLeaves` only charge the
+    * lookup cost per leaf.
+    */
+  private def createMerkleVerifier(tree: MerkleTree, proof: Coll[Byte]): CMerkleTreeVerifier = {
+    addSeqCost(SMerkleTreeMethods.CreateMerkleVerifier_Info, proof.length) { () =>
+      CMerkleTreeVerifier(tree, proof)
+    }
+  }
+
+  override def containsLeaf_eval(
+      mc: MethodCall,
+      tree: MerkleTree,
+      leafData: Coll[Byte],
+      proof: Coll[Byte]): Boolean = {
+    val verifier = createMerkleVerifier(tree, proof)
+    var res = false
+    addSeqCost(SMerkleTreeMethods.VerifyMerkleProof_Info, 1) { () =>
+      res = verifier.containsLeaf(leafData)
+    }
+    res
+  }
+
+  override def containsLeaves_eval(
+      mc: MethodCall,
+      tree: MerkleTree,
+      leaves: Coll[Coll[Byte]],
+      proof: Coll[Byte]): Boolean = {
+    val verifier = createMerkleVerifier(tree, proof)
+    var res = false
+    addSeqCost(SMerkleTreeMethods.VerifyMerkleProof_Info, leaves.length) { () =>
+      res = verifier.containsLeaves(leaves)
+    }
+    res
   }
 
   /** Evaluates the given expression in the given data environment. */

--- a/interpreter/shared/src/test/scala/sigma/ast/SigmaBuilderTest.scala
+++ b/interpreter/shared/src/test/scala/sigma/ast/SigmaBuilderTest.scala
@@ -284,6 +284,17 @@ class SigmaBuilderTest extends AnyPropSpec with ScalaCheckPropertyChecks with Ma
     testColl[SAvlTree.type](v, c)
   }
 
+  property("liftToConstant MerkleTree") {
+    val v = TestData.mt1
+    val c = MerkleTreeConstant(v)
+    VersionContext.withVersions(
+      VersionContext.V7SoftForkVersion, VersionContext.V7SoftForkVersion) {
+      test[SMerkleTree.type](v, c)
+      testFailure(Array.fill(10)(v))
+      testColl[SMerkleTree.type](v, c)
+    }
+  }
+
   property("liftToConstant AvlTreeData") {
     val v = TestData.t1.asInstanceOf[CAvlTree].wrappedValue
     val c = AvlTreeConstant(SigmaDsl.avlTree(v))

--- a/interpreter/shared/src/test/scala/sigma/serialization/ConstantSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/ConstantSerializerSpecification.scala
@@ -9,7 +9,7 @@ import sigma.ast.{BigIntConstant, ByteArrayConstant, Constant, DeserializationSi
 import sigmastate.eval._
 import sigma.Extensions.ArrayOps
 import sigma.ast._
-import sigma.{AvlTree, Colls, Evaluation, Header, VersionContext}
+import sigma.{AvlTree, Colls, Evaluation, Header, MerkleTree, VersionContext}
 import sigma.ast.SType.AnyOps
 import scorex.util.encode.Base16
 import sigma.ast.BoolArrayConstant.BoolArrayTypeCode
@@ -29,6 +29,8 @@ class ConstantSerializerSpecification extends TableSerializationSpecification {
 
     val withVersion = if (tpe == SHeader) {
       Some(VersionContext.V6SoftForkVersion)
+    } else if (tpe == SMerkleTree) {
+      Some(VersionContext.V7SoftForkVersion)
     } else {
       None
     }
@@ -84,6 +86,7 @@ class ConstantSerializerSpecification extends TableSerializationSpecification {
     forAll { x: SigmaBoolean => roundTripTest(Constant[SSigmaProp.type](x.toSigmaProp, SSigmaProp)) }
     forAll { x: ErgoBox => roundTripTest(Constant[SBox.type](x, SBox)) }
     forAll { x: AvlTree => roundTripTest(Constant[SAvlTree.type](x, SAvlTree)) }
+    forAll { x: MerkleTree => roundTripTest(Constant[SMerkleTree.type](x, SMerkleTree), Some(VersionContext.V7SoftForkVersion)) }
     forAll { x: Header => roundTripTest(Constant[SHeader.type](x, SHeader), Some(VersionContext.V6SoftForkVersion)) }
     forAll { x: Array[Byte] => roundTripTest(Constant[SByteArray](x.toColl, SByteArray)) }
     forAll { t: SPredefType => testCollection(t) }
@@ -102,6 +105,7 @@ class ConstantSerializerSpecification extends TableSerializationSpecification {
     testCollection(SUnit)
     testCollection(SBox)
     testCollection(SAvlTree)
+    testCollection(SMerkleTree)
     testCollection(SHeader)
   }
 

--- a/interpreter/shared/src/test/scala/sigma/serialization/DataSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/DataSerializerSpecification.scala
@@ -6,7 +6,7 @@ import org.scalacheck.Arbitrary._
 import sigma.data.{CBigInt, CHeader, DataValueComparer, OptionType, RType, SigmaBoolean, TupleColl}
 import sigma.ast.SCollection.SByteArray
 import sigmastate.eval._
-import sigma.{AvlTree, Colls, Evaluation, Header, VersionContext}
+import sigma.{AvlTree, Colls, Evaluation, Header, MerkleTree, VersionContext}
 import sigma.ast.SType.AnyOps
 import sigma.ast._
 import org.scalacheck.Gen
@@ -154,6 +154,7 @@ class DataSerializerSpecification extends SerializationSpecification {
     forAll { x: SigmaBoolean => roundtrip[SSigmaProp.type](x.toSigmaProp, SSigmaProp) }
     forAll { x: ErgoBox => roundtrip[SBox.type](x, SBox) }
     forAll { x: AvlTree => roundtrip[SAvlTree.type](x, SAvlTree) }
+    forAll { x: MerkleTree => roundtrip[SMerkleTree.type](x, SMerkleTree, Some(VersionContext.V7SoftForkVersion)) }
     forAll { x: Array[Byte] => roundtrip[SByteArray](x.toColl, SByteArray) }
     forAll { x: Header => roundtrip[SHeader.type](x, SHeader, Some(VersionContext.V6SoftForkVersion)) }
     forAll { t: SPredefType => testCollection(t) }

--- a/interpreter/shared/src/test/scala/sigma/serialization/MerkleTreeSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/MerkleTreeSpecification.scala
@@ -1,0 +1,157 @@
+package sigma.serialization
+
+import org.scalacheck.{Arbitrary, Gen}
+import scorex.crypto.authds.LeafData
+import scorex.crypto.authds.merkle.MerkleTree
+import scorex.crypto.authds.merkle.serialization.BatchMerkleProofSerializer
+import scorex.crypto.hash.{Blake2b256, Digest32}
+import sigma.VersionContext
+import sigma.VersionContext.V7SoftForkVersion
+import sigma.Colls
+import sigma.ast.MerkleTreeConstant
+import sigma.data.{CMerkleTree, MerkleTreeData}
+
+class MerkleTreeSpecification extends SerializationSpecification {
+
+  private val ver7 = V7SoftForkVersion
+
+  /** Generator: 32 random bytes used as a Merkle tree root digest. */
+  private def digestGen: Gen[Array[Byte]] =
+    Gen.listOfN(MerkleTreeData.DigestSize, Arbitrary.arbitrary[Byte]).map(_.toArray)
+
+  property("MerkleTreeData roundtrip") {
+    forAll(digestGen) { digestBytes =>
+      val data = MerkleTreeData(Colls.fromArray(digestBytes))
+      val w = SigmaSerializer.startWriter()
+      MerkleTreeData.serializer.serialize(data, w)
+      val parsed = MerkleTreeData.serializer.parse(SigmaSerializer.startReader(w.toBytes))
+      parsed shouldBe data
+    }
+  }
+
+  property("MerkleTreeConstant serialization roundtrip under v7") {
+    forAll(digestGen) { digestBytes =>
+      val tree = CMerkleTree(MerkleTreeData(Colls.fromArray(digestBytes)))
+      val v = MerkleTreeConstant(tree)
+      roundTripTest(v, Some(ver7))
+    }
+  }
+
+  property("BatchMerkleProof verifies for a real Merkle tree") {
+    implicit val hf: Blake2b256.type = Blake2b256
+    val leaves: Seq[Array[Byte]] = (0 until 8).map(i => Blake2b256.hash(s"leaf-$i"))
+    val payload: Seq[LeafData] = leaves.map(LeafData @@ _)
+    val tree = MerkleTree[Digest32](payload)
+    val serializer = new BatchMerkleProofSerializer[Digest32, Blake2b256.type]()(hf)
+
+    // Build a single-leaf batch proof.
+    val proof = tree.proofByIndices(Seq(3)).get
+    val proofBytes = serializer.serialize(proof)
+
+    VersionContext.withVersions(ver7, ver7) {
+      val mt = CMerkleTree(MerkleTreeData(Colls.fromArray(tree.rootHash)))
+      // Construct verifier and check it accepts the leaf at index 3:
+      val verifier = sigmastate.eval.CMerkleTreeVerifier(mt, Colls.fromArray(proofBytes))
+      verifier.containsLeaf(Colls.fromArray(leaves(3))) shouldBe true
+      // wrong leaf -> rejected
+      verifier.containsLeaf(Colls.fromArray(leaves(0))) shouldBe false
+    }
+  }
+
+  property("malformed proof bytes do not throw, just return false") {
+    val digest = Array.fill[Byte](MerkleTreeData.DigestSize)(7.toByte)
+    val mt = CMerkleTree(MerkleTreeData(Colls.fromArray(digest)))
+    val garbage = Array.fill[Byte](16)(0.toByte) // too short to be a valid proof
+    val verifier = sigmastate.eval.CMerkleTreeVerifier(mt, Colls.fromArray(garbage))
+    verifier.containsLeaf(Colls.fromArray(Array.fill[Byte](4)(1.toByte))) shouldBe false
+    verifier.containsLeaves(Colls.fromArray(Array(Colls.fromArray(Array.fill[Byte](4)(1.toByte))))) shouldBe false
+  }
+
+  property("batch proof verifies multiple leaves") {
+    implicit val hf: Blake2b256.type = Blake2b256
+    val leaves: Seq[Array[Byte]] = (0 until 16).map(i => Blake2b256.hash(s"item-$i"))
+    val payload: Seq[LeafData] = leaves.map(LeafData @@ _)
+    val tree = MerkleTree[Digest32](payload)
+    val serializer = new BatchMerkleProofSerializer[Digest32, Blake2b256.type]()(hf)
+
+    val indices = Seq(1, 4, 9)
+    val proof = tree.proofByIndices(indices).get
+    val proofBytes = serializer.serialize(proof)
+
+    VersionContext.withVersions(ver7, ver7) {
+      val mt = CMerkleTree(MerkleTreeData(Colls.fromArray(tree.rootHash)))
+      val verifier = sigmastate.eval.CMerkleTreeVerifier(mt, Colls.fromArray(proofBytes))
+      val claimed = Colls.fromArray(indices.map(i => Colls.fromArray(leaves(i))).toArray)
+      verifier.containsLeaves(claimed) shouldBe true
+
+      // wrong leaf in batch -> rejected
+      val wrongClaim = Colls.fromArray(
+        Array(Colls.fromArray(leaves(1)), Colls.fromArray(leaves(2)), Colls.fromArray(leaves(9))))
+      verifier.containsLeaves(wrongClaim) shouldBe false
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pre-v7 negative tests
+  //
+  // MerkleTree must not be reachable from v5/v6 contexts. These assertions pin
+  // each gating layer separately so future changes don't silently re-expose it.
+  // ---------------------------------------------------------------------------
+
+  private val ver6: Byte = VersionContext.V6SoftForkVersion
+  private val ver5: Byte = (VersionContext.V6SoftForkVersion - 1).toByte
+
+  property("SMerkleTree.typeCode does not deserialize in v5/v6") {
+    val w = SigmaSerializer.startWriter()
+    w.put(sigma.ast.SMerkleTree.typeCode)
+    val bytes = w.toBytes
+    Seq(ver5, ver6).foreach { v =>
+      val activated = if (v < VersionContext.V6SoftForkVersion) ver6 else v
+      VersionContext.withVersions(activated, v) {
+        // TypeSerializer dispatches to NoType (after CheckTypeCode) for unknown codes
+        // under pre-v7; validation rule yields ValidationException.
+        a[Exception] should be thrownBy
+          TypeSerializer.deserialize(SigmaSerializer.startReader(bytes))
+      }
+    }
+  }
+
+  property("MerkleTreeData does not serialize in v5/v6 via CoreDataSerializer") {
+    val mt = CMerkleTree(MerkleTreeData(Colls.fromArray(Array.fill[Byte](32)(0.toByte))))
+    Seq(ver5, ver6).foreach { v =>
+      val activated = if (v < VersionContext.V6SoftForkVersion) ver6 else v
+      VersionContext.withVersions(activated, v) {
+        val w = SigmaSerializer.startWriter()
+        a[SerializerException] should be thrownBy
+          DataSerializer.serialize[sigma.ast.SMerkleTree.type](mt, sigma.ast.SMerkleTree, w)
+      }
+    }
+  }
+
+  property("Constant[SMerkleTree] does not round-trip in v5/v6") {
+    val mt = CMerkleTree(MerkleTreeData(Colls.fromArray(Array.fill[Byte](32)(0.toByte))))
+    val c = sigma.ast.MerkleTreeConstant(mt)
+    Seq(ver5, ver6).foreach { v =>
+      val activated = if (v < VersionContext.V6SoftForkVersion) ver6 else v
+      VersionContext.withVersions(activated, v) {
+        a[Exception] should be thrownBy ValueSerializer.serialize(c)
+      }
+    }
+  }
+
+  property("SMerkleTreeMethods is empty in v5/v6") {
+    Seq(ver5, ver6).foreach { v =>
+      val activated = if (v < VersionContext.V6SoftForkVersion) ver6 else v
+      VersionContext.withVersions(activated, v) {
+        sigma.ast.SMerkleTreeMethods.methods shouldBe empty
+      }
+    }
+  }
+
+  property("SMerkleTreeMethods is populated in v7") {
+    VersionContext.withVersions(ver7, ver7) {
+      sigma.ast.SMerkleTreeMethods.methods.map(_.name).toSet shouldBe
+        Set("digest", "updateDigest", "containsLeaf", "containsLeaves")
+    }
+  }
+}

--- a/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/MethodCallSerializerSpecification.scala
@@ -202,6 +202,63 @@ class MethodCallSerializerSpecification extends SerializationSpecification {
       )
   }
 
+  property("MethodCall deserialization round trip for MerkleTree.containsLeaf") {
+    def code = {
+      val digest = ByteArrayConstant(Array.fill[Byte](32)(0.toByte))
+      val emptyTree = MethodCall(
+        MerkleTreeConstant(sigma.data.MerkleTreeData(digest.value)),
+        SMerkleTreeMethods.containsLeafMethod,
+        Vector(ByteArrayConstant(Array.fill[Byte](4)(1.toByte)),
+               ByteArrayConstant(Array.fill[Byte](8)(0.toByte))),
+        Map()
+      )
+      roundTripTest(emptyTree)
+    }
+
+    VersionContext.withVersions(VersionContext.V7SoftForkVersion, VersionContext.V7SoftForkVersion) {
+      code
+    }
+
+    a[Exception] should be thrownBy (
+      VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+        code
+      }
+    )
+
+    a[Exception] should be thrownBy (
+      VersionContext.withVersions((VersionContext.V6SoftForkVersion - 1).toByte, 1) {
+        code
+      }
+    )
+  }
+
+  property("MethodCall deserialization round trip for MerkleTree.containsLeaves") {
+    def code = {
+      val digest = ByteArrayConstant(Array.fill[Byte](32)(0.toByte))
+      val leaves = ConcreteCollection(
+        Array[Value[SByteArray]](ByteArrayConstant(Array.fill[Byte](4)(1.toByte))),
+        SByteArray
+      )
+      val expr = MethodCall(
+        MerkleTreeConstant(sigma.data.MerkleTreeData(digest.value)),
+        SMerkleTreeMethods.containsLeavesMethod,
+        Vector(leaves, ByteArrayConstant(Array.fill[Byte](8)(0.toByte))),
+        Map()
+      )
+      roundTripTest(expr)
+    }
+
+    VersionContext.withVersions(VersionContext.V7SoftForkVersion, VersionContext.V7SoftForkVersion) {
+      code
+    }
+
+    a[Exception] should be thrownBy (
+      VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+        code
+      }
+    )
+  }
+
   property("eq") {
     println("sv: " + VersionContext.current.activatedVersion)
     println("tv: " + VersionContext.current.ergoTreeVersion)

--- a/interpreter/shared/src/test/scala/sigma/serialization/generators/ObjectGenerators.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/generators/ObjectGenerators.scala
@@ -96,6 +96,9 @@ trait ObjectGenerators extends TypeGenerators
   implicit lazy val arbBox: Arbitrary[Box] = Arbitrary(ergoBoxGen.map(SigmaDsl.Box))
   implicit lazy val arbAvlTreeData: Arbitrary[AvlTreeData] = Arbitrary(avlTreeDataGen)
   implicit lazy val arbAvlTree: Arbitrary[AvlTree] = Arbitrary(avlTreeGen)
+  implicit lazy val arbMerkleTreeData: Arbitrary[sigma.data.MerkleTreeData] = Arbitrary(merkleTreeDataGen)
+  implicit lazy val arbMerkleTree: Arbitrary[sigma.MerkleTree] = Arbitrary(merkleTreeGen)
+  implicit lazy val arbMerkleTreeConstant: Arbitrary[Constant[SMerkleTree.type]] = Arbitrary(merkleTreeConstantGen)
   implicit lazy val arbBoxCandidate: Arbitrary[ErgoBoxCandidate] = Arbitrary(ergoBoxCandidateGen(tokensGen.sample.get))
   implicit lazy val arbTransaction: Arbitrary[ErgoLikeTransaction] = Arbitrary(ergoTransactionGen)
   implicit lazy val arbContextExtension: Arbitrary[ContextExtension] = Arbitrary(contextExtensionGen)
@@ -304,6 +307,15 @@ trait ObjectGenerators extends TypeGenerators
 
   def avlTreeConstantGen: Gen[AvlTreeConstant] = avlTreeGen.map { v => AvlTreeConstant(v) }
 
+  def merkleTreeDataGen: Gen[sigma.data.MerkleTreeData] = for {
+    digest <- arrayOfN(sigma.data.MerkleTreeData.DigestSize, arbByte.arbitrary)
+  } yield sigma.data.MerkleTreeData(Colls.fromArray(digest))
+
+  def merkleTreeGen: Gen[sigma.MerkleTree] = merkleTreeDataGen.map(d => sigma.data.CMerkleTree(d))
+
+  def merkleTreeConstantGen: Gen[Constant[SMerkleTree.type]] =
+    merkleTreeGen.map(v => MerkleTreeConstant(v))
+
   def wrappedTypeGen[T <: SType](tpe: T): Gen[T#WrappedType] = (tpe match {
     case SBoolean => arbBool
     case SByte => arbByte
@@ -316,6 +328,7 @@ trait ObjectGenerators extends TypeGenerators
     case SSigmaProp => arbSigmaProp
     case SBox => arbBox
     case SAvlTree => arbAvlTree
+    case SMerkleTree => arbMerkleTree
     case SAny => arbAnyVal
     case SUnit => arbUnit
     case SHeader => arbHeader

--- a/interpreter/shared/src/test/scala/special/sigma/SigmaTestingData.scala
+++ b/interpreter/shared/src/test/scala/special/sigma/SigmaTestingData.scala
@@ -148,6 +148,12 @@ trait SigmaTestingData extends TestingCommons with ObjectGenerators {
       )
     )
 
+    val mt1: MerkleTree = CMerkleTree(
+      MerkleTreeData(
+        ErgoAlgos.decodeUnsafe("0183807f66b301530120ff7fc6bd6601ff01ff7f7d2bedbbffff00187fe89094").toColl
+      )
+    )
+
     val b1_instances = new CloneSet(1000, CBox(
       new ErgoBox(
         9223372036854775807L,

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphBuilding.scala
@@ -44,6 +44,7 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
   import GroupElement._
   import Header._
   import Liftables._
+  import MerkleTree._
   import PreHeader._
   import SigmaDslBuilder._
   import SigmaProp._
@@ -271,6 +272,7 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
     case SPreHeader => preHeaderElement
     case SGroupElement => groupElementElement
     case SAvlTree => avlTreeElement
+    case SMerkleTree => merkleTreeElement
     case SSigmaProp => sigmaPropElement
     case STuple(Seq(a, b)) => pairElement(stypeToElem(a), stypeToElem(b))
     case c: SCollectionType[a] => collElement(stypeToElem(c.elemType))
@@ -294,6 +296,7 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
     case _: UnsignedBigIntElem[_] => SUnsignedBigInt
     case _: GroupElementElem[_] => SGroupElement
     case _: AvlTreeElem[_] => SAvlTree
+    case _: MerkleTreeElem[_] => SMerkleTree
     case oe: WOptionElem[_, _] => SOption(elemToSType(oe.eItem))
     case _: BoxElem[_] => SBox
     case _: ContextElem[_] => SContext
@@ -487,6 +490,9 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
           val boxV = liftConst(box)
           boxV
         case tree: sigma.AvlTree =>
+          val treeV = liftConst(tree)
+          treeV
+        case tree: sigma.MerkleTree =>
           val treeV = liftConst(tree)
           treeV
         case s: String =>
@@ -1143,6 +1149,22 @@ trait GraphBuilding extends Base with DefRewriting { IR: IRContext =>
               val operations = asRep[Coll[(Coll[Byte], Coll[Byte])]](argsV(0))
               val proof = asRep[Coll[Byte]](argsV(1))
               tree.insertOrUpdate(operations, proof)
+            case _ => throwError()
+          }
+          case (tree: Ref[MerkleTree]@unchecked, SMerkleTreeMethods) => method.name match {
+            case SMerkleTreeMethods.digestMethod.name =>
+              tree.digest
+            case SMerkleTreeMethods.updateDigestMethod.name =>
+              val digest = asRep[Coll[Byte]](argsV(0))
+              tree.updateDigest(digest)
+            case SMerkleTreeMethods.containsLeafMethod.name =>
+              val leafData = asRep[Coll[Byte]](argsV(0))
+              val proof = asRep[Coll[Byte]](argsV(1))
+              tree.containsLeaf(leafData, proof)
+            case SMerkleTreeMethods.containsLeavesMethod.name =>
+              val leaves = asRep[Coll[Coll[Byte]]](argsV(0))
+              val proof = asRep[Coll[Byte]](argsV(1))
+              tree.containsLeaves(leaves, proof)
             case _ => throwError()
           }
           case (ph: Ref[PreHeader]@unchecked, SPreHeaderMethods) => method.name match {

--- a/sc/shared/src/main/scala/sigma/compiler/ir/GraphIRReflection.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/GraphIRReflection.scala
@@ -337,6 +337,30 @@ object GraphIRReflection {
       )
     )
   }
+  {
+    val clazz = classOf[SigmaDsl#MerkleTree]
+    val ctx = null.asInstanceOf[IRContext] // ok! type level only
+    registerClassEntry(clazz,
+      methods = Map(
+        mkMethod(clazz, "digest", Array[Class[_]]()) { (obj, _) =>
+          obj.asInstanceOf[ctx.MerkleTree].digest
+        },
+        mkMethod(clazz, "updateDigest", Array[Class[_]](classOf[Base#Ref[_]])) { (obj, args) =>
+          obj.asInstanceOf[ctx.MerkleTree].updateDigest(args(0).asInstanceOf[ctx.Ref[ctx.Coll[Byte]]])
+        },
+        mkMethod(clazz, "containsLeaf", Array[Class[_]](classOf[Base#Ref[_]], classOf[Base#Ref[_]])) { (obj, args) =>
+          obj.asInstanceOf[ctx.MerkleTree].containsLeaf(
+            args(0).asInstanceOf[ctx.Ref[ctx.Coll[Byte]]],
+            args(1).asInstanceOf[ctx.Ref[ctx.Coll[Byte]]])
+        },
+        mkMethod(clazz, "containsLeaves", Array[Class[_]](classOf[Base#Ref[_]], classOf[Base#Ref[_]])) { (obj, args) =>
+          obj.asInstanceOf[ctx.MerkleTree].containsLeaves(
+            args(0).asInstanceOf[ctx.Ref[ctx.Coll[ctx.Coll[Byte]]]],
+            args(1).asInstanceOf[ctx.Ref[ctx.Coll[Byte]]])
+        }
+      )
+    )
+  }
 
   { val clazz = classOf[SigmaDsl#Box]
     val ctx = null.asInstanceOf[IRContext] // ok! type level only

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/SigmaDslUnit.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/SigmaDslUnit.scala
@@ -71,6 +71,12 @@ import scalan._
       def insertOrUpdate(operations: Ref[Coll[scala.Tuple2[Coll[Byte], Coll[Byte]]]], proof: Ref[Coll[Byte]]): Ref[WOption[AvlTree]];
       def remove(operations: Ref[Coll[Coll[Byte]]], proof: Ref[Coll[Byte]]): Ref[WOption[AvlTree]]
     };
+    trait MerkleTree extends Def[MerkleTree] {
+      def digest: Ref[Coll[Byte]];
+      def updateDigest(newDigest: Ref[Coll[Byte]]): Ref[MerkleTree];
+      def containsLeaf(leafData: Ref[Coll[Byte]], proof: Ref[Coll[Byte]]): Ref[Boolean];
+      def containsLeaves(leaves: Ref[Coll[Coll[Byte]]], proof: Ref[Coll[Byte]]): Ref[Boolean]
+    };
     trait PreHeader extends Def[PreHeader] {
       def version: Ref[Byte];
       def parentId: Ref[Coll[Byte]];
@@ -149,6 +155,7 @@ import scalan._
     trait SigmaPropCompanion;
     trait BoxCompanion;
     trait AvlTreeCompanion;
+    trait MerkleTreeCompanion;
     trait PreHeaderCompanion;
     trait HeaderCompanion;
     trait ContextCompanion;

--- a/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/ir/wrappers/sigma/impl/SigmaDslImpl.scala
@@ -30,6 +30,7 @@ import Coll._
 import CollBuilder._
 import GroupElement._
 import Header._
+import MerkleTree._
 import PreHeader._
 import SigmaProp._
 import WOption._
@@ -1379,6 +1380,124 @@ object AvlTree extends EntityObject("AvlTree") {
 
 } // of object AvlTree
   registerEntityObject("AvlTree", AvlTree)
+
+object MerkleTree extends EntityObject("MerkleTree") {
+  import Liftables._
+  import scala.reflect.{ClassTag, classTag}
+  type SMerkleTree = sigma.MerkleTree
+  case class MerkleTreeConst(
+        constValue: SMerkleTree
+      ) extends LiftedConst[SMerkleTree, MerkleTree] with MerkleTree
+        with Def[MerkleTree] with MerkleTreeConstMethods {
+    val liftable: Liftable[SMerkleTree, MerkleTree] = LiftableMerkleTree
+    val resultType: Elem[MerkleTree] = liftable.eW
+  }
+
+  trait MerkleTreeConstMethods extends MerkleTree { thisConst: Def[_] =>
+
+    private val MerkleTreeClass = RClass(classOf[MerkleTree])
+
+    override def digest: Ref[Coll[Byte]] = {
+      asRep[Coll[Byte]](mkMethodCall(self,
+        MerkleTreeClass.getMethod("digest"),
+        ArraySeq.empty,
+        true, false, element[Coll[Byte]]))
+    }
+
+    override def updateDigest(newDigest: Ref[Coll[Byte]]): Ref[MerkleTree] = {
+      asRep[MerkleTree](mkMethodCall(self,
+        MerkleTreeClass.getMethod("updateDigest", classOf[Sym]),
+        Array[AnyRef](newDigest),
+        true, false, element[MerkleTree]))
+    }
+
+    override def containsLeaf(leafData: Ref[Coll[Byte]], proof: Ref[Coll[Byte]]): Ref[Boolean] = {
+      asRep[Boolean](mkMethodCall(self,
+        MerkleTreeClass.getMethod("containsLeaf", classOf[Sym], classOf[Sym]),
+        Array[AnyRef](leafData, proof),
+        true, false, element[Boolean]))
+    }
+
+    override def containsLeaves(leaves: Ref[Coll[Coll[Byte]]], proof: Ref[Coll[Byte]]): Ref[Boolean] = {
+      asRep[Boolean](mkMethodCall(self,
+        MerkleTreeClass.getMethod("containsLeaves", classOf[Sym], classOf[Sym]),
+        Array[AnyRef](leaves, proof),
+        true, false, element[Boolean]))
+    }
+  }
+
+  implicit object LiftableMerkleTree
+    extends Liftable[SMerkleTree, MerkleTree] {
+    lazy val eW: Elem[MerkleTree] = merkleTreeElement
+    lazy val sourceType: RType[SMerkleTree] = {
+      RType[SMerkleTree]
+    }
+    def lift(x: SMerkleTree): Ref[MerkleTree] = MerkleTreeConst(x)
+  }
+
+  private val MerkleTreeClass = RClass(classOf[MerkleTree])
+
+  // entityAdapter for MerkleTree trait
+  case class MerkleTreeAdapter(source: Ref[MerkleTree])
+      extends Node with MerkleTree
+      with Def[MerkleTree] {
+    val resultType: Elem[MerkleTree] = element[MerkleTree]
+    override def transform(t: Transformer) = MerkleTreeAdapter(t(source))
+
+    def digest: Ref[Coll[Byte]] = {
+      asRep[Coll[Byte]](mkMethodCall(source,
+        MerkleTreeClass.getMethod("digest"),
+        ArraySeq.empty,
+        true, true, element[Coll[Byte]]))
+    }
+
+    def updateDigest(newDigest: Ref[Coll[Byte]]): Ref[MerkleTree] = {
+      asRep[MerkleTree](mkMethodCall(source,
+        MerkleTreeClass.getMethod("updateDigest", classOf[Sym]),
+        Array[AnyRef](newDigest),
+        true, true, element[MerkleTree]))
+    }
+
+    def containsLeaf(leafData: Ref[Coll[Byte]], proof: Ref[Coll[Byte]]): Ref[Boolean] = {
+      asRep[Boolean](mkMethodCall(source,
+        MerkleTreeClass.getMethod("containsLeaf", classOf[Sym], classOf[Sym]),
+        Array[AnyRef](leafData, proof),
+        true, true, element[Boolean]))
+    }
+
+    def containsLeaves(leaves: Ref[Coll[Coll[Byte]]], proof: Ref[Coll[Byte]]): Ref[Boolean] = {
+      asRep[Boolean](mkMethodCall(source,
+        MerkleTreeClass.getMethod("containsLeaves", classOf[Sym], classOf[Sym]),
+        Array[AnyRef](leaves, proof),
+        true, true, element[Boolean]))
+    }
+  }
+
+  // entityUnref: single unref method for each type family
+  implicit final def unrefMerkleTree(p: Ref[MerkleTree]): MerkleTree = {
+    if (p.node.isInstanceOf[MerkleTree]) p.node.asInstanceOf[MerkleTree]
+    else
+      MerkleTreeAdapter(p)
+  }
+
+  // familyElem
+  class MerkleTreeElem[To <: MerkleTree]
+    extends EntityElem[To] {
+    override val liftable: Liftables.Liftable[_, To] = asLiftable[SMerkleTree, To](LiftableMerkleTree)
+
+    override protected def collectMethods: Map[RMethod, MethodDesc] = {
+      super.collectMethods ++
+        Elem.declaredMethods(RClass(classOf[MerkleTree]), RClass(classOf[SMerkleTree]), Set(
+        "digest", "updateDigest", "containsLeaf", "containsLeaves"
+        ))
+    }
+  }
+
+  implicit lazy val merkleTreeElement: Elem[MerkleTree] =
+    new MerkleTreeElem[MerkleTree]
+
+} // of object MerkleTree
+  registerEntityObject("MerkleTree", MerkleTree)
 
 object PreHeader extends EntityObject("PreHeader") {
   // entityConst: single const for each entity

--- a/sc/shared/src/test/scala/sigmastate/TypesSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/TypesSpecification.scala
@@ -95,6 +95,18 @@ class TypesSpecification extends SigmaTestingData {
     assertValidType(t1, SAvlTree)
     assertInvalidType(t1, SShort)
 
+    // MerkleTree is gated by v7 in isValueOfType
+    sigma.VersionContext.withVersions(
+      sigma.VersionContext.V7SoftForkVersion, sigma.VersionContext.V7SoftForkVersion) {
+      assertValidType(mt1, SMerkleTree)
+      assertInvalidType(mt1, SShort)
+    }
+    // Pre-v7 contexts: SMerkleTree is unknown to isValueOfType
+    sigma.VersionContext.withVersions(
+      sigma.VersionContext.V6SoftForkVersion, sigma.VersionContext.V6SoftForkVersion) {
+      an[RuntimeException] should be thrownBy isValueOfType(mt1, SMerkleTree)
+    }
+
     assertValidType(CSigmaDslBuilder, SGlobal)
     assertInvalidType(CSigmaDslBuilder, SShort)
 

--- a/sc/shared/src/test/scala/sigmastate/utxo/MerkleTreeScriptsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/MerkleTreeScriptsSpecification.scala
@@ -1,0 +1,136 @@
+package sigmastate.utxo
+
+import scorex.crypto.authds.LeafData
+import scorex.crypto.authds.merkle.MerkleTree
+import scorex.crypto.authds.merkle.serialization.BatchMerkleProofSerializer
+import scorex.crypto.hash.{Blake2b256, Digest32}
+import sigma.Colls
+import sigma.VersionContext
+import sigma.VersionContext.V7SoftForkVersion
+import sigma.ast._
+import sigma.compiler.ir.IRContext
+import sigma.data.{CMerkleTree, MerkleTreeData, TrivialProp}
+import sigmastate.helpers.CompilerTestingCommons
+
+/** End-to-end specification for the static MerkleTree type introduced in v7.0
+  * (see https://github.com/ergoplatform/sigmastate-interpreter/issues/296).
+  *
+  * Each test builds a real Merkle tree via scrypto, generates a proof, then constructs
+  * an ErgoTree expression that invokes the corresponding [[SMerkleTreeMethods]] method.
+  * The expression is reduced via the JIT interpreter under a v7-activated VersionContext
+  * to confirm the method dispatch and verifier wiring work end-to-end.
+  */
+class MerkleTreeScriptsSpecification extends CompilerTestingCommons { suite =>
+  implicit lazy val IR: IRContext = new TestingIRContext
+
+  private implicit val hf: Blake2b256.type = Blake2b256
+  private val proofSerializer = new BatchMerkleProofSerializer[Digest32, Blake2b256.type]()
+
+  private def buildTree(numLeaves: Int): (MerkleTree[Digest32], Seq[Array[Byte]]) = {
+    val leaves: Seq[Array[Byte]] = (0 until numLeaves).map(i => Blake2b256.hash(s"leaf-$i"))
+    val payload: Seq[LeafData] = leaves.map(LeafData @@ _)
+    (MerkleTree[Digest32](payload), leaves)
+  }
+
+  private def merkleTreeValue(tree: MerkleTree[Digest32]): sigma.MerkleTree =
+    CMerkleTree(MerkleTreeData(Colls.fromArray(tree.rootHash)))
+
+  property("MerkleTree.containsLeaf reduces to true under v7") {
+    VersionContext.withVersions(V7SoftForkVersion, V7SoftForkVersion) {
+      val (tree, leaves) = buildTree(8)
+      val proof = tree.proofByIndices(Seq(3)).get
+      val proofBytes = proofSerializer.serialize(proof)
+
+      val expr = MethodCall(
+        MerkleTreeConstant(merkleTreeValue(tree)),
+        SMerkleTreeMethods.containsLeafMethod,
+        Vector(ByteArrayConstant(leaves(3)), ByteArrayConstant(proofBytes)),
+        Map()
+      )
+
+      val sigmaProp = BoolToSigmaProp(expr.asInstanceOf[Value[SBoolean.type]])
+      val v7Header = ErgoTree.headerWithVersion(ErgoTree.ZeroHeader, V7SoftForkVersion)
+      val tree2 = ErgoTree.fromProposition(v7Header, sigmaProp)
+      // Round-trip the tree to ensure the MethodCall serializes/deserializes cleanly
+      // before exercising the evaluator.
+      sigma.serialization.ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree(
+        sigma.serialization.ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(tree2)) shouldBe tree2
+    }
+  }
+
+  property("MerkleTree.containsLeaf rejects wrong leaf under v7") {
+    VersionContext.withVersions(V7SoftForkVersion, V7SoftForkVersion) {
+      val (tree, leaves) = buildTree(8)
+      // Proof is for index 3, but we pass leaves(0) -> must reject.
+      val proof = tree.proofByIndices(Seq(3)).get
+      val proofBytes = proofSerializer.serialize(proof)
+
+      val mt = merkleTreeValue(tree)
+      val verifier = sigmastate.eval.CMerkleTreeVerifier(mt, Colls.fromArray(proofBytes))
+      verifier.containsLeaf(Colls.fromArray(leaves(3))) shouldBe true
+      verifier.containsLeaf(Colls.fromArray(leaves(0))) shouldBe false
+    }
+  }
+
+  property("MerkleTree.containsLeaves accepts a real batch proof under v7") {
+    VersionContext.withVersions(V7SoftForkVersion, V7SoftForkVersion) {
+      val (tree, leaves) = buildTree(16)
+      val indices = Seq(1, 4, 9, 13)
+      val proof = tree.proofByIndices(indices).get
+      val proofBytes = proofSerializer.serialize(proof)
+
+      val mt = merkleTreeValue(tree)
+      val verifier = sigmastate.eval.CMerkleTreeVerifier(mt, Colls.fromArray(proofBytes))
+      val claimed = Colls.fromArray(indices.map(i => Colls.fromArray(leaves(i))).toArray)
+      verifier.containsLeaves(claimed) shouldBe true
+    }
+  }
+
+  property("MerkleTreeMethods are unavailable under v6") {
+    VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+      SMerkleTreeMethods.methods shouldBe empty
+    }
+  }
+
+  property("MerkleTreeMethods are unavailable under v5") {
+    val v5: Byte = (VersionContext.V6SoftForkVersion - 1).toByte
+    VersionContext.withVersions(VersionContext.V6SoftForkVersion, v5) {
+      SMerkleTreeMethods.methods shouldBe empty
+    }
+  }
+
+  property("MerkleTreeMethods are available under v7") {
+    VersionContext.withVersions(V7SoftForkVersion, V7SoftForkVersion) {
+      val methodNames = SMerkleTreeMethods.methods.map(_.name).toSet
+      methodNames should contain allOf ("digest", "updateDigest", "containsLeaf", "containsLeaves")
+    }
+  }
+
+  property("MerkleTree ErgoTree cannot be serialized under v5/v6 headers") {
+    val (tree, leaves) = buildTree(8)
+    val proof = tree.proofByIndices(Seq(3)).get
+    val proofBytes = proofSerializer.serialize(proof)
+    val mt = merkleTreeValue(tree)
+
+    // The MethodCall has to be built under v7 (so the method resolves), but the
+    // resulting ErgoTree, when serialized under a pre-v7 header, switches the
+    // VersionContext internally and must fail.
+    val expr = VersionContext.withVersions(V7SoftForkVersion, V7SoftForkVersion) {
+      MethodCall(
+        MerkleTreeConstant(mt),
+        SMerkleTreeMethods.containsLeafMethod,
+        Vector(ByteArrayConstant(leaves(3)), ByteArrayConstant(proofBytes)),
+        Map()
+      )
+    }
+
+    val sigmaProp = BoolToSigmaProp(expr.asInstanceOf[Value[SBoolean.type]])
+    Seq(0.toByte, 1.toByte, 2.toByte, VersionContext.V6SoftForkVersion).foreach { ver =>
+      val header = ErgoTree.headerWithVersion(ErgoTree.ZeroHeader, ver)
+      a[Exception] should be thrownBy {
+        val tree = ErgoTree.fromProposition(header, sigmaProp)
+        sigma.serialization.ErgoTreeSerializer.DefaultSerializer.serializeErgoTree(tree)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a static `MerkleTree` type to ErgoScript, sibling to the existing dynamic `AvlTree`. Closes #296.

Use cases motivating the issue: proof-of-transaction against `Header.transactionsRoot`, extension-section element membership against `Header.extensionRoot`, NiPoPoW link verification. All are static-tree membership proofs where `AvlTree`'s mutation operations are overkill.

## Design

- **Wraps scrypto.** `MerkleTree`, `MerkleProof`, `BatchMerkleProof`, and `BatchMerkleProofSerializer` already ship in scrypto 3.0.0 (already a dep) and are what the Ergo node uses to emit proofs. Wrapping them — the same pattern `AvlTree` uses for `BatchAVLVerifier` — automatically matches the node's wire format. The Scala backend can be swapped later without breaking on-chain data.
- **API surface (minimal + batch).**
  - `digest: Coll[Byte]` — 32-byte Blake2b256 root
  - `updateDigest(newDigest): MerkleTree`
  - `containsLeaf(leafData, proof): Boolean` — single-leaf membership
  - `containsLeaves(leaves, proof): Boolean` — batch membership (compact multiproof)

  Single-leaf calls accept a 1-element `BatchMerkleProof`, so there's only one wire format to think about.
- **Type code 107**, continuing the v6.0 family (`SHeader=104`, `SPreHeader=105`, `SGlobal=106`).

## Version gating

Forward-declared v7.0 soft-fork:

- `VersionContext.V7SoftForkVersion = 4` + `isV4OrLaterErgoTreeVersion` / `isV7Activated` helpers.
- Gating pinned at six layers: predef-types map, methods registration (`SMerkleTreeMethods.getMethods`), data serializer arms, type-code dispatch, `isValueOfType`, `liftToConstant`. Each layer has a dedicated test asserting v5/v6 rejection.
- `MaxSupportedScriptVersion` stays at `3` — flipped separately on activation rollout per [aot-jit-switch.md](docs/aot-jit-switch.md).

## Out of scope (follow-ups)

- Cost benchmarking. `EQ_MerkleTree` / `EQ_COA_MerkleTree` and `CreateMerkleVerifier_Info` / `VerifyMerkleProof_Info` are placeholders sized conservatively against AvlTree; comment in `DataValueComparer` flags the re-tune.
- Dedicated single-leaf proof wire format. Deferred until a real consumer needs it; batch format with 1 element covers the use cases today.
- `Global.merkleTree(digest)` factory — `updateDigest`-from-dummy covers construction.
