### PR TITLE
Add equalBoxExcept compiler helper for box equality

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -529,6 +529,63 @@ object SigmaPredef {
         Seq(ArgInfo("id", "identifier of the register")))
     )
 
+    val EqualBoxExceptFunc = PredefinedFunc("equalBoxExcept",
+      Lambda(
+        Array("b1" -> SBox, "b2" -> SBox, "exclude" -> SCollection(SInt)),
+        SBoolean, None),
+      PredefFuncInfo({
+        case (_, Seq(
+          b1: Value[SBox.type] @unchecked,
+          b2: Value[SBox.type] @unchecked,
+          excludeArg: Value[SCollection[SInt.type]] @unchecked)) =>
+            val excludeIds: Set[Int] = excludeArg match {
+              case CollectionConstant(arr, SInt) =>
+                arr.toArray.toSet
+              case ConcreteCollection(items, SInt) =>
+                items.map {
+                  case IntConstant(v) => v
+                  case other =>
+                    throw new InvalidArguments(
+                      s"equalBoxExcept: exclude argument must be a literal Coll[Int]; got non-literal element $other")
+                }.toSet
+              case _ =>
+                throw new InvalidArguments(
+                  s"equalBoxExcept: exclude argument must be a literal Coll[Int]; got $excludeArg")
+            }
+            def keep(regId: Int)(build: => BoolValue): Option[BoolValue] =
+              if (excludeIds.contains(regId)) None else Some(build)
+            val checks: Seq[BoolValue] = Seq(
+              keep(0)(mkEQ(mkExtractAmount(b1), mkExtractAmount(b2))),
+              keep(1)(mkEQ(mkExtractScriptBytes(b1), mkExtractScriptBytes(b2))),
+              keep(2)(mkEQ(
+                mkMethodCall(b1, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty),
+                mkMethodCall(b2, SBoxMethods.tokensMethod, IndexedSeq.empty, Map.empty)))
+            ).flatten
+            checks match {
+              case Nil       => TrueLeaf
+              case h +: tail => tail.foldLeft[BoolValue](h)(mkBinAnd)
+            }
+      }),
+      OperationInfo(BinAnd,
+        """Returns true when \lst{b1} and \lst{b2} are equal on \lst{value}, \lst{propositionBytes},
+         | and \lst{tokens}, ignoring the registers listed in \lst{exclude} as well as R3
+         | (creationInfo, always implicitly excluded because its txId/outputIndex tail differs
+         | between any input box and its successor output by construction).
+         |
+         | Non-mandatory registers R4-R9 are NOT compared by this helper because they are typed
+         | and cannot be compared polymorphically without a new ErgoTree primitive. To require
+         | a specific R4-R9 register to stay equal, add the equality clause manually:
+         | \lst{equalBoxExcept(b1, b2, Coll[Int]()) && b1.R4[Long].get == b2.R4[Long].get}.
+         |
+         | The \lst{exclude} argument must be a compile-time literal \lst{Coll[Int]}; the helper
+         | expands at compile time into a conjunction of the surviving \lst{==} comparisons.
+        """.stripMargin,
+        Seq(
+          ArgInfo("b1", "first box to compare"),
+          ArgInfo("b2", "second box to compare"),
+          ArgInfo("exclude", "compile-time literal Coll[Int] of register ids (0..2) whose comparison should be skipped")))
+    )
+
     val globalFuncs: Map[String, PredefinedFunc] = Seq(
       AllOfFunc,
       AnyOfFunc,
@@ -562,7 +619,8 @@ object SigmaPredef {
       SerializeFunc,
       DeserializeToFunc,
       GetVarFromInputFunc,
-      FromBigEndianBytesFunc
+      FromBigEndianBytesFunc,
+      EqualBoxExceptFunc
     ).map(f => f.name -> f).toMap
 
     def comparisonOp(symbolName: String, opDesc: ValueCompanion, desc: String, args: Seq[ArgInfo]) = {

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -1331,6 +1331,33 @@ def executeFromSelfRegWithDefault[T](id: Int, default: T): T
   *         replaced and all other bytes remain exactly the same
   */
 def substConstants[T](scriptBytes: Coll[Byte], positions: Coll[Int], newValues: Coll[T]): Coll[Byte]
+
+/** Returns true when `b1` and `b2` are equal on the mandatory registers that
+  * this helper can compare, ignoring the register ids listed in `exclude` as
+  * well as R3 (always implicitly excluded, since the `txId + outputIndex` tail
+  * of `creationInfo` differs between any input box and its successor output by
+  * construction).
+  *
+  * Currently the helper compares only `value` (R0), `propositionBytes` (R1) and
+  * `tokens` (R2). The non-mandatory registers R4-R9 are typed and cannot be
+  * compared without specifying an element type, so they are not folded into the
+  * helper; if your contract needs a specific R4-R9 register to stay equal, add
+  * the equality clause yourself, for example:
+  * <pre class="stHighlight">
+  *   equalBoxExcept(b1, b2, Coll[Int]()) &&
+  *     b1.R4[Long].get == b2.R4[Long].get
+  * </pre>
+  *
+  * The `exclude` argument must be a compile-time literal `Coll[Int]`; the call
+  * expands at compile time into a conjunction of the surviving `==` checks.
+  * Putting R3 (3) or any of R4-R9 (4-9) into `exclude` is a no-op: it does not
+  * change the set of comparisons the helper emits.
+  *
+  * @param b1 first box to compare
+  * @param b2 second box to compare
+  * @param exclude compile-time literal of register ids whose comparison is skipped
+  */
+def equalBoxExcept(b1: Box, b2: Box, exclude: Coll[Int]): Boolean
 ```
 
 ## Known Limitations

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
@@ -9689,6 +9689,48 @@ class LanguageSpecificationV5 extends LanguageSpecificationBase { suite =>
     }
   }
 
+  // Cross-version test for the equalBoxExcept predef (issue #1034). The helper
+  // is pure compiler sugar that lowers to value/propositionBytes/tokens equality
+  // and uses operations available since the earliest ErgoTree version, so it must
+  // be equivalent under v5 as well as under v6 (this is asserted here for v5,
+  // and a sibling test in LanguageSpecificationV6 covers v6).
+  // LanguageSpecificationBase sets okRunTestsWithoutMCLowering = true, so this
+  // property is also re-run with _lowerMethodCalls = false, exercising the
+  // MethodCall(tokensMethod) path that BasicOpsSpec's variant does not cover.
+  property("equalBoxExcept equivalence") {
+    val b1 = create_b1
+    val b2 = create_b2
+    val scalaImpl = { (xs: (Box, Box)) =>
+      xs._1.value == xs._2.value &&
+        xs._1.propositionBytes == xs._2.propositionBytes &&
+        xs._1.tokens == xs._2.tokens
+    }
+    val emptyExclude = existingFeature(scalaImpl,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll[Int]()) }")
+    val noOpExclude = existingFeature(scalaImpl,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll(3, 7, 8)) }")
+    val allExcluded = existingFeature((_: (Box, Box)) => true,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll(0, 1, 2)) }")
+
+    def expectedBool(v: Boolean) = new Expected[Boolean](ExpectedResult(Success(v), None))
+    val cases = Seq(
+      ((b1, b1), expectedBool(true)),
+      ((b1, b2), expectedBool(false)),
+      ((b2, b1), expectedBool(false)),
+      ((b2, b2), expectedBool(true))
+    )
+    val cases2 = Seq(
+      ((b1, b1), expectedBool(true)),
+      ((b1, b2), expectedBool(true)),
+      ((b2, b1), expectedBool(true)),
+      ((b2, b2), expectedBool(true))
+    )
+
+    verifyCases(cases,  emptyExclude, preGeneratedSamples = Some(ArraySeq.empty))
+    verifyCases(cases,  noOpExclude,  preGeneratedSamples = Some(ArraySeq.empty))
+    verifyCases(cases2, allExcluded,  preGeneratedSamples = Some(ArraySeq.empty))
+  }
+
   override protected def afterAll(): Unit = {
     printDebug(CErgoTreeEvaluator.DefaultProfiler.generateReport())
     printDebug("==========================================================")

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
@@ -3181,4 +3181,68 @@ class LanguageSpecificationV6 extends LanguageSpecificationBase { suite =>
     testCases(cases, iou, preGeneratedSamples = Some(Seq.empty))
   }
 
+  // Cross-version test for the equalBoxExcept predef (issue #1034).
+  // The helper is pure compiler sugar that lowers to value/propositionBytes/tokens
+  // equality and uses ErgoTree operations available since v5, so it must behave
+  // identically under v6. LanguageSpecificationBase enables _lowerMethodCalls = false
+  // (okRunTestsWithoutMCLowering), so this property also re-runs without method-call
+  // lowering, exercising the MethodCall(tokensMethod) serialization path.
+  property("equalBoxExcept equivalence") {
+    def mkBox(value: Long, txIdByte: Byte): Box = CBox(new ErgoBox(
+      value,
+      TrueTree,
+      Colls.emptyColl[Token],
+      Map.empty,
+      ModifierId @@ Base16.encode(Array.fill(32)(txIdByte)),
+      0,
+      0))
+    // Two boxes that match on value/propositionBytes/tokens but differ in R3.tail
+    // (different txId). equalBoxExcept must therefore return true on (a, aTwin).
+    val a       = mkBox(10L, 0.toByte)
+    val aTwin   = mkBox(10L, 1.toByte)
+    val bigger  = mkBox(20L, 0.toByte)
+
+    val scalaImpl = { (xs: (Box, Box)) =>
+      xs._1.value == xs._2.value &&
+        xs._1.propositionBytes == xs._2.propositionBytes &&
+        xs._1.tokens == xs._2.tokens
+    }
+    val emptyExclude = existingFeature(scalaImpl,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll[Int]()) }")
+    val noOpExclude  = existingFeature(scalaImpl,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll(3, 7, 8)) }")
+    val excludeValue = existingFeature(
+      { (xs: (Box, Box)) =>
+        xs._1.propositionBytes == xs._2.propositionBytes &&
+          xs._1.tokens == xs._2.tokens
+      },
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll(0)) }")
+    val allExcluded  = existingFeature((_: (Box, Box)) => true,
+      "{ (xs: (Box, Box)) => equalBoxExcept(xs._1, xs._2, Coll(0, 1, 2)) }")
+
+    def expectedBool(v: Boolean) = new Expected[Boolean](ExpectedResult(Success(v), None))
+    val matchCases = Seq(
+      ((a, a),      expectedBool(true)),
+      ((a, aTwin),  expectedBool(true)),   // only R3 differs -> always excluded
+      ((a, bigger), expectedBool(false)),  // value differs
+      ((bigger, a), expectedBool(false))
+    )
+    val excludeValueCases = Seq(
+      ((a, a),      expectedBool(true)),
+      ((a, aTwin),  expectedBool(true)),
+      ((a, bigger), expectedBool(true)),   // value diff allowed
+      ((bigger, a), expectedBool(true))
+    )
+    val allExcludedCases = Seq(
+      ((a, a),      expectedBool(true)),
+      ((a, bigger), expectedBool(true)),
+      ((bigger, a), expectedBool(true))
+    )
+
+    verifyCases(matchCases,        emptyExclude, preGeneratedSamples = Some(Seq.empty))
+    verifyCases(matchCases,        noOpExclude,  preGeneratedSamples = Some(Seq.empty))
+    verifyCases(excludeValueCases, excludeValue, preGeneratedSamples = Some(Seq.empty))
+    verifyCases(allExcludedCases,  allExcluded,  preGeneratedSamples = Some(Seq.empty))
+  }
+
 }

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -239,6 +239,43 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
       mkMethodCall(Self, SBoxMethods.tokensMethod, IndexedSeq())
   }
 
+  property("equalBoxExcept") {
+    // Use SELF and OUTPUTS(0) so each box reference appears at most once per
+    // surviving check, sidestepping common-subexpression elimination that
+    // would otherwise wrap the result in a BlockValue/ValDef pair.
+    val out0 = ByIndex(Outputs, IntConstant(0))
+
+    // exclude {1, 2}: only the value (R0) check survives
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(1, 2))") shouldBe
+      EQ(ExtractAmount(Self), ExtractAmount(out0))
+
+    // exclude {0, 2}: only the propositionBytes (R1) check survives
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(0, 2))") shouldBe
+      EQ(ExtractScriptBytes(Self), ExtractScriptBytes(out0))
+
+    // exclude {0, 1}: only the tokens (R2) check survives
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(0, 1))") shouldBe
+      EQ(
+        mkMethodCall(Self, SBoxMethods.tokensMethod, IndexedSeq()),
+        mkMethodCall(out0, SBoxMethods.tokensMethod, IndexedSeq()))
+
+    // R3 in exclude is a no-op (always implicit), same shape as {1, 2}
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(1, 2, 3))") shouldBe
+      EQ(ExtractAmount(Self), ExtractAmount(out0))
+
+    // R7, R8 in exclude is a no-op (R4-R9 not compared), same shape as {1, 2}
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(1, 2, 7, 8))") shouldBe
+      EQ(ExtractAmount(Self), ExtractAmount(out0))
+
+    // excluding all comparable mandatory registers collapses to TrueLeaf
+    comp("equalBoxExcept(SELF, OUTPUTS(0), Coll(0, 1, 2))") shouldBe TrueLeaf
+  }
+
+  property("equalBoxExcept rejects non-literal exclude") {
+    an[InvalidArguments] should be thrownBy
+      comp("{ (xs: Coll[Int]) => equalBoxExcept(SELF, SELF, xs) }")
+  }
+
   property("SContext.dataInputs") {
     comp("CONTEXT.dataInputs") shouldBe
       mkMethodCall(Context, SContextMethods.dataInputsMethod, IndexedSeq())

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -5063,6 +5063,35 @@ $lrFoldScript
     )
   }
 
+  property("equalBoxExcept - mandatory fields match across SELF and OUTPUTS(0)") {
+    // The test harness creates SELF and OUTPUTS(0) with the same value (10), the
+    // same script (so propositionBytes match) and no tokens. Their R3 differs
+    // (creationHeight 5 vs 0; tx ref absent on SELF vs newBox1) and their R4/R5
+    // also differ, but equalBoxExcept excludes R3 implicitly and never compares
+    // R4-R9, so the helper must return true on this transaction.
+    test("equalBoxExceptIdentity", env, ext,
+      "{ equalBoxExcept(SELF, OUTPUTS(0), Coll[Int]()) }",
+      null,
+      true
+    )
+  }
+
+  property("equalBoxExcept - R7/R8 in exclude is a no-op, still true") {
+    test("equalBoxExceptR7R8", env, ext,
+      "{ equalBoxExcept(SELF, OUTPUTS(0), Coll(7, 8)) }",
+      null,
+      true
+    )
+  }
+
+  property("equalBoxExcept - excluding all mandatory comparable registers collapses to true") {
+    test("equalBoxExceptAllExcluded", env, ext,
+      "{ equalBoxExcept(SELF, OUTPUTS(0), Coll(0, 1, 2)) }",
+      null,
+      true
+    )
+  }
+
   property("expUnsigned - with mod inside") {
       val zz = SecP256K1Group.order.add(new BigInteger("8"))
       def someTest() = test("exp", env, ext,


### PR DESCRIPTION
Closes #1034

## Summary
- Adds `equalBoxExcept(b1, b2, exclude)` predef that lowers to a `BinAnd` chain comparing `value` (R0), `propositionBytes` (R1) and `tokens` (R2).
- Pure compiler sugar: no new opcode, no method addition, no version gate - every op the lowering emits has existed since ErgoTree v0, so an old interpreter verifies the resulting tree without learning anything new.
- R3 is always implicitly excluded (its txId/outputIndex tail differs between any input box and its successor output).
- R4-R9 are not compared. ErgoTree register access is typed and the helper has no element-type context, so polymorphic register comparison would need a new `SBox` method — out of scope for this PR. Contracts that need specific R4-R9 equality compose manually: `equalBoxExcept(b1, b2, Coll[Int]()) && b1.R4[Long].get == b2.R4[Long].get`.
- `exclude` must be a compile-time literal `Coll[Int]`; non-literal arguments fail compilation with `InvalidArguments`.

## Out of scope (potential follow-up)
True per-register exclusion for R4-R9 would require a new `SBox` runtime method (e.g. `regBytes(i): Option[Coll[Byte]]` or a richer `equalsExcept(other, exclude)`); that becomes a soft-fork-scoped ticket separate from this "good first issue".