### PR TITLE
TaggedVariable: pin wire format and deprecate Scala types

### DIFF
--- a/core/shared/src/main/scala/sigma/VersionContext.scala
+++ b/core/shared/src/main/scala/sigma/VersionContext.scala
@@ -42,7 +42,7 @@ object VersionContext {
     * - version 3.x this value must be 0
     * - in v4.0 must be 1
     * - in v5.x must be 2
-    * - in 6.x must be 3
+    * - in v6.x must be 3
     * etc.
     */
   val MaxSupportedScriptVersion: Byte = 3 // supported versions 0, 1, 2, 3

--- a/data/shared/src/main/scala/sigma/ast/SigmaBuilder.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaBuilder.scala
@@ -151,6 +151,12 @@ abstract class SigmaBuilder {
   def mkConcreteCollection[T <: SType](items: Seq[Value[T]],
                                        elementType: T): Value[SCollection[T]]
 
+  /** Retained on the trait so third-party `SigmaBuilder` implementations
+    * remain source/binary compatible. Internal call sites are the serializer
+    * dispatch table only; the ErgoScript compiler does not produce these
+    * nodes. Scheduled for consensus-level rejection in v7.0.
+    */
+  @deprecated("Use mkGetVar / mkValUse; TaggedVariable is scheduled for retirement in v7.0", since = "7.0.0")
   def mkTaggedVariable[T <: SType](varId: Byte, tpe: T): TaggedVariable[T]
 
   def mkBlock(bindings: Seq[Val], result: Value[SType]): Value[SType]
@@ -516,6 +522,7 @@ class StdSigmaBuilder extends SigmaBuilder {
                                                 elementType: T): Value[SCollection[T]] =
     ConcreteCollection(items, elementType).withSrcCtx(currentSrcCtx.value)
 
+  @annotation.nowarn("cat=deprecation")
   override def mkTaggedVariable[T <: SType](varId: Byte, tpe: T): TaggedVariable[T] =
     TaggedVariableNode(varId, tpe).withSrcCtx(currentSrcCtx.value).asInstanceOf[TaggedVariable[T]]
 

--- a/data/shared/src/main/scala/sigma/ast/values.scala
+++ b/data/shared/src/main/scala/sigma/ast/values.scala
@@ -424,13 +424,34 @@ object ConstantPlaceholder extends ValueCompanion {
 trait NotReadyValue[S <: SType] extends Value[S] {
 }
 
-// TODO v6.0: remove these TaggedVariable and TaggedVariableNode (https://github.com/ScorexFoundation/sigmastate-interpreter/issues/584)
+// Retirement plan for TaggedVariable / opcode 0x71.
+//
+// Phase 1: the AST/builder types are deprecated. The on-wire format is unchanged:
+// opcode 0x71 is still registered in the ValueSerializer dispatch table and still
+// round-trips (pinned by TaggedVariableSerializerSpecification). The companion object
+// itself MUST remain non-deprecated because it is referenced by the dispatch table via
+// `ValueCompanion.opCode`.
+//
+// Phase 2 (future, version-gated): once the next protocol version that rejects
+// opcode 0x71 is activated (targeted at v7.0), the serializer entry will start
+// throwing for trees at ergoTreeVersion >= V7SoftForkVersion. The opcode slot will
+// be reserved permanently and never reassigned.
 
-/** Reference a context variable by id. */
+/** Reference a context variable by id.
+  *
+  * @deprecated
+  * Unreachable from the ErgoScript compiler since the introduction of
+  * `GetVar` / `ValUse`. Retained only to preserve binary compatibility
+  * for deserialization of legacy ErgoTrees. Scheduled for consensus-level
+  * rejection in the v7.0 protocol update.
+  */
+@deprecated("Use ValUse / GetVar; TaggedVariable is scheduled for retirement in v7.0", since = "7.0.0")
 trait TaggedVariable[T <: SType] extends NotReadyValue[T] {
   val varId: Byte
 }
 
+/** @see [[TaggedVariable]] for the retirement plan. */
+@deprecated("Use ValUse / GetVar; TaggedVariable is scheduled for retirement in v7.0", since = "7.0.0")
 case class TaggedVariableNode[T <: SType](varId: Byte, override val tpe: T)
     extends TaggedVariable[T] {
   override def companion = TaggedVariable
@@ -438,11 +459,19 @@ case class TaggedVariableNode[T <: SType](varId: Byte, override val tpe: T)
   def opType: SFunc = Value.notSupportedError(this, "opType")
 }
 
+/** Companion object for [[TaggedVariable]].
+  *
+  * NOTE: this object is intentionally NOT deprecated — it must stay reachable
+  * because the serializer dispatch table looks up `opCode` on it. Only the
+  * `apply` constructor is marked deprecated to discourage new producers of
+  * `TaggedVariableNode` while keeping the parse path intact.
+  */
 object TaggedVariable extends ValueCompanion {
   override def opCode: OpCode = TaggedVariableCode
 
   override def costKind: CostKind = FixedCost(JitCost(1))
 
+  @deprecated("Use ValUse / GetVar; TaggedVariable is scheduled for retirement in v7.0", since = "7.0.0")
   def apply[T <: SType](varId: Byte, tpe: T): TaggedVariable[T] =
     TaggedVariableNode(varId, tpe)
 }

--- a/data/shared/src/main/scala/sigma/serialization/TaggedVariableSerializer.scala
+++ b/data/shared/src/main/scala/sigma/serialization/TaggedVariableSerializer.scala
@@ -3,7 +3,20 @@ package sigma.serialization
 import sigma.ast.SType
 import sigma.ast._
 
-// TODO v6.0: remove this class (https://github.com/ScorexFoundation/sigmastate-interpreter/issues/584)
+/** Serializer for the legacy [[TaggedVariable]] node (opcode 0x71).
+  *
+  * Retained to preserve the consensus-level wire format for ErgoTrees with
+  * `ergoTreeVersion <= V6SoftForkVersion`. The class is `@deprecated` to
+  * signal the retirement plan:
+  *   - Phase 1: types deprecated, wire format unchanged.
+  *   - Phase 2 (version-gated): `parse` will reject opcode 0x71 when
+  *     `VersionContext.current.isV7Activated`. The opcode slot is
+  *     reserved and MUST NOT be reassigned to a new node.
+  *
+  * Behavior pinned by `TaggedVariableSerializerSpecification`.
+  */
+@deprecated("Scheduled for version-gated rejection in v7.0; do not reference outside the dispatch table.", since = "7.0.0")
+@annotation.nowarn("cat=deprecation")
 case class TaggedVariableSerializer(cons: (Byte, SType) => Value[SType])
   extends ValueSerializer[TaggedVariable[_ <: SType]] {
   override def opDesc = TaggedVariable

--- a/data/shared/src/main/scala/sigma/serialization/ValueSerializer.scala
+++ b/data/shared/src/main/scala/sigma/serialization/ValueSerializer.scala
@@ -91,7 +91,10 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     LogicalTransformerSerializer(AND, mkAND),
     LogicalTransformerSerializer(OR, mkOR),
     LogicalTransformerSerializer(XorOf, mkXorOf),
-    TaggedVariableSerializer(mkTaggedVariable), // TODO v7.0: remove this serializer https://github.com/ScorexFoundation/sigmastate-interpreter/issues/584
+    // Opcode 0x71. Deprecated; scheduled for version-gated rejection in Phase 2 of the retirement plan.
+    // The rejection target is v7.0. DO NOT remove the entry and DO NOT reassign opcode 0x71.
+    // Doing so changes consensus.
+    TaggedVariableSerializer(mkTaggedVariable),
     GetVarSerializer(mkGetVar),
     MapCollectionSerializer(mkMapCollection),
     BooleanTransformerSerializer[SType](Exists, mkExists),

--- a/interpreter/shared/src/test/scala/sigma/serialization/TaggedVariableSerializerSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigma/serialization/TaggedVariableSerializerSpecification.scala
@@ -1,0 +1,95 @@
+package sigma.serialization
+
+import scala.annotation.nowarn
+
+import sigma.VersionContext
+import sigma.ast._
+import sigma.serialization.OpCodes.TaggedVariableCode
+
+/** Behavior pinning for the legacy `TaggedVariable` node (opcode 0x71).
+  *
+  * `TaggedVariable` is unreachable from the ErgoScript compiler (replaced by
+  * `GetVar` / `ValUse`), but its opcode remains a consensus-visible part of the
+  * ErgoTree serialization format. These tests freeze the current observable
+  * behavior so that subsequent refactoring cannot silently change what bytes
+  * are accepted or what those bytes decode to.
+  *
+  * Any change to these expectations MUST be deliberate and gated behind a
+  * protocol version bump (see Phase 2 of the retirement plan).
+  */
+@nowarn("cat=deprecation")
+class TaggedVariableSerializerSpecification extends SerializationSpecification {
+
+  private val varIds: Seq[Byte]   = Seq(0.toByte, 1.toByte, 42.toByte, 127.toByte, -1.toByte)
+  private val sampleTypes: Seq[SType] =
+    Seq(SBoolean, SByte, SShort, SInt, SLong, SBigInt,
+        SGroupElement, SSigmaProp, SBox, SAvlTree,
+        SCollection.SByteArray, SCollection.SIntArray)
+
+  /** All `(activatedVersion, ergoTreeVersion)` combos exercised by existing
+    * version-switching specs. Listed explicitly so that adding a new protocol
+    * version forces this test to be reviewed. */
+  private val versionMatrix: Seq[(Byte, Byte)] =
+    for {
+      av <- (0: Byte) to VersionContext.MaxSupportedScriptVersion
+      tv <- (0: Byte) to av
+    } yield (av.toByte, tv.toByte)
+
+  property("opcode constant value is stable (0x71)") {
+    // Hard-coded to catch any accidental reshuffle of OpCodes.scala.
+    TaggedVariableCode.toByte shouldBe 0x71.toByte
+  }
+
+  property("dispatch table still maps 0x71 to TaggedVariableSerializer") {
+    val ser = ValueSerializer.getSerializer(TaggedVariableCode)
+    ser shouldBe a[TaggedVariableSerializer]
+    ser.opDesc shouldBe TaggedVariable
+  }
+
+  property("TaggedVariableNode: serializer round trip across version matrix") {
+    for ((av, tv) <- versionMatrix; tpe <- sampleTypes; vid <- varIds) {
+      VersionContext.withVersions(av, tv) {
+        val node  = TaggedVariableNode(vid, tpe)
+        val bytes = ValueSerializer.serialize(node)
+        withClue(s"av=$av, tv=$tv, tpe=$tpe, varId=$vid: ") {
+          // First byte must be the TaggedVariable opcode.
+          bytes(0) shouldBe TaggedVariableCode.toByte
+          // Second byte is the raw varId (per current wire format).
+          bytes(1) shouldBe vid
+          // Round-trip preserves structure.
+          val parsed = ValueSerializer.deserialize(bytes)
+          parsed shouldBe node
+        }
+      }
+    }
+  }
+
+  property("TaggedVariableNode: golden bytes for a representative payload") {
+    // Pinning a single hand-built byte sequence guards against accidental
+    // changes in how `varId` / `tpe` are written. The full type-coverage matrix
+    // is handled by the round-trip property above.
+    VersionContext.withVersions(
+      VersionContext.V6SoftForkVersion, VersionContext.V6SoftForkVersion) {
+      val node  = TaggedVariableNode(1.toByte, SInt)
+      val bytes = ValueSerializer.serialize(node)
+      // opcode (0x71) || varId (0x01) || SInt.typeCode (0x04)
+      bytes shouldBe Array[Byte](0x71.toByte, 0x01.toByte, 0x04.toByte)
+    }
+  }
+
+  property("all currently-supported ErgoTree versions accept opcode 0x71") {
+    // Sanity check the negative direction of the Phase 2 activation: until
+    // the next protocol version that rejects 0x71 is activated, every
+    // currently-supported `ergoTreeVersion` MUST accept the opcode.
+    val acceptingVersions: Seq[Byte] =
+      (0: Byte).to(VersionContext.MaxSupportedScriptVersion).toSeq.map(_.toByte)
+    for (v <- acceptingVersions; tpe <- Seq[SType](SInt, SBox, SAvlTree)) {
+      VersionContext.withVersions(v, v) {
+        val node   = TaggedVariableNode(7.toByte, tpe)
+        val bytes  = ValueSerializer.serialize(node)
+        val parsed = ValueSerializer.deserialize(bytes)
+        parsed shouldBe node
+      }
+    }
+  }
+}

--- a/sc/shared/src/test/scala/sigmastate/utxo/examples/FsmExampleSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/examples/FsmExampleSpecification.scala
@@ -113,19 +113,6 @@ class FsmExampleSpecification extends CompilerTestingCommons
 
     val finalStateCheck = EQ(ExtractRegisterAs[SByte.type](Self, currentStateRegister).get, ByteConstant(state3Id))
 
-    /*
-    val finalScriptCorrect = OptionIsDefined(
-      TreeLookup(
-        OptionGet(ExtractRegisterAs[SAvlTree.type](Self, fsmDescRegister)),
-        Append(
-          ConcreteCollection[SByte.type](
-            OptionGet(ExtractRegisterAs[SByte.type](Self, currentStateRegister)),
-            ByteConstant(leaveFsmStateId)),
-          CalcBlake2b256(TaggedByteArray(scriptVarId))
-        ),
-        TaggedByteArray(transitionProofId))
-    )*/
-
     val finalScriptCorrect = TrueLeaf
 
 


### PR DESCRIPTION
Partially closes #584 

This PR (Phases A + B) is intentionally **non-consensus**. It freezes current on-wire behavior with regression tests and deprecates the unused Scala AST types, but **does not change a single byte** that is serialized or accepted by the deserializer. The wider retirement plan is below so reviewers can evaluate this PR in context.

## Why split

`TaggedVariable` (opcode `0x71`) is unreachable from the ErgoScript compiler: it was replaced by `ValUse` / `GetVar` long time ago. However, the opcode is part of the ErgoTree wire format and therefore consensus-critical. The previous attempt to remove it (#657) conflated two changes with very different consequences. We are splitting them:

| Phase | Scope                              | Consensus? | This PR |
|-------|------------------------------------|------------|---------|
| 1     | Pinning tests for opcode `0x71`, deprecate Scala types, doc cleanup    | No         | ✅      |
| 2     | Reject opcode `0x71` (v7.0 gated)  | **Yes**    | ❌ later |