### PR TITLE
audit Exponentiate, lock-in cross-platform equivalence

### DIFF
--- a/core/shared/src/main/scala/sigma/data/CGroupElement.scala
+++ b/core/shared/src/main/scala/sigma/data/CGroupElement.scala
@@ -19,6 +19,11 @@ case class CGroupElement(override val wrappedValue: Ecp) extends GroupElement wi
 
   override def isIdentity: Boolean = CryptoFacade.isInfinityPoint(wrappedValue)
 
+  // Out-of-range `k` (negative, or magnitude >= group order) is reduced inside
+  // `CryptoFacade.exponentiatePoint`: BouncyCastle `ECPoint.multiply` on JVM and
+  // noble-curves-backed `multiplyPoint` on JS both compute `p^(k mod order)`.
+  // See `GroupLawsSpecification` ("BcDlogGroup.exponentiate matches CGroupElement.exp")
+  // for the equivalence test.
   override def exp(k: BigInt): GroupElement =
     CGroupElement(CryptoFacade.exponentiatePoint(wrappedValue, k.asInstanceOf[CBigInt].wrappedValue))
 

--- a/interpreter/shared/src/test/scala/sigmastate/crypto/GroupLawsSpecification.scala
+++ b/interpreter/shared/src/test/scala/sigmastate/crypto/GroupLawsSpecification.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Gen
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import sigma.crypto.{CryptoConstants, CryptoFacade, EcPointType, Ecp}
+import sigma.data.{CBigInt, CGroupElement}
 import sigmastate.TestsBase
 import sigmastate.utils.Helpers
 
@@ -40,6 +41,27 @@ class GroupLawsSpecification extends AnyPropSpec with ScalaCheckPropertyChecks w
       group.exponentiate(ge, BigInteger.ONE) shouldBe ge
       group.exponentiate(ge, group.order) shouldBe identity
       group.exponentiate(ge, group.order.add(BigInteger.ONE)) shouldBe ge
+    }
+  }
+
+  // Pins the invariant that BcDlogGroup.exponentiate (explicit `mod(order)` for negatives)
+  // and CGroupElement.exp (delegating straight to CryptoFacade.exponentiatePoint) agree.
+  // BC and the JS bridge both implement `abs+negate` for negative scalars, which on a
+  // prime-order group equals `mod(order)`.
+  property("BcDlogGroup.exponentiate matches CGroupElement.exp") {
+    // CBigInt rejects bitLength > 255, so bigIntGen (max bitLength 247) is safe.
+    val signedBigIntGen: Gen[BigInteger] = Gen.oneOf(
+      Gen.const(BigInteger.ZERO),
+      Gen.const(BigInteger.ONE),
+      Gen.const(BigInteger.ONE.negate()),
+      bigIntGen,
+      bigIntGen.map(_.negate())
+    )
+    forAll(groupElementGen, signedBigIntGen) { (ge, k) =>
+      val viaBcDlog = group.exponentiate(ge, k)
+      val viaDsl    = CGroupElement(ge).exp(CBigInt(k))
+        .asInstanceOf[CGroupElement].wrappedValue
+      viaDsl shouldBe viaBcDlog
     }
   }
 

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
@@ -2499,11 +2499,20 @@ class LanguageSpecificationV6 extends LanguageSpecificationBase { suite =>
       sinceVersion = VersionContext.V6SoftForkVersion
     )
 
+    val generator = CryptoConstants.dlogGroup.generator
+    val order = CryptoConstants.dlogGroup.order
+    // Max representable UnsignedBigInt (bitLength = 256), strictly > group order.
+    // Cross-checks that the JS bridge reduces scalars `mod order` consistently with BC. See #731.
+    val maxUnsigned = BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE)
+    val expMaxUnsigned = CryptoConstants.dlogGroup.exponentiate(generator, maxUnsigned.mod(order))
+
     verifyCases(
       Seq(
-        (CGroupElement(CryptoConstants.dlogGroup.generator), CUnsignedBigInt(new BigInteger("1"))) -> Expected(ExpectedResult(Success(CGroupElement(CryptoConstants.dlogGroup.generator)), None)),
-        (CGroupElement(CryptoConstants.dlogGroup.generator), CUnsignedBigInt(new BigInteger("0"))) -> Expected(ExpectedResult(Success(CGroupElement(CryptoConstants.dlogGroup.identity)), None)),
-        (CGroupElement(CryptoConstants.dlogGroup.generator), CUnsignedBigInt(CryptoConstants.dlogGroup.order)) -> Expected(ExpectedResult(Success(CGroupElement(CryptoConstants.dlogGroup.identity)), None))
+        (CGroupElement(generator), CUnsignedBigInt(new BigInteger("1"))) -> Expected(ExpectedResult(Success(CGroupElement(generator)), None)),
+        (CGroupElement(generator), CUnsignedBigInt(new BigInteger("0"))) -> Expected(ExpectedResult(Success(CGroupElement(CryptoConstants.dlogGroup.identity)), None)),
+        (CGroupElement(generator), CUnsignedBigInt(order)) -> Expected(ExpectedResult(Success(CGroupElement(CryptoConstants.dlogGroup.identity)), None)),
+        (CGroupElement(generator), CUnsignedBigInt(order.add(BigInteger.ONE))) -> Expected(ExpectedResult(Success(CGroupElement(generator)), None)),
+        (CGroupElement(generator), CUnsignedBigInt(maxUnsigned)) -> Expected(ExpectedResult(Success(CGroupElement(expMaxUnsigned)), None))
       ),
       f
     )


### PR DESCRIPTION
### Audit summary

The original concern — that the DSL path is missing the `mod(order)` normalization that `BcDlogGroup.exponentiate` does — turns out to be moot in current code. @kushti's comment:

> BouncyCastle is doing `abs()` under the hood

is incomplete. The snippet @kushti pasted does `abs()` **and then `negate()`** when the sign is negative:

```java
ECPoint positive = multiplyPositive(p, k.abs());
ECPoint result   = sign > 0 ? positive : positive.negate();
```

On a prime-order group, `positive.negate()` equals `p^(order − |k|) = p^(k mod order)` — i.e. mathematically identical to what `BcDlogGroup.exponentiate` does explicitly. The same abs+negate dance is mirrored in the JS bridge (`core/js/.../Platform.scala`). So all three paths converge:

| Path | Negative-`k` handling | Result |
|---|---|---|
| `BcDlogGroup.exponentiate` | explicit `exponent.mod(order)` | `p^(k mod q)` |
| JVM `Platform.exponentiatePoint` | BC `multiply` → abs+negate | `p^(k mod q)` |
| JS `Platform.exponentiatePoint` | explicit `abs()` + `negatePoint` | `p^(k mod q)` |

The V5 spec has been pinning fixed hex outputs for negative `k` (`LanguageSpecificationV5.scala:2555-2564`) and runs cross-platform, so the convergence is already enforced indirectly — but `BcDlogGroup.exponentiate` was never directly compared to `GroupElement.exp` in a test.

### What's done (this very PR, against `v6.0.4`)

- New property `"BcDlogGroup.exponentiate matches CGroupElement.exp"` in `GroupLawsSpecification` covering `k ∈ {0, ±1, random positive, random negative}` — runs on both `interpreterJVM` and `interpreterJS`.
- Extended `"GroupElement.expUnsigned"` in `LanguageSpecificationV6` with `(generator, order + 1)` and `(generator, 2^256 − 1)` cases. The latter pins that the JS noble-curves bridge reduces scalars `mod order` consistently with BC — **previously untested, now green on both `scJVM` and `scJS`.**
- Short Scaladoc on `CGroupElement.exp` / `expUnsigned` documenting where the invariant lives.

No semantic change, no version gate, no opcode/serializer touch.

### Proposed follow-up PR — two questions for maintainers

With equivalence proven, `BcDlogGroup` and the `DlogGroup` trait are pure passthroughs over `CryptoFacade` (~75 `dlogGroup.*` references across 22 files, plus three methods with zero external callers: `exponentiateWithPreComputedValues`, `orderGreaterThan`, `maxLengthOfByteArrayForEncoding`). Before opening PR B I'd like to settle:

**Q1.** Follow up PR will delete `data/shared/.../crypto/{DlogGroup,BcDlogGroup}.scala` and lifts the live surface (`generator`, `identity`, `ctx`, `createRandomElement`, …) onto `CryptoConstants` / `CryptoFacade`. Mechanical, no behaviour change, but it touches the [hard-fork red zone](https://github.com/ergoplatform/sigmastate-interpreter/blob/develop/docs/pr-review-policy.md). Is this acceptable as a pure-refactor PR against `v6.0.4`, or should it wait for a post-v6.0 cleanup branch?

**Q2.** Should follow up PR also close #865 (rename `GroupElement.negate` → `inverse`, `isInfinity` → `isIdentity`)? Refactor intersects #865 at exactly one symbol (`CGroupElement.negate`), so the natural bundling is to add `inverse` / `isIdentity` to `SGroupElementMethods` behind a v6+ version gate (keeping `negate`/`isInfinity` for v5 scripts). I can see few options: (a) bundle into follow up PR, (b) keep #865 as a follow-up, (c) close #865 as wontfix.

Closes #731 once PR A lands; #865's outcome decides follow-up PR.