### PR TITLE
Skip npm snapshot publish on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
     name: JS - Test and publish snapshots
     env:
       HAS_SECRETS: ${{ secrets.SONATYPE_PASSWORD != '' }}
+      HAS_NPM_SECRETS: ${{ secrets.NPM_TOKEN != '' }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -120,11 +121,12 @@ jobs:
         working-directory: ./sigma-js
 
       - name: Setup JS snapshot
+        if: github.event_name == 'push' && env.HAS_NPM_SECRETS == 'true'
         run: npm run ci:snapshot
         working-directory: ./sigma-js
 
       - name: Publish JS snapshot ${{ github.ref }}
-        if: env.HAS_SECRETS == 'true'
+        if: github.event_name == 'push' && env.HAS_NPM_SECRETS == 'true'
         run: npm publish --tag snapshot
         working-directory: ./sigma-js
         env:


### PR DESCRIPTION
This keeps pull request CI focused on build/test validation while avoiding npm registry mutation from PR runs.

The JS build and Jest tests still run on pull requests. `npm run ci:snapshot` and `npm publish --tag snapshot` now run only on push and only when `NPM_TOKEN` is available.

This should unblock the current red JS CI on #1115, where tests pass and only the final npm publish snapshot step fails with npm 404.