### PR TITLE
scalameter benchmarks for serializers

### DIFF
--- a/sc/jvm/src/test/scala/sigmastate/serialization/ConstantSerializationBenchmarks.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/ConstantSerializationBenchmarks.scala
@@ -1,0 +1,137 @@
+package sigmastate.serialization
+
+import debox.cfor
+import org.scalameter.api._
+import org.scalameter.picklers.Implicits._
+import sigma.Colls
+import sigma.ast.{BigIntConstant, Constant, ConstantPlaceholder, DeserializationSigmaBuilder, GroupElementConstant, IntArrayConstant, IntConstant, LongConstant, SInt, SType, StdSigmaBuilder}
+import sigma.crypto.CryptoConstants
+import sigma.serialization.{ConstantPlaceholderSerializer, ConstantSerializer, ConstantStore, SigmaSerializer}
+
+/** Benchmarks for `ConstantSerializer` and `ConstantPlaceholderSerializer`.
+  *
+  * Run with:
+  * {{{
+  * sbt --client -batch -no-colors -mem 8192 \
+  *   "scJVM/Test/runMain sigmastate.serialization.ConstantSerializationBenchmarks"
+  * }}}
+  *
+  * `ConstantSerializer` writes a type tag followed by `DataSerializer` output;
+  * benchmarking it independently exposes regressions in the type-tag path
+  * specifically. `ConstantPlaceholderSerializer` is the segregated-constants
+  * counterpart — its deserialize path hits the reader's `ConstantStore`.
+  *
+  * Baseline (Apple M1 Pro, OpenJDK 11):
+  *
+  *   ConstantSerializer.serialize     deserialize
+  *     SInt          0.0013 ms          0.0030 ms
+  *     SLong         0.0018 ms          0.0037 ms
+  *     SBigInt       0.0032 ms          0.0049 ms
+  *     SGroupElement 0.0054 ms          0.0260 ms
+  *     Coll[Int]   10   0.0029 ms       0.0059 ms
+  *     Coll[Int]  100   0.0036 ms       0.0077 ms
+  *     Coll[Int] 1000   0.0152 ms       0.0233 ms
+  *     Coll[Int]10000   0.1388 ms       0.1983 ms
+  *
+  *   ConstantPlaceholderSerializer.serialize: ~0.00083 ms (constant across ids)
+  *   ConstantPlaceholderSerializer.parse:     ~0.0025 ms  (constant across ids)
+  */
+object ConstantSerializationBenchmarks extends Bench.LocalTime { suite: Bench[Double] =>
+
+  private val constSer = ConstantSerializer(StdSigmaBuilder)
+  private val placeholderSer = ConstantPlaceholderSerializer(DeserializationSigmaBuilder.mkConstantPlaceholder)
+
+  // ---- single-value Constants of various SType ----
+  private val intConst: Constant[SType]      = IntConstant(42).asInstanceOf[Constant[SType]]
+  private val longConst: Constant[SType]     = LongConstant(1234567890123456789L).asInstanceOf[Constant[SType]]
+  private val bigIntConst: Constant[SType]   = BigIntConstant(new java.math.BigInteger("1234567890123456789")).asInstanceOf[Constant[SType]]
+  private val groupElemConst: Constant[SType] = GroupElementConstant(CryptoConstants.dlogGroup.generator).asInstanceOf[Constant[SType]]
+
+  // ---- collection Constants of growing size ----
+  private val intCollSizes: Gen[Int] = Gen.exponential("size")(10, 10000, 10)
+  private val intCollConstants: Gen[Constant[SType]] = intCollSizes.map { size =>
+    val arr = new Array[Int](size)
+    cfor(0)(_ < size, _ + 1) { i => arr(i) = i }
+    IntArrayConstant(Colls.fromArray(arr)).asInstanceOf[Constant[SType]]
+  }
+
+  private def writeConstant(c: Constant[SType]): Array[Byte] = {
+    val w = SigmaSerializer.startWriter()
+    constSer.serialize(c, w)
+    w.toBytes
+  }
+
+  private val intConstBytes: Array[Byte] = writeConstant(intConst)
+  private val longConstBytes: Array[Byte] = writeConstant(longConst)
+  private val bigIntConstBytes: Array[Byte] = writeConstant(bigIntConst)
+  private val groupElemConstBytes: Array[Byte] = writeConstant(groupElemConst)
+  private val intCollConstBytesGen: Gen[Array[Byte]] = intCollConstants.map(writeConstant)
+
+  // ---- ConstantPlaceholder ids: a spread of UInt-VLQ encoding widths ----
+  private val placeholderIds: Gen[Int] = Gen.enumeration("id")(0, 127, 16384, 268435456)
+  // Populated constant store for deserialize-side measure
+  private val populatedStore = new ConstantStore(
+    IndexedSeq.tabulate(128)(i => IntConstant(i).asInstanceOf[Constant[SType]])
+  )
+  private val placeholderDeserIds: Gen[Int] = Gen.enumeration("id")(0, 1, 64, 127)
+
+  private val once: Gen[Unit] = Gen.unit("once")
+
+  performance of "ConstantSerializer.serialize" in {
+    measure method "SInt" in {
+      using(once) in { _ => writeConstant(intConst) }
+    }
+    measure method "SLong" in {
+      using(once) in { _ => writeConstant(longConst) }
+    }
+    measure method "SBigInt" in {
+      using(once) in { _ => writeConstant(bigIntConst) }
+    }
+    measure method "SGroupElement" in {
+      using(once) in { _ => writeConstant(groupElemConst) }
+    }
+    measure method "Coll[Int]" in {
+      using(intCollConstants) in { c => writeConstant(c) }
+    }
+  }
+
+  performance of "ConstantSerializer.deserialize" in {
+    measure method "SInt" in {
+      using(once) in { _ => constSer.deserialize(SigmaSerializer.startReader(intConstBytes)) }
+    }
+    measure method "SLong" in {
+      using(once) in { _ => constSer.deserialize(SigmaSerializer.startReader(longConstBytes)) }
+    }
+    measure method "SBigInt" in {
+      using(once) in { _ => constSer.deserialize(SigmaSerializer.startReader(bigIntConstBytes)) }
+    }
+    measure method "SGroupElement" in {
+      using(once) in { _ => constSer.deserialize(SigmaSerializer.startReader(groupElemConstBytes)) }
+    }
+    measure method "Coll[Int]" in {
+      using(intCollConstBytesGen) in { bytes => constSer.deserialize(SigmaSerializer.startReader(bytes)) }
+    }
+  }
+
+  performance of "ConstantPlaceholderSerializer.serialize" in {
+    measure method "by id" in {
+      using(placeholderIds) in { id =>
+        val w = SigmaSerializer.startWriter()
+        placeholderSer.serialize(ConstantPlaceholder(id, SInt), w)
+        w.toBytes
+      }
+    }
+  }
+
+  performance of "ConstantPlaceholderSerializer.parse" in {
+    measure method "by id" in {
+      using(placeholderDeserIds) in { id =>
+        val w = SigmaSerializer.startWriter()
+        placeholderSer.serialize(ConstantPlaceholder(id, SInt), w)
+        val bytes = w.toBytes
+        val r = SigmaSerializer.startReader(bytes, populatedStore, resolvePlaceholdersToConstants = false)
+        placeholderSer.parse(r)
+      }
+    }
+  }
+}

--- a/sc/jvm/src/test/scala/sigmastate/serialization/DataSerializationBenchmarks.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/DataSerializationBenchmarks.scala
@@ -1,0 +1,106 @@
+package sigmastate.serialization
+
+import debox.cfor
+import org.scalameter.api._
+import sigma.ast._
+import sigma.crypto.CryptoConstants
+import sigma.serialization.{DataSerializer, SigmaSerializer}
+
+/** Benchmarks for `DataSerializer.serialize` / `deserialize` per `SType`.
+  *
+  * Run with:
+  * {{{
+  * sbt --client -batch -no-colors -mem 8192 \
+  *   "scJVM/Test/runMain sigmastate.serialization.DataSerializationBenchmarks"
+  * }}}
+  *
+  * Each measurement serializes (or deserializes) a typed value once per
+  * iteration. `Coll[Byte]` is parameterized by length to expose any
+  * non-linearity in byte-array (de)serialization. Values are constructed
+  * through typed `Constant` factories and threaded through `DataSerializer`
+  * via `c.value` / `c.tpe` to keep the existential `S#WrappedType`
+  * relationship intact for type inference.
+  *
+  * Baseline (Apple M1 Pro, OpenJDK 11):
+  *
+  *  `serialize`:                          `deserialize`:
+  *    SInt              0.0025 ms          SInt              0.0035 ms
+  *    SLong             0.0026 ms          SLong             0.0037 ms
+  *    SBigInt           0.0040 ms          SBigInt           0.0041 ms
+  *    SGroupElement     0.0056 ms          SGroupElement     0.0230 ms
+  *    Coll[Byte] 16     0.0035 ms          Coll[Byte] 16     0.0032 ms
+  *    Coll[Byte] 256    0.0029 ms          Coll[Byte] 256    0.0033 ms
+  *    Coll[Byte] 4096   0.0037 ms          Coll[Byte] 4096   0.0035 ms
+  *    Coll[Byte] 16384  0.0043 ms          Coll[Byte] 16384  0.0055 ms
+  */
+object DataSerializationBenchmarks extends Bench.LocalTime { suite: Bench[Double] =>
+
+  // ---- fixed-shape Constants per SType ----
+  private val intConst: Constant[SType]    = IntConstant(42).asInstanceOf[Constant[SType]]
+  private val longConst: Constant[SType]   = LongConstant(1234567890123456789L).asInstanceOf[Constant[SType]]
+  private val bigIntConst: Constant[SType] = BigIntConstant(new java.math.BigInteger("1234567890123456789")).asInstanceOf[Constant[SType]]
+  private val groupElemConst: Constant[SType] = GroupElementConstant(CryptoConstants.dlogGroup.generator).asInstanceOf[Constant[SType]]
+
+  // ---- collection sizes ----
+  private val byteCollSizes: Gen[Int] = Gen.exponential("size")(16, 16384, 4)
+  private val byteCollConstants: Gen[Constant[SType]] = byteCollSizes.map { size =>
+    val arr = new Array[Byte](size)
+    cfor(0)(_ < size, _ + 1) { i => arr(i) = (i & 0xFF).toByte }
+    ByteArrayConstant(arr).asInstanceOf[Constant[SType]]
+  }
+
+  // ---- helpers ----
+  private def writeConst(c: Constant[SType]): Array[Byte] = {
+    val w = SigmaSerializer.startWriter()
+    DataSerializer.serialize(c.value, c.tpe, w)
+    w.toBytes
+  }
+
+  private def readType(tpe: SType, bytes: Array[Byte]): Any =
+    DataSerializer.deserialize(tpe, SigmaSerializer.startReader(bytes))
+
+  // ---- pre-serialized bytes for deserialize side ----
+  private val intBytes: Array[Byte]        = writeConst(intConst)
+  private val longBytes: Array[Byte]       = writeConst(longConst)
+  private val bigIntBytes: Array[Byte]     = writeConst(bigIntConst)
+  private val groupElemBytes: Array[Byte]  = writeConst(groupElemConst)
+  private val byteCollBytesGen: Gen[Array[Byte]] = byteCollConstants.map(writeConst)
+
+  private val once: Gen[Unit] = Gen.unit("once")
+
+  performance of "DataSerializer.serialize" in {
+    measure method "SInt" in {
+      using(once) in { _ => writeConst(intConst) }
+    }
+    measure method "SLong" in {
+      using(once) in { _ => writeConst(longConst) }
+    }
+    measure method "SBigInt" in {
+      using(once) in { _ => writeConst(bigIntConst) }
+    }
+    measure method "SGroupElement" in {
+      using(once) in { _ => writeConst(groupElemConst) }
+    }
+    measure method "Coll[Byte]" in {
+      using(byteCollConstants) in { c => writeConst(c) }
+    }
+  }
+
+  performance of "DataSerializer.deserialize" in {
+    measure method "SInt" in {
+      using(once) in { _ => readType(SInt, intBytes) }
+    }
+    measure method "SLong" in {
+      using(once) in { _ => readType(SLong, longBytes) }
+    }
+    measure method "SBigInt" in {
+      using(once) in { _ => readType(SBigInt, bigIntBytes) }
+    }
+    measure method "SGroupElement" in {
+      using(once) in { _ => readType(SGroupElement, groupElemBytes) }
+    }
+    measure method "Coll[Byte]" in {
+      using(byteCollBytesGen) in { bytes => readType(SCollection(SByte), bytes) }
+    }
+  }
+}

--- a/sc/jvm/src/test/scala/sigmastate/serialization/ErgoTreeSerializationBenchmarks.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/ErgoTreeSerializationBenchmarks.scala
@@ -1,0 +1,92 @@
+package sigmastate.serialization
+
+import org.scalameter.api._
+import sigma.serialization.ErgoTreeSerializer
+
+/** Benchmarks for top-level `ErgoTreeSerializer` round-trips.
+  *
+  * Run with:
+  * {{{
+  * sbt --client -batch -no-colors -mem 8192 \
+  *   "scJVM/Test/runMain sigmastate.serialization.ErgoTreeSerializationBenchmarks"
+  * }}}
+  *
+  * Targets:
+  *   - `ErgoTreeSerializer.DefaultSerializer.serializeErgoTree`
+  *   - `ErgoTreeSerializer.DefaultSerializer.deserializeErgoTree`
+  *
+  * Sample shapes:
+  *   - Deep nested `ArithOp(+)` chain wrapped in `EQ` + `BoolToSigmaProp`
+  *   - Deep right-associated `AND` chain
+  *   - `Coll[Int]` constant of growing size (capped at 500 to stay below
+  *     `SigmaConstants.MaxPropositionBytes`)
+  *   - Real v3 ErgoTree hex sample (with upcast)
+  *
+  * Baseline (Apple M1 Pro, OpenJDK 11):
+  *
+  *   serializeErgoTree            5    15    45
+  *     ArithOp(+) chain        0.003 0.003 0.006 ms
+  *     AND chain               0.006 0.012 0.027 ms
+  *
+  *   serializeErgoTree           10   100   500
+  *     Coll[Int] constant      0.003 0.008 0.029 ms
+  *
+  *   deserializeErgoTree          5    15    45
+  *     ArithOp(+) chain        0.031 0.016 0.038 ms
+  *     AND chain               0.013 0.021 0.046 ms
+  *
+  *   deserializeErgoTree         10   100   500
+  *     Coll[Int] constant      0.010 0.037 0.144 ms
+  *
+  *   deserializeErgoTree v3 hex sample:               0.076 ms
+  *
+  *   roundTrip                    5    15    45
+  *     ArithOp(+) chain        0.006 0.011 0.031 ms
+  *
+  *   roundTrip                   10   100   500
+  *     Coll[Int] constant      0.007 0.023 0.099 ms
+  */
+object ErgoTreeSerializationBenchmarks extends Bench.LocalTime with SerializationBenchmarkGens { suite: Bench[Double] =>
+
+  private val ser = ErgoTreeSerializer.DefaultSerializer
+
+  performance of "ErgoTreeSerializer.serializeErgoTree" in {
+    measure method "ArithOp(+) chain" in {
+      using(arithOpTrees) in { tree => ser.serializeErgoTree(tree) }
+    }
+    measure method "AND chain" in {
+      using(logicalAndTrees) in { tree => ser.serializeErgoTree(tree) }
+    }
+    measure method "Coll[Int] constant" in {
+      using(collIntTrees) in { tree => ser.serializeErgoTree(tree) }
+    }
+  }
+
+  performance of "ErgoTreeSerializer.deserializeErgoTree" in {
+    measure method "ArithOp(+) chain" in {
+      using(arithOpTreeBytes) in { bytes => ser.deserializeErgoTree(bytes) }
+    }
+    measure method "AND chain" in {
+      using(logicalAndTreeBytes) in { bytes => ser.deserializeErgoTree(bytes) }
+    }
+    measure method "Coll[Int] constant" in {
+      using(collIntTreeBytes) in { bytes => ser.deserializeErgoTree(bytes) }
+    }
+    measure method "v3 hex sample" in {
+      using(Gen.unit("v3-sample")) in { _ => ser.deserializeErgoTree(v3SampleBytes) }
+    }
+  }
+
+  performance of "ErgoTreeSerializer.roundTrip" in {
+    measure method "ArithOp(+) chain" in {
+      using(arithOpTrees) in { tree =>
+        ser.deserializeErgoTree(ser.serializeErgoTree(tree))
+      }
+    }
+    measure method "Coll[Int] constant" in {
+      using(collIntTrees) in { tree =>
+        ser.deserializeErgoTree(ser.serializeErgoTree(tree))
+      }
+    }
+  }
+}

--- a/sc/jvm/src/test/scala/sigmastate/serialization/MethodCallSerializationBenchmarks.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/MethodCallSerializationBenchmarks.scala
@@ -1,0 +1,150 @@
+package sigmastate.serialization
+
+import org.scalameter.api._
+import sigma.VersionContext
+import sigma.ast.SCollection.SByteArray
+import sigma.ast._
+import sigma.serialization.{MethodCallSerializer, PropertyCallSerializer, SigmaSerializer}
+
+/** Benchmarks for `MethodCallSerializer` (non-empty args) and
+  * `PropertyCallSerializer` (zero args).
+  *
+  * Run with:
+  * {{{
+  * sbt --client -batch -no-colors -mem 8192 \
+  *   "scJVM/Test/runMain sigmastate.serialization.MethodCallSerializationBenchmarks"
+  * }}}
+  *
+  * MethodCall serialization requires V3+ ErgoTree version to enforce the
+  * non-empty args invariant on deserialize, so the benchmark runs under
+  * `VersionContext.V6SoftForkVersion`.
+  *
+  * Baseline (Apple M1 Pro, OpenJDK 11):
+  *
+  *   PropertyCallSerializer.serialize Outputs.size           0.0040 ms
+  *   PropertyCallSerializer.parse     Outputs.size           0.0403 ms
+  *   MethodCallSerializer.serialize   Outputs.flatMap        0.0160 ms
+  *   MethodCallSerializer.serialize   Global.serialize       0.0114 ms
+  *   MethodCallSerializer.parse       Outputs.flatMap        0.1072 ms
+  *   MethodCallSerializer.parse       Global.serialize       0.0485 ms
+  *
+  * `parse` is significantly slower than `serialize` because
+  * `SMethod.fromIds` + `specializeFor` chase the method registry on every call.
+  */
+object MethodCallSerializationBenchmarks extends Bench.LocalTime { suite: Bench[Double] =>
+
+  private val mcSer = MethodCallSerializer(DeserializationSigmaBuilder.mkMethodCall)
+  private val pcSer = PropertyCallSerializer(DeserializationSigmaBuilder.mkMethodCall)
+
+  // ---- fixture method calls ----
+
+  // PropertyCall (no args): Outputs.size
+  private val sizeCall: MethodCall = MethodCall(
+    Outputs,
+    SCollectionMethods.SizeMethod.withConcreteTypes(Map(SCollection.tIV -> SBox)),
+    Vector.empty,
+    Map.empty
+  )
+
+  // MethodCall (1 function arg): Outputs.flatMap(b => b.scriptBytes)
+  private val flatMapCall: MethodCall = MethodCall(
+    Outputs,
+    SCollectionMethods.FlatMapMethod.withConcreteTypes(
+      Map(SCollection.tIV -> SBox, SCollection.tOV -> SByte)
+    ),
+    Vector(FuncValue(1, SBox, ExtractScriptBytes(ValUse(1, SBox)))),
+    Map.empty
+  )
+
+  // MethodCall (1 explicit-type arg): Global.serialize[Coll[Byte]](bytes)
+  private val serializeCall: MethodCall = MethodCall(
+    Global,
+    SGlobalMethods.serializeMethod.withConcreteTypes(Map(SType.tT -> SByteArray)),
+    Vector(ByteArrayConstant(Array[Byte](1, 2, 3))),
+    Map.empty
+  )
+
+  // Pre-serialized byte buffers (under V6 context, since some methods are V6-only)
+  private val sizeCallBytes: Array[Byte] = VersionContext.withVersions(
+    VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion
+  ) {
+    val w = SigmaSerializer.startWriter()
+    pcSer.serialize(sizeCall, w)
+    w.toBytes
+  }
+
+  private val flatMapCallBytes: Array[Byte] = VersionContext.withVersions(
+    VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion
+  ) {
+    val w = SigmaSerializer.startWriter()
+    mcSer.serialize(flatMapCall, w)
+    w.toBytes
+  }
+
+  private val serializeCallBytes: Array[Byte] = VersionContext.withVersions(
+    VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion
+  ) {
+    val w = SigmaSerializer.startWriter()
+    mcSer.serialize(serializeCall, w)
+    w.toBytes
+  }
+
+  private val once: Gen[Unit] = Gen.unit("once")
+
+  private def underV6[A](block: => A): A =
+    VersionContext.withVersions(VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion)(block)
+
+  performance of "PropertyCallSerializer.serialize" in {
+    measure method "Outputs.size" in {
+      using(once) in { _ =>
+        underV6 {
+          val w = SigmaSerializer.startWriter()
+          pcSer.serialize(sizeCall, w)
+          w.toBytes
+        }
+      }
+    }
+  }
+
+  performance of "PropertyCallSerializer.parse" in {
+    measure method "Outputs.size" in {
+      using(once) in { _ =>
+        underV6 { pcSer.parse(SigmaSerializer.startReader(sizeCallBytes)) }
+      }
+    }
+  }
+
+  performance of "MethodCallSerializer.serialize" in {
+    measure method "Outputs.flatMap (1 func arg)" in {
+      using(once) in { _ =>
+        underV6 {
+          val w = SigmaSerializer.startWriter()
+          mcSer.serialize(flatMapCall, w)
+          w.toBytes
+        }
+      }
+    }
+    measure method "Global.serialize (1 explicit type arg)" in {
+      using(once) in { _ =>
+        underV6 {
+          val w = SigmaSerializer.startWriter()
+          mcSer.serialize(serializeCall, w)
+          w.toBytes
+        }
+      }
+    }
+  }
+
+  performance of "MethodCallSerializer.parse" in {
+    measure method "Outputs.flatMap" in {
+      using(once) in { _ =>
+        underV6 { mcSer.parse(SigmaSerializer.startReader(flatMapCallBytes)) }
+      }
+    }
+    measure method "Global.serialize" in {
+      using(once) in { _ =>
+        underV6 { mcSer.parse(SigmaSerializer.startReader(serializeCallBytes)) }
+      }
+    }
+  }
+}

--- a/sc/jvm/src/test/scala/sigmastate/serialization/SerializationBenchmarkGens.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/SerializationBenchmarkGens.scala
@@ -1,0 +1,81 @@
+package sigmastate.serialization
+
+import debox.cfor
+import org.scalameter.api._
+import org.scalameter.picklers.Implicits._
+import scorex.util.encode.Base16
+import sigma.ast.ErgoTree.ZeroHeader
+import sigma.ast._
+import sigma.serialization.ErgoTreeSerializer
+import sigma.serialization.OpCodes.PlusCode
+
+/** Generators and pre-built fixtures shared by the serialization benchmark suites.
+  *
+  * The benchmarks intentionally split two size ranges:
+  *
+  *   - `treeDepths`  — small, for nested AST structures where depth grows the tree
+  *                     non-linearly (ArithOp, logical AND). Capped well below
+  *                     `SigmaConstants.MaxTreeDepth`.
+  *   - `collSizes`   — larger, for flat structures (Coll[Int]) where size is the
+  *                     count of leaf items.
+  *
+  * Trees and their serialized byte forms are built once per size by Scalameter's
+  * lazy `Gen` machinery; the closure passed to `using(...) in { ... }` runs many
+  * times per measurement and should NOT rebuild fixtures inside.
+  */
+trait SerializationBenchmarkGens { suite: Bench[Double] =>
+
+  /** Exponential depths for nested AST benchmarks: 5, 15, 45. Stays below
+    * default tree depth limit even after wrapping in `BoolToSigmaProp(EQ(...))`. */
+  val treeDepths: Gen[Int] = Gen.exponential("depth")(5, 45, 3)
+
+  /** Collection sizes that keep the resulting `ErgoTree` below
+    * `SigmaConstants.MaxPropositionBytes` (4096) once serialized — each
+    * `IntConstant` may use up to 5 bytes of VLQ encoding plus per-item overhead. */
+  val collSizes: Gen[Int] = Gen.enumeration("size")(10, 100, 500)
+
+  /** A real v3 ErgoTree hex sample (with upcast) used by the spec tests. Small,
+    * deterministic, and tied to a concrete on-chain shape. */
+  val v3SampleHex: String = "0b15ea02e4dc650cfe020300020008b20e020102020100"
+  val v3SampleBytes: Array[Byte] = Base16.decode(v3SampleHex).get
+
+  /** ErgoTree wrapping a deeply nested `ArithOp(+)` chain of `IntConstant`s,
+    * compared for equality so the result type is `SigmaProp`. */
+  def buildArithOpTree(depth: Int): ErgoTree = {
+    var expr: Value[SInt.type] = IntConstant(0)
+    cfor(0)(_ < depth, _ + 1) { i =>
+      expr = ArithOp(expr, IntConstant(i), PlusCode)
+    }
+    val prop = BoolToSigmaProp(EQ(expr, IntConstant(depth)))
+    ErgoTree.withSegregation(ZeroHeader, prop)
+  }
+
+  /** ErgoTree wrapping a deep nested `AND` of pairwise booleans. */
+  def buildLogicalAndTree(depth: Int): ErgoTree = {
+    var expr: Value[SBoolean.type] = TrueLeaf
+    cfor(0)(_ < depth, _ + 1) { _ =>
+      expr = AND(ConcreteCollection(IndexedSeq(expr, TrueLeaf), SBoolean))
+    }
+    ErgoTree.withSegregation(ZeroHeader, BoolToSigmaProp(expr))
+  }
+
+  /** ErgoTree carrying a single `Coll[Int]` constant of the requested length. */
+  def buildCollIntTree(size: Int): ErgoTree = {
+    val items = new Array[Value[SInt.type]](size)
+    cfor(0)(_ < size, _ + 1) { i => items(i) = IntConstant(i) }
+    val coll = ConcreteCollection(items.toIndexedSeq, SInt)
+    val prop = BoolToSigmaProp(EQ(SizeOf(coll), IntConstant(size)))
+    ErgoTree.withSegregation(ZeroHeader, prop)
+  }
+
+  val arithOpTrees: Gen[ErgoTree] = treeDepths.map(buildArithOpTree)
+  val logicalAndTrees: Gen[ErgoTree] = treeDepths.map(buildLogicalAndTree)
+  val collIntTrees: Gen[ErgoTree] = collSizes.map(buildCollIntTree)
+
+  val arithOpTreeBytes: Gen[Array[Byte]] =
+    arithOpTrees.map(ErgoTreeSerializer.DefaultSerializer.serializeErgoTree)
+  val logicalAndTreeBytes: Gen[Array[Byte]] =
+    logicalAndTrees.map(ErgoTreeSerializer.DefaultSerializer.serializeErgoTree)
+  val collIntTreeBytes: Gen[Array[Byte]] =
+    collIntTrees.map(ErgoTreeSerializer.DefaultSerializer.serializeErgoTree)
+}

--- a/sc/jvm/src/test/scala/sigmastate/serialization/TypeSerializationBenchmarks.scala
+++ b/sc/jvm/src/test/scala/sigmastate/serialization/TypeSerializationBenchmarks.scala
@@ -1,0 +1,93 @@
+package sigmastate.serialization
+
+import org.scalameter.api._
+import org.scalameter.picklers.Implicits._
+import sigma.ast._
+import sigma.serialization.{SigmaSerializer, TypeSerializer}
+
+/** Benchmarks for `TypeSerializer`.
+  *
+  * Run with:
+  * {{{
+  * sbt --client -batch -no-colors -mem 8192 \
+  *   "scJVM/Test/runMain sigmastate.serialization.TypeSerializationBenchmarks"
+  * }}}
+  *
+  * Covers the primary encoding shapes of `TypeSerializer`:
+  *   - primitive embeddable types (1-byte path)
+  *   - generics over primitives (1-byte path via type-code embedding)
+  *   - nested generics (recursive path)
+  *   - tuples (pair, triple, quadruple, n-ary)
+  *
+  * Scalameter requires a `Pickler` for the axis type, so the benchmark uses
+  * an Int index into a fixed lookup table rather than carrying tuples through
+  * the `Gen` machinery.
+  *
+  * Baseline (Apple M1 Pro, OpenJDK 11):
+  *
+  * `serialize`:                                `deserialize`:
+  *   SInt                      0.0014 ms       SInt                      0.0044 ms
+  *   SLong                     0.0012 ms       SLong                     0.0045 ms
+  *   SBoolean                  0.0013 ms       SBoolean                  0.0042 ms
+  *   SBigInt                   0.0012 ms       SBigInt                   0.0042 ms
+  *   SGroupElement             0.0012 ms       SGroupElement             0.0042 ms
+  *   SSigmaProp                0.0012 ms       SSigmaProp                0.0043 ms
+  *   Coll[Int]                 0.0018 ms       Coll[Int]                 0.0039 ms
+  *   Coll[Coll[Int]]           0.0019 ms       Coll[Coll[Int]]           0.0039 ms
+  *   Coll[Coll[Box]]           0.0016 ms       Coll[Coll[Box]]           0.0038 ms
+  *   Option[Int]               0.0015 ms       Option[Int]               0.0025 ms
+  *   Option[Coll[Byte]]        0.0015 ms       Option[Coll[Byte]]        0.0024 ms
+  *   (Int, Int)                0.0019 ms       (Int, Int)                0.0048 ms
+  *   (Int, Long)               0.0022 ms       (Int, Long)               0.0053 ms
+  *   (Int, Long, Box)          0.0027 ms       (Int, Long, Box)          0.0070 ms
+  *   (Int, Long, Box, AvlTree) 0.0020 ms       (Int, Long, Box, AvlTree) 0.0075 ms
+  *   (Int x 8)                 0.0024 ms       (Int x 8)                 0.0087 ms
+  */
+object TypeSerializationBenchmarks extends Bench.LocalTime { suite: Bench[Double] =>
+
+  // ---- representative types covering each branch of TypeSerializer ----
+  private val types: Array[(String, SType)] = Array(
+    "SInt" -> SInt,
+    "SLong" -> SLong,
+    "SBoolean" -> SBoolean,
+    "SBigInt" -> SBigInt,
+    "SGroupElement" -> SGroupElement,
+    "SSigmaProp" -> SSigmaProp,
+    "Coll[Int]" -> SCollection(SInt),
+    "Coll[Coll[Int]]" -> SCollection(SCollection(SInt)),
+    "Coll[Coll[Box]]" -> SCollection(SCollection(SBox)),
+    "Option[Int]" -> SOption(SInt),
+    "Option[Coll[Byte]]" -> SOption(SCollection(SByte)),
+    "(Int, Int)" -> STuple(SInt, SInt),
+    "(Int, Long)" -> STuple(SInt, SLong),
+    "(Int, Long, Box)" -> STuple(SInt, SLong, SBox),
+    "(Int, Long, Box, AvlTree)" -> STuple(Vector[SType](SInt, SLong, SBox, SAvlTree)),
+    "(Int x 8)" -> STuple(Vector.fill[SType](8)(SInt))
+  )
+
+  private val typeBytes: Array[Array[Byte]] = types.map { case (_, tpe) =>
+    val w = SigmaSerializer.startWriter()
+    TypeSerializer.serialize(tpe, w)
+    w.toBytes
+  }
+
+  private val typeIdx: Gen[Int] = Gen.range("typeIdx")(0, types.length - 1, 1)
+
+  performance of "TypeSerializer.serialize" in {
+    measure method "by type" in {
+      using(typeIdx) in { idx =>
+        val w = SigmaSerializer.startWriter()
+        TypeSerializer.serialize(types(idx)._2, w)
+        w.toBytes
+      }
+    }
+  }
+
+  performance of "TypeSerializer.deserialize" in {
+    measure method "by type" in {
+      using(typeIdx) in { idx =>
+        TypeSerializer.deserialize(SigmaSerializer.startReader(typeBytes(idx)))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #209.

Adds five Scalameter benchmark suites covering the consensus-critical (de)serialization paths. They are not picked up by `sbt test` (Scalameter `Bench.LocalTime` is not a ScalaTest suite), matching the issue's "not by default" requirement.

Baseline numbers (Apple M1 Pro, OpenJDK 11) are baked into each file's scaladoc so future runs have an in-tree reference.
