### PR TITLE
Auto-downcast register id in executeFromSelfReg

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -419,12 +419,12 @@ object SigmaPredef {
     val ExecuteFromSelfRegWithDefaultFunc = PredefinedFunc("executeFromSelfRegWithDefault",
       Lambda(
         Seq(paramT),
-        Array("id" -> SInt, "default" -> tT),
+        Array("id" -> SByte, "default" -> tT),
         tT, None
       ),
       PredefFuncInfo(
         { case (Ident(_, SFunc(_, rtpe, _)), Seq(id: Constant[SNumericType]@unchecked, default)) =>
-          val idx: Int = SInt.downcast((id.value.asInstanceOf[AnyVal]))
+          val idx: Int = SByte.downcast(id.value.asInstanceOf[AnyVal]).toInt
           if (idx < 0 || idx >= org.ergoplatform.ErgoBox.allRegisters.length) {
             default
           } else {
@@ -505,12 +505,12 @@ object SigmaPredef {
     val ExecuteFromSelfRegFunc = PredefinedFunc("executeFromSelfReg",
       Lambda(
         Seq(paramT),
-        Array("id" -> SInt),
+        Array("id" -> SByte),
         tT, None
       ),
       PredefFuncInfo(
         { case (Ident(_, SFunc(_, rtpe, _)), Seq(id: Constant[SNumericType]@unchecked)) =>
-          val idx: Int = SInt.downcast((id.value.asInstanceOf[AnyVal]))
+          val idx: Int = SByte.downcast(id.value.asInstanceOf[AnyVal]).toInt
           if (idx < 0 || idx >= org.ergoplatform.ErgoBox.allRegisters.length) {
             throw new InvalidArguments(s"Invalid register specified $idx")
           }

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -1186,6 +1186,9 @@ def decodePoint(bytes: Coll[Byte]): GroupElement
   *   }
   * </pre>
   *
+  * Note: numeric literals (e.g. `4` or `4L`) are accepted and downcast to Byte
+  * at compile time, so callers need not write `.toByte` explicitly.
+  *
   * @param id zero-based identifier of the variable.
   * @tparam T expected type of the variable.
   * @return Some(value) if the variable is defined in the context AND has the given type.
@@ -1193,7 +1196,7 @@ def decodePoint(bytes: Coll[Byte]): GroupElement
   * @throws InvalidType exception when the type of the variable value is
   *                                   different from cT.
   */
-def getVar[T](tag: Int): Option[T]
+def getVar[T](id: Byte): Option[T]
 
 /** Extracts Context variable from any input by input index, variable id and variable type.
   * Unlike getVar, it is not throwing exception when expected type does not match real type of the variable.
@@ -1268,6 +1271,9 @@ def deserialize[T](string: String): T
  * Throws an exception if the result type of the execution doesn't conform to the return
  * type specified.
  * 
+ * Note: numeric literals (e.g. `4` or `4L`) are accepted and downcast to Byte
+ * at compile time, so callers need not write `.toByte` explicitly.
+ *
  * @param id context variable holding the serialized script to execute
  * @tparam T expected type of the variable and return type.
  * @return result of the executed script
@@ -1283,6 +1289,9 @@ def executeFromVar[T](id: Byte): T
  * An exception is thrown if the result type of the execution doesn't conform to the
  * return type specified and if an invalid register is specified.
  * 
+ * Note: numeric literals (e.g. `4` or `4L`) are accepted and downcast to Byte
+ * at compile time, so callers need not write `.toByte` explicitly.
+ *
  * @param id register id holding the serialized script to execute
  * @tparam T expected type of the register and return type.
  * @return result of the executed script or default value
@@ -1290,7 +1299,7 @@ def executeFromVar[T](id: Byte): T
  * @throws InvalidType exception when the result type of the execution value is 
  *                     different from T.
  */
-def executeFromSelfReg[T](id: Int): T
+def executeFromSelfReg[T](id: Byte): T
 
 /**
  * 
@@ -1300,6 +1309,9 @@ def executeFromSelfReg[T](id: Int): T
  * type of the execution doesn't conform to the return type specified and if an invalid 
  * register is specified.
  * 
+ * Note: numeric literals (e.g. `4` or `4L`) are accepted and downcast to Byte
+ * at compile time, so callers need not write `.toByte` explicitly.
+ *
  * @param id register id holding the serialized script to execute
  * @param default value returned if the register is unavailable
  * @tparam T expected type of the register and return type.
@@ -1308,7 +1320,7 @@ def executeFromSelfReg[T](id: Int): T
  * @throws InvalidType exception when the result type of the execution value is 
  *                     different from T.
  */
-def executeFromSelfRegWithDefault[T](id: Int, default: T): T
+def executeFromSelfRegWithDefault[T](id: Byte, default: T): T
 
 /**
   * Transforms serialized bytes of ErgoTree with segregated constants by

--- a/docs/spec/generated/predeffunc_rows.tex
+++ b/docs/spec/generated/predeffunc_rows.tex
@@ -71,7 +71,7 @@
  \hline
           212 & \hyperref[sec:serialization:operation:DeserializeContext]{\lst{DeserializeContext}} & \parbox{4cm}{\lst{executeFromVar:} \\ \lst{(Byte)} \\ \lst{  => T}} & ... \\
  \hline
-          213 & \hyperref[sec:serialization:operation:DeserializeRegister]{\lst{DeserializeRegister}} & \parbox{4cm}{\lst{executeFromSelfRegWithDefault:} \\ \lst{(Int, T)} \\ \lst{  => T}} & ... \\
+          213 & \hyperref[sec:serialization:operation:DeserializeRegister]{\lst{DeserializeRegister}} & \parbox{4cm}{\lst{executeFromSelfRegWithDefault:} \\ \lst{(Byte, T)} \\ \lst{  => T}} & ... \\
  \hline
           218 & \hyperref[sec:serialization:operation:Apply]{\lst{Apply}} & \parbox{4cm}{\lst{apply:} \\ \lst{((T) => R, T)} \\ \lst{  => R}} & Apply the function to the arguments.  \\
  \hline

--- a/docs/spec/generated/predeffunc_sections.tex
+++ b/docs/spec/generated/predeffunc_sections.tex
@@ -820,7 +820,7 @@
   \hline
   \bf{Parameters} &
       \(\begin{array}{l l l}
-         \lst{id} & \lst{: Int} & \text{// identifier of the register} \\
+         \lst{id} & \lst{: Byte} & \text{// identifier of the register} \\
 \lst{default} & \lst{: T} & \text{// optional default value, if register is not available} \\
       \end{array}\) \\
        

--- a/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
+++ b/sc/shared/src/main/scala/sigma/compiler/phases/SigmaTyper.scala
@@ -281,9 +281,12 @@ class SigmaTyper(val builder: SigmaBuilder,
           val adaptedTypedArgs = (new_f, typedArgs) match {
             case (AllOfFunc.sym | AnyOfFunc.sym, _) =>
               adaptSigmaPropToBoolean(typedArgs, argTypes)
-            case (Ident(GetVarFunc.name | ExecuteFromVarFunc.name, _), Seq(id: Constant[SNumericType]@unchecked))
+            case (Ident(GetVarFunc.name | ExecuteFromVarFunc.name | ExecuteFromSelfRegFunc.name, _), Seq(id: Constant[SNumericType]@unchecked))
               if id.tpe.isNumType =>
                 Seq(ByteConstant(SByte.downcast(id.value.asInstanceOf[AnyVal])).withSrcCtx(id.sourceContext))
+            case (Ident(ExecuteFromSelfRegWithDefaultFunc.name, _), Seq(id: Constant[SNumericType]@unchecked, default))
+              if id.tpe.isNumType =>
+                Seq(ByteConstant(SByte.downcast(id.value.asInstanceOf[AnyVal])).withSrcCtx(id.sourceContext), default)
             case (Ident(SContextMethods.getVarFromInputMethod.name, _),
                   Seq(inputId: Constant[SNumericType]@unchecked, varId: Constant[SNumericType]@unchecked))
                   if inputId.tpe.isNumType && varId.tpe.isNumType =>

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -120,6 +120,22 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     an[TyperException] should be thrownBy comp("getVar[Byte](\"ha\")")
   }
 
+  property("executeFromSelfReg") {
+    // Int and Long literals are auto-downcast to Byte to match the SByte parameter.
+    comp("executeFromSelfReg[Boolean](4)") shouldBe DeserializeRegister(ErgoBox.R4, SBoolean, None)
+    comp("executeFromSelfReg[Boolean](4L)") shouldBe DeserializeRegister(ErgoBox.R4, SBoolean, None)
+    an[InvalidArguments] should be thrownBy comp("executeFromSelfReg[Boolean](99)")
+  }
+
+  property("executeFromSelfRegWithDefault") {
+    comp("executeFromSelfRegWithDefault[Boolean](4, false)") shouldBe
+      DeserializeRegister(ErgoBox.R4, SBoolean, Some(FalseLeaf))
+    comp("executeFromSelfRegWithDefault[Boolean](4L, false)") shouldBe
+      DeserializeRegister(ErgoBox.R4, SBoolean, Some(FalseLeaf))
+    // Out-of-range id short-circuits to the default at compile time.
+    comp("executeFromSelfRegWithDefault[Boolean](99, false)") shouldBe FalseLeaf
+  }
+
   property("PK (testnet network prefix)") {
     implicit val ergoAddressEncoder: ErgoAddressEncoder = new ErgoAddressEncoder(TestnetNetworkPrefix)
     val dk1 = proveDlogGen.sample.get

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaTyperTest.scala
@@ -669,8 +669,16 @@ class SigmaTyperTest extends AnyPropSpec
     typecheck(env, "executeFromVar[Boolean](1)") shouldBe SBoolean
   }
 
+  property("executeFromSelfReg") {
+    // Int and Long literals are auto-downcast to Byte to match the SByte parameter.
+    typecheck(env, "executeFromSelfReg[Boolean](4)") shouldBe SBoolean
+    typecheck(env, "executeFromSelfReg[Boolean](4L)") shouldBe SBoolean
+  }
+
   property("executeFromSelfRegWithDefault") {
+    // Int and Long literals are auto-downcast to Byte to match the SByte parameter.
     typecheck(env, "executeFromSelfRegWithDefault[Boolean](4, getVar[Boolean](1).get)") shouldBe SBoolean
+    typecheck(env, "executeFromSelfRegWithDefault[Boolean](4L, getVar[Boolean](1).get)") shouldBe SBoolean
 
     an[TyperException] should be thrownBy {
       typecheck(env, "executeFromSelfRegWithDefault[Boolean](4, getVar[Int](1).get)")


### PR DESCRIPTION
Closes #602.

Adds Int → Byte auto-downcast in the typer for `executeFromSelfReg(WithDefault)`, matching the existing behaviour for `getVar` / `executeFromVar`. Predef `id` parameter changes from `SInt` to `SByte`; manual `SInt.downcast(...)` in the IR builders is dropped.

Compiler-frontend only — emitted ErgoTree is byte-identical for existing literal-arg usage. Tests added in `SigmaTyperTest` and `SigmaCompilerTest`; spec doc and LangSpec.md updated; `getVar`'s long-standing `(tag: Int)` doc mismatch fixed to `(id: Byte)`.
