### PR TITLE
Implement allZK/anyZK global functions

### DIFF
--- a/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
+++ b/data/shared/src/main/scala/sigma/ast/SigmaPredef.scala
@@ -55,6 +55,28 @@ object SigmaPredef {
     private val undefined: IrBuilderFunc =
       PartialFunction.empty[(SValue, Seq[SValue]), SValue]
 
+    /** Extracts the sigma-proposition items from the argument of `allZK`/`anyZK`.
+      *
+      * Both functions lower to the fixed-arity `SigmaAnd`/`SigmaOr` ErgoTree nodes (the same
+      * nodes produced by `&&`/`||` on sigma propositions). Those nodes hold a static
+      * `Seq[SigmaPropValue]`, so the argument must be a `Coll(...)` literal written in the
+      * script (a [[ConcreteCollection]]); a runtime collection cannot be folded into them.
+      * An empty collection is rejected because `CAND.normalized`/`COR.normalized` require at
+      * least one item and would otherwise fail at evaluation time.
+      */
+    private def sigmaPropItems(funcName: String, arg: SValue): Seq[SigmaPropValue] = {
+      val items: Seq[SigmaPropValue] = arg match {
+        case ConcreteCollection(items, SSigmaProp) =>
+          items.map(_.asSigmaProp)
+        case other =>
+          throw new InvalidArguments(
+            s"$funcName: argument must be a literal Coll[SigmaProp]; got $other")
+      }
+      if (items.isEmpty)
+        throw new InvalidArguments(s"$funcName: argument collection must be non-empty")
+      items
+    }
+
     val AllOfFunc = PredefinedFunc("allOf",
       Lambda(Array("conditions" -> SCollection(SBoolean)), SBoolean, None),
       PredefFuncInfo({ case (_, Seq(col: Value[SCollection[SBoolean.type]]@unchecked)) => mkAND(col) }),
@@ -78,14 +100,16 @@ object SigmaPredef {
 
     val AllZKFunc = PredefinedFunc("allZK",
       Lambda(Array("propositions" -> SCollection(SSigmaProp)), SSigmaProp, None),
-      PredefFuncInfo(undefined),
+      PredefFuncInfo({ case (_, Seq(col: Value[SCollection[SSigmaProp.type]]@unchecked)) =>
+        mkSigmaAnd(sigmaPropItems("allZK", col)) }),
       OperationInfo(SigmaAnd, "Returns sigma proposition which is proven when \\emph{all} the elements in collection are proven.",
         Seq(ArgInfo("propositions", "a collection of propositions")))
     )
 
     val AnyZKFunc = PredefinedFunc("anyZK",
       Lambda(Array("propositions" -> SCollection(SSigmaProp)), SSigmaProp, None),
-      PredefFuncInfo(undefined),
+      PredefFuncInfo({ case (_, Seq(col: Value[SCollection[SSigmaProp.type]]@unchecked)) =>
+        mkSigmaOr(sigmaPropItems("anyZK", col)) }),
       OperationInfo(SigmaOr, "Returns sigma proposition which is proven when \\emph{any} of the elements in collection is proven.",
         Seq(ArgInfo("propositions", "a collection of propositions")))
     )

--- a/docs/LangSpec.md
+++ b/docs/LangSpec.md
@@ -1105,6 +1105,20 @@ def xorOf(conditions: Coll[Boolean]): Boolean
  * if at least k properties can be proven to be true. 
  */
 def atLeast(k: Int, properties: Coll[SigmaProp]): SigmaProp
+
+/** Returns a SigmaProp (a `SigmaAnd` node) which can be ZK proven to be true if *all* the
+ * propositions can be proven to be true, without revealing which proof was presented.
+ * Equivalent to combining the propositions with `&&`. The argument must be a literal
+ * collection: its size is fixed at compile time.
+ */
+def allZK(propositions: Coll[SigmaProp]): SigmaProp
+
+/** Returns a SigmaProp (a `SigmaOr` node) which can be ZK proven to be true if *any* of the
+ * propositions can be proven to be true, without revealing which proof was presented.
+ * Equivalent to combining the propositions with `||`. The argument must be a literal
+ * collection: its size is fixed at compile time.
+ */
+def anyZK(propositions: Coll[SigmaProp]): SigmaProp
     
 /** Embedding of Boolean values to SigmaProp values. As an example, this
  * operation allows boolean expressions to be used as arguments of

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV5.scala
@@ -9139,6 +9139,64 @@ class LanguageSpecificationV5 extends LanguageSpecificationBase { suite =>
         )))
   }
 
+  // allZK / anyZK are pure compiler sugar (issue #543): they lower to the SAME SigmaAnd / SigmaOr
+  // nodes that `&&` / `||` produce on sigma propositions, which exist since v4/v5. They are therefore
+  // available in all script versions, not gated to v6. These properties pin the v5 (pre-v6) behavior:
+  // the compiled ErgoTree is the expected SigmaAnd/SigmaOr and the result matches the reference.
+  property("allZK equivalence") {
+    val allZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.allZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => allZK(Coll(x._1, x._2)) }",
+      FuncValue(
+        Vector((1, SPair(SSigmaProp, SSigmaProp))),
+        SigmaAnd(
+          Seq(
+            SelectField.typed[SigmaPropValue](ValUse(1, SPair(SSigmaProp, SSigmaProp)), 1.toByte),
+            SelectField.typed[SigmaPropValue](ValUse(1, SPair(SSigmaProp, SSigmaProp)), 2.toByte)
+          )
+        )))
+    val dlA = ProveDlog(Helpers.decodeECPoint("02ea9bf6da7f512386c6ca509d40f8c5e7e0ffb3eea5dc3c398443ea17f4510798"))
+    val dlB = ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))
+    val pkA = CSigmaProp(dlA)
+    val pkB = CSigmaProp(dlB)
+    def expected(v: SigmaProp) = new Expected(ExpectedResult(Success(v), None))
+    verifyCases(
+      Seq(
+        (pkA, pkB)                               -> expected(CSigmaProp(CAND.normalized(Array(dlA, dlB)))),
+        (CSigmaProp(TrivialProp.TrueProp), pkB)  -> expected(pkB),                              // true && x == x
+        (CSigmaProp(TrivialProp.FalseProp), pkB) -> expected(CSigmaProp(TrivialProp.FalseProp)) // false && x == false
+      ),
+      allZK,
+      preGeneratedSamples = Some(Seq.empty))
+  }
+
+  property("anyZK equivalence") {
+    val anyZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.anyZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => anyZK(Coll(x._1, x._2)) }",
+      FuncValue(
+        Vector((1, SPair(SSigmaProp, SSigmaProp))),
+        SigmaOr(
+          Seq(
+            SelectField.typed[SigmaPropValue](ValUse(1, SPair(SSigmaProp, SSigmaProp)), 1.toByte),
+            SelectField.typed[SigmaPropValue](ValUse(1, SPair(SSigmaProp, SSigmaProp)), 2.toByte)
+          )
+        )))
+    val dlA = ProveDlog(Helpers.decodeECPoint("02ea9bf6da7f512386c6ca509d40f8c5e7e0ffb3eea5dc3c398443ea17f4510798"))
+    val dlB = ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))
+    val pkA = CSigmaProp(dlA)
+    val pkB = CSigmaProp(dlB)
+    def expected(v: SigmaProp) = new Expected(ExpectedResult(Success(v), None))
+    verifyCases(
+      Seq(
+        (pkA, pkB)                               -> expected(CSigmaProp(COR.normalized(Array(dlA, dlB)))),
+        (CSigmaProp(TrivialProp.TrueProp), pkB)  -> expected(CSigmaProp(TrivialProp.TrueProp)), // true || x == true
+        (CSigmaProp(TrivialProp.FalseProp), pkB) -> expected(pkB)                               // false || x == x
+      ),
+      anyZK,
+      preGeneratedSamples = Some(Seq.empty))
+  }
+
   property("SigmaProp.propBytes equivalence") {
     verifyCases(
       {

--- a/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
+++ b/sc/shared/src/test/scala/sigma/LanguageSpecificationV6.scala
@@ -15,7 +15,7 @@ import sigma.ast.SCollection.SByteArray
 import sigma.ast.SType.tT
 import sigma.ast.syntax.TrueSigmaProp
 import sigma.ast.{SInt, _}
-import sigma.data.{AvlTreeData, AvlTreeFlags, CAnyValue, CAvlTree, CBigInt, CBox, CHeader, CSigmaProp, ExactNumeric, ProveDHTuple, RType}
+import sigma.data.{AvlTreeData, AvlTreeFlags, CAND, COR, CAnyValue, CAvlTree, CBigInt, CBox, CHeader, CSigmaProp, ExactNumeric, ProveDHTuple, ProveDlog, RType, TrivialProp}
 import sigma.data.CSigmaDslBuilder
 import sigma.data.{CGroupElement, CUnsignedBigInt}
 import sigma.crypto.SecP256K1Group
@@ -1380,36 +1380,81 @@ class LanguageSpecificationV6 extends LanguageSpecificationBase { suite =>
     }
   }
 
-  // TODO v6.0 (3h): implement allZK func https://github.com/ScorexFoundation/sigmastate-interpreter/issues/543
+  // allZK / anyZK are compiler sugar for the SigmaAnd / SigmaOr nodes (issue #543). They lower
+  // to the same ErgoTree that `a && b` / `a || b` produce on sigma propositions, so they are
+  // available in all script versions (existingFeature). Only literal collections are accepted;
+  // the argument arity is fixed at compile time. See SigmaCompilerTest for the rejection cases.
   property("allZK equivalence") {
-    lazy val allZK = newFeature((x: Coll[SigmaProp]) => SigmaDsl.allZK(x),
-      "{ (x: Coll[SigmaProp]) => allZK(x) }",
-      sinceVersion = V6SoftForkVersion)
+    val allZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.allZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => allZK(Coll(x._1, x._2)) }")
 
-    if (activatedVersionInTests < VersionContext.V6SoftForkVersion) {
-      // NOTE, for such versions getReg is not supported
-      // which is checked below
+    val dlA = ProveDlog(Helpers.decodeECPoint("02ea9bf6da7f512386c6ca509d40f8c5e7e0ffb3eea5dc3c398443ea17f4510798"))
+    val dlB = ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))
+    val pkA = CSigmaProp(dlA)
+    val pkB = CSigmaProp(dlB)
+    def expected(v: SigmaProp) = new Expected(ExpectedResult(Success(v), None))
 
-      forAll { x: Coll[SigmaProp] =>
-        allZK.checkEquality(x)
-      }
-    }
+    verifyCases(
+      Seq(
+        (pkA, pkB)                               -> expected(CSigmaProp(CAND.normalized(Array(dlA, dlB)))),
+        (CSigmaProp(TrivialProp.TrueProp), pkB)  -> expected(pkB),                              // true && x == x
+        (CSigmaProp(TrivialProp.FalseProp), pkB) -> expected(CSigmaProp(TrivialProp.FalseProp)) // false && x == false
+      ),
+      allZK,
+      preGeneratedSamples = Some(Seq.empty))
   }
 
-  // TODO v6.0 (3h): implement anyZK func https://github.com/ScorexFoundation/sigmastate-interpreter/issues/543
   property("anyZK equivalence") {
-    lazy val anyZK = newFeature((x: Coll[SigmaProp]) => SigmaDsl.anyZK(x),
-      "{ (x: Coll[SigmaProp]) => anyZK(x) }",
-      sinceVersion = V6SoftForkVersion)
+    val anyZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.anyZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => anyZK(Coll(x._1, x._2)) }")
 
-    if (activatedVersionInTests < VersionContext.V6SoftForkVersion) {
-      // NOTE, for such versions getReg is not supported
-      // which is checked below
+    val dlA = ProveDlog(Helpers.decodeECPoint("02ea9bf6da7f512386c6ca509d40f8c5e7e0ffb3eea5dc3c398443ea17f4510798"))
+    val dlB = ProveDlog(Helpers.decodeECPoint("03a426a66fc1af2792b35d9583904c3fb877b49ae5cea45b7a2aa105ffa4c68606"))
+    val pkA = CSigmaProp(dlA)
+    val pkB = CSigmaProp(dlB)
+    def expected(v: SigmaProp) = new Expected(ExpectedResult(Success(v), None))
 
-      forAll { x: Coll[SigmaProp] =>
-        anyZK.checkEquality(x)
-      }
-    }
+    verifyCases(
+      Seq(
+        (pkA, pkB)                               -> expected(CSigmaProp(COR.normalized(Array(dlA, dlB)))),
+        (CSigmaProp(TrivialProp.TrueProp), pkB)  -> expected(CSigmaProp(TrivialProp.TrueProp)), // true || x == true
+        (CSigmaProp(TrivialProp.FalseProp), pkB) -> expected(pkB)                               // false || x == x
+      ),
+      anyZK,
+      preGeneratedSamples = Some(Seq.empty))
+  }
+
+  property("allZK/anyZK over heterogeneous sigma propositions") {
+    // allZK/anyZK combine SigmaProp values of any kind uniformly: here a ProveDHTuple is
+    // combined with a ProveDlog. The result must be the same CAND/COR tree as `&&`/`||`.
+    val dlog = CryptoConstants.dlogGroup
+    val ecp1 = dlog.generator
+    val ecp2 = dlog.multiplyGroupElements(ecp1, ecp1)
+    val ecp3 = dlog.multiplyGroupElements(ecp2, ecp2)
+    val ecp4 = dlog.multiplyGroupElements(ecp3, ecp3)
+    val dht  = ProveDHTuple(ecp1, ecp2, ecp3, ecp4)
+    val dl   = ProveDlog(Helpers.decodeECPoint("02ea9bf6da7f512386c6ca509d40f8c5e7e0ffb3eea5dc3c398443ea17f4510798"))
+    val pkDht = CSigmaProp(dht)
+    val pkDl  = CSigmaProp(dl)
+    def expected(v: SigmaProp) = new Expected(ExpectedResult(Success(v), None))
+
+    val allZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.allZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => allZK(Coll(x._1, x._2)) }")
+    verifyCases(
+      Seq((pkDht, pkDl) -> expected(CSigmaProp(CAND.normalized(Array(dht, dl))))),
+      allZK,
+      preGeneratedSamples = Some(Seq.empty))
+
+    val anyZK = existingFeature(
+      { (x: (SigmaProp, SigmaProp)) => SigmaDsl.anyZK(Colls.fromItems(x._1, x._2)) },
+      "{ (x: (SigmaProp, SigmaProp)) => anyZK(Coll(x._1, x._2)) }")
+    verifyCases(
+      Seq((pkDht, pkDl) -> expected(CSigmaProp(COR.normalized(Array(dht, dl))))),
+      anyZK,
+      preGeneratedSamples = Some(Seq.empty))
   }
 
   property("Numeric.toBytes methods equivalence") {

--- a/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
+++ b/sc/shared/src/test/scala/sigmastate/lang/SigmaCompilerTest.scala
@@ -105,6 +105,53 @@ class SigmaCompilerTest extends CompilerTestingCommons with LangTests with Objec
     comp("atLeast(2, Coll[SigmaProp](p1, p2))") shouldBe AtLeast(2, p1, p2)
   }
 
+  // NOTE: each sigma proposition in a script must be a distinct subexpression, otherwise the
+  // compiler hoists the repeated one into a BlockValue(ValDef, ...) via common-subexpression
+  // elimination and the result is no longer a bare SigmaAnd/SigmaOr.
+  property("allZK") {
+    comp("allZK(Coll[SigmaProp](p1, p2))") shouldBe SigmaAnd(p1, p2)
+    // a single-element collection collapses to the element itself (AND of one)
+    comp("allZK(Coll[SigmaProp](p1))") shouldBe comp("p1")
+    // lowers to exactly the same node as `&&` on sigma propositions
+    comp("allZK(Coll[SigmaProp](p1, p2))") shouldBe comp("p1 && p2")
+    // arity > 2 with mixed element kinds: sigmaProp(bool) is a valid SigmaProp expression
+    comp("allZK(Coll[SigmaProp](p1, p2, sigmaProp(HEIGHT > 1000)))") shouldBe
+      SigmaAnd(p1, p2, BoolToSigmaProp(GT(Height, IntConstant(1000))))
+    // nested zk operations
+    comp("allZK(Coll[SigmaProp](anyZK(Coll[SigmaProp](p1, p2)), sigmaProp(HEIGHT > 1000)))") shouldBe
+      SigmaAnd(SigmaOr(p1, p2), BoolToSigmaProp(GT(Height, IntConstant(1000))))
+  }
+
+  property("anyZK") {
+    comp("anyZK(Coll[SigmaProp](p1, p2))") shouldBe SigmaOr(p1, p2)
+    // a single-element collection collapses to the element itself (OR of one)
+    comp("anyZK(Coll[SigmaProp](p1))") shouldBe comp("p1")
+    // lowers to exactly the same node as `||` on sigma propositions
+    comp("anyZK(Coll[SigmaProp](p1, p2))") shouldBe comp("p1 || p2")
+    comp("anyZK(Coll[SigmaProp](p1, p2, sigmaProp(HEIGHT > 1000)))") shouldBe
+      SigmaOr(p1, p2, BoolToSigmaProp(GT(Height, IntConstant(1000))))
+    comp("anyZK(Coll[SigmaProp](allZK(Coll[SigmaProp](p1, p2)), sigmaProp(HEIGHT > 1000)))") shouldBe
+      SigmaOr(SigmaAnd(p1, p2), BoolToSigmaProp(GT(Height, IntConstant(1000))))
+  }
+
+  property("allZK/anyZK reject a non-literal collection") {
+    // SigmaAnd/SigmaOr are fixed-arity nodes, so a runtime Coll[SigmaProp] cannot be folded into them
+    an[InvalidArguments] should be thrownBy comp("allZK(getVar[Coll[SigmaProp]](1).get)")
+    an[InvalidArguments] should be thrownBy comp("anyZK(getVar[Coll[SigmaProp]](1).get)")
+  }
+
+  property("allZK/anyZK reject an empty collection") {
+    // CAND/COR.normalized require at least one item; reject at compile time rather than crash at eval
+    an[InvalidArguments] should be thrownBy comp("allZK(Coll[SigmaProp]())")
+    an[InvalidArguments] should be thrownBy comp("anyZK(Coll[SigmaProp]())")
+  }
+
+  property("allZK/anyZK reject a non-SigmaProp collection") {
+    // the declared parameter type is Coll[SigmaProp]; a Coll[Boolean] must not type-check
+    an[TyperException] should be thrownBy comp("allZK(Coll[Boolean](true, false))")
+    an[TyperException] should be thrownBy comp("anyZK(Coll[Boolean](true, false))")
+  }
+
   property("ZKProof") {
     testMissingCostingWOSerialization("ZKProof { sigmaProp(HEIGHT > 1000) }",
       ZKProofBlock(BoolToSigmaProp(GT(Height, IntConstant(1000)))))

--- a/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
+++ b/sc/shared/src/test/scala/sigmastate/utxo/BasicOpsSpecification.scala
@@ -2845,6 +2845,40 @@ class BasicOpsSpecification extends CompilerTestingCommons
       onlyPositive = true,
       testExceededCost = false
     )
+    test("PropAllZK", env, ext,
+      "{ allZK(Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get))}",
+      SigmaAnd(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get, GetVarSigmaProp(propVar1).get)),
+      onlyPositive = true,
+      testExceededCost = false
+    )
+    test("PropAnyZK", env, ext,
+      "{ anyZK(Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get))}",
+      SigmaOr(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get, GetVarSigmaProp(propVar1).get)),
+      onlyPositive = true,
+      testExceededCost = false
+    )
+    // 3-of-3 conjunction (all three secrets are known to the prover) -> real SigmaAnd proof
+    test("PropAllZK3", env, ext,
+      "{ allZK(Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get, getVar[SigmaProp](proofVar2).get))}",
+      SigmaAnd(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get, GetVarSigmaProp(propVar1).get, GetVarSigmaProp(propVar2).get)),
+      onlyPositive = true,
+      testExceededCost = false
+    )
+    test("PropAnyZK3", env, ext,
+      "{ anyZK(Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get, getVar[SigmaProp](proofVar2).get))}",
+      SigmaOr(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get, GetVarSigmaProp(propVar1).get, GetVarSigmaProp(propVar2).get)),
+      onlyPositive = true,
+      testExceededCost = false
+    )
+    // nested: (R4 OR proofVar1) AND proofVar2 -> SigmaAnd(SigmaOr(..), ..)
+    test("PropNestedZK", env, ext,
+      "{ allZK(Coll(anyZK(Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get)), getVar[SigmaProp](proofVar2).get))}",
+      SigmaAnd(Seq(
+        SigmaOr(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get, GetVarSigmaProp(propVar1).get)),
+        GetVarSigmaProp(propVar2).get)),
+      onlyPositive = true,
+      testExceededCost = false
+    )
     test("Prop11", env, ext,
       "{ Coll(SELF.R4[SigmaProp].get, getVar[SigmaProp](proofVar1).get).forall({ (p: SigmaProp) => p.isProven }) }",
       SigmaAnd(Seq(ExtractRegisterAs[SSigmaProp.type](Self, reg1).get , GetVarSigmaProp(propVar1).get)),


### PR DESCRIPTION
Closes #543 

Implements the `allZK` / `anyZK` global functions - the named counterparts of `allOf` / `anyOf` for sigma propositions:
```scala
anyZK(Coll(pkAlice, pkBob, pkCarol))  // -> SigmaOr  (== pkAlice || pkBob || pkCarol)
allZK(Coll(pkAlice, pkBob))           // -> SigmaAnd (== pkAlice && pkBob)
```

`allZK` lowers to `SigmaAnd`, `anyZK` to `SigmaOr` - the same ErgoTree nodes that `&&` / `||` on `SigmaProp` already produce.

## ❓ Question for maintainers: versioning / pre-v6

I'd like a steer on this one point. `SigmaAnd`/`SigmaOr` (opcodes 122/123) exist since v4/v5, so these functions add **no new opcode, type code, or cost rule** — the compiled ErgoTree is byte-identical to the equivalent `&&`/`||` script, and this is **not a hard fork**. So the only real decision is the source-language availability:

- **This PR: unversioned** — accepted in all script versions, like the recent `equalBoxExcept` helper; tested with `existingFeature` in both `LanguageSpecificationV5` and `V6`.
- **Alternative: gate to v6+** — matches the original ignored test (`newFeature(sinceVersion = V6)`) and the v6.x milestone; pre-v6 compilation of `allZK` would be rejected.

I went unversioned because this is `A-frontend`, desugars to nodes that already exist, and produces output already expressible with `&&`/`||` — so gating would only deny older-version scripts a syntactic convenience without protecting anything at the consensus level. Happy to switch to v6-gating if preferred.

## Implementation

The only production change is the predef-function IR builder in `SigmaPredef.scala`; the rest of the pipeline (GraphBuilding/TreeBuilding recognizers, runtime `CSigmaDslBuilder.allZK/anyZK`, docgen wiring) already existed.

- Accepts a **literal** `Coll[SigmaProp]` (a `ConcreteCollection` in the script) → `SigmaAnd(items)` / `SigmaOr(items)`.
- **Non-literal** collection → rejected with `InvalidArguments`: `SigmaAnd`/ `SigmaOr` hold a fixed-arity `Seq` of children, so a runtime collection can't be folded (only `AtLeast` takes a runtime collection, with different `CTHRESHOLD` semantics).
- **Empty** collection → rejected (`CAND.normalized`/`COR.normalized` require ≥1 item; would otherwise crash at eval).
- **Single-element** collection → collapses to the element (existing rewrite).