### PR TITLE
remove treeLookup language binding (AST kept)

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/Operations.scala
+++ b/data/shared/src/main/scala/sigma/ast/Operations.scala
@@ -496,14 +496,6 @@ object Operations {
     val argInfos: Seq[ArgInfo] = Array(scriptBytesArg, positionsArg, newValuesArg)
   }
 
-  object TreeLookupInfo extends InfoObject {
-    private val func = predefinedOps.specialFuncs("treeLookup")
-    val treeArg: ArgInfo = func.argInfo("tree")
-    val keyArg: ArgInfo = func.argInfo("key")
-    val proofArg: ArgInfo = func.argInfo("proof")
-    val argInfos: Seq[ArgInfo] = Array(treeArg, keyArg, proofArg)
-  }
-
   object UpcastInfo extends InfoObject {
     private val func = predefinedOps.specialFuncs("upcast")
     val inputArg: ArgInfo = func.argInfo("input")

--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -687,15 +687,6 @@ object SigmaPredef {
           "Select tuple field by its 1-based index. E.g. \\lst{input._1} is transformed to \\lst{SelectField(input, 1)}",
           Seq(ArgInfo("input", "tuple of items"), ArgInfo("fieldIndex", "index of an item to select")))
       ),
-      PredefinedFunc("treeLookup",
-        Lambda(Array("tree" -> SAvlTree, "key" -> SByteArray, "proof" -> SByteArray), SOption(SByteArray), None),
-        PredefFuncInfo(undefined),
-        OperationInfo(TreeLookup,
-          "",
-          Seq(ArgInfo("tree", "tree to lookup the key"),
-          ArgInfo("key", "a key of an item in the \\lst{tree} to lookup"),
-          ArgInfo("proof", "proof to perform verification of the operation")))
-      ),
       PredefinedFunc("if",
         Lambda(Array(paramT), Array("condition" -> SBoolean, "trueBranch" -> tT, "falseBranch" -> tT), tT, None),
         PredefFuncInfo(undefined),

--- a/data/shared/src/main/scala/sigma/ast/trees.scala
+++ b/data/shared/src/main/scala/sigma/ast/trees.scala
@@ -1318,6 +1318,9 @@ sealed trait Quadruple[IV1 <: SType, IV2 <: SType, IV3 <: SType, OV <: SType] ex
   * Throws exception if proof is incorrect
   * Return Some(bytes) of leaf with key `key` if it exists
   * Return None if leaf with provided key does not exist.
+  *
+  * Retained for deserialization of legacy ErgoTrees carrying opcode 71
+  * (AvlTreeGetCode); the compiler emits MethodCall(AvlTree.get) instead.
   */
 case class TreeLookup(tree: Value[SAvlTree.type],
     key: Value[SByteArray],
@@ -1334,7 +1337,10 @@ trait QuadrupleCompanion extends ValueCompanion {
 object TreeLookup extends QuadrupleCompanion {
   override def opCode: OpCode = OpCodes.AvlTreeGetCode
   override def costKind: CostKind = Value.notSupportedError(this, "costKind")
-  override def argInfos: Seq[ArgInfo] = TreeLookupInfo.argInfos
+  override def argInfos: Seq[ArgInfo] = Array(
+    ArgInfo("tree", "tree to lookup the key"),
+    ArgInfo("key", "a key of an item in the \\lst{tree} to lookup"),
+    ArgInfo("proof", "proof to perform verification of the operation"))
 }
 
 /**

--- a/data/shared/src/main/scala/sigma/serialization/OpCodes.scala
+++ b/data/shared/src/main/scala/sigma/serialization/OpCodes.scala
@@ -108,6 +108,8 @@ object OpCodes {
   val SliceCode            : OpCode = newOpCode(68)
   val FilterCode           : OpCode = newOpCode(69)
   val AvlTreeCode          : OpCode = newOpCode(70)
+  // Reserved for legacy `TreeLookup` deserialization; the compiler emits
+  // `MethodCall(AvlTree.get)` instead. See issue #645.
   val AvlTreeGetCode       : OpCode = newOpCode(71)
   val FlatMapCollectionCode: OpCode = newOpCode(72) // reserved 73 - 80 (8)
 

--- a/data/shared/src/main/scala/sigma/serialization/ValueSerializer.scala
+++ b/data/shared/src/main/scala/sigma/serialization/ValueSerializer.scala
@@ -52,6 +52,8 @@ object ValueSerializer extends SigmaSerializerCompanion[Value[SType]] {
     Relation2Serializer(EQ, mkEQ[SType]),
     Relation2Serializer(NEQ, mkNEQ[SType]),
     CreateAvlTreeSerializer(mkCreateAvlTree),
+    // Retained so legacy ErgoTrees carrying opcode 71 (AvlTreeGetCode) still
+    // deserialize; the compiler emits MethodCall(AvlTree.get) instead. See #645.
     QuadrupleSerializer(TreeLookup, mkTreeLookup),
     Relation2Serializer(BinOr, mkBinOr),
     Relation2Serializer(BinAnd, mkBinAnd),


### PR DESCRIPTION
## Summary

Partially resolves #645. Removes the dead `treeLookup` frontend metadata while explicitly retaining the `TreeLookup` AST node, opcode `71` (`AvlTreeGetCode`), and serializer registration, with inline comments explaining why.

## Why

@kushti's only comment (see #645) — *"Why is it unused?"* — never received a complete answer. The concern was valid: the "unused" framing conflates two different artefacts.

- **Unused at the language surface.** `PredefinedFunc("treeLookup", …)` in `SigmaPredef.specialFuncs` is marked `PredefFuncInfo(undefined)` — pure SpecGen metadata, never callable from ErgoScript. `tree.get(key, proof)` compiles to a `MethodCall(SAvlTreeMethods.getMethod)`, not a `TreeLookup` quadruple.
- **NOT unused at the serializer.** Opcode `71` is registered via `QuadrupleSerializer(TreeLookup, mkTreeLookup)`. Any historical on-chain `ErgoTree` that carries opcode `71` must still deserialize, so the AST class, opcode, and serializer cannot be removed without an empirical mainnet/testnet scan and a script-version gate. That work belongs to the node team, not a compiler refactor.

## What changes

This PR removes only the dead frontend metadata (`PredefinedFunc("treeLookup", …)` and the `TreeLookupInfo` object that consumed it) and inlines `TreeLookup.argInfos`. Retention comments pointing to #645 are added on the pieces that stay.

**Untouched (intentionally):** `case class TreeLookup` and its companion, `mkTreeLookup` in `SigmaBuilder`, `AvlTreeGetCode`, the `QuadrupleSerializer` registration, the `RelationsSpecification` round-trip test, and the `RelationGenerators` ScalaCheck generator.

## Follow-up (out of scope)

Fully closing #645 — removing the AST node, opcode, `mkTreeLookup`, and `QuadrupleSerializer` registration — requires 
(a) scanning mainnet + currently-maintained testnets for any `ErgoTree` whose byte stream decodes to a `TreeLookup` quadruple, and
(b) introducing a new script version that retires opcode `71` from the active opcode set while keeping prior-version deserialization. That's a node-team consensus task.